### PR TITLE
Feat/#8 사이드바 구현

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,6 +18,7 @@
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-highlight": "^0.15.0",
+        "react-icons": "^5.5.0",
         "react-router-dom": "^7.6.0",
         "react-scripts": "5.0.1",
         "sockjs-client": "^1.6.1",
@@ -14001,6 +14002,15 @@
       "license": "MIT",
       "dependencies": {
         "highlight.js": "^10.5.0"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-highlight": "^0.15.0",
+    "react-icons": "^5.5.0",
     "react-router-dom": "^7.6.0",
     "react-scripts": "5.0.1",
     "sockjs-client": "^1.6.1",

--- a/frontend/src/fragments/SideBar.js
+++ b/frontend/src/fragments/SideBar.js
@@ -1,0 +1,87 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { FaChevronRight, FaChevronDown, FaUser, FaComments, FaRegCommentDots, FaPlus } from 'react-icons/fa';
+
+const Sidebar = () => {
+  const navigate = useNavigate();
+  const [expandedRoom, setExpandedRoom] = useState(null);
+
+  const chatRooms = [
+    { id: 1, name: '2차 프로젝트', participants: ['데브코스'] },
+    { id: 4, name: '채팅 프로젝트', participants: ['지은', '창인', '문성', '강현'] }
+  ];
+
+  const toggleRoom = (id) => {
+    setExpandedRoom(prev => prev === id ? null : id);
+  };
+
+  return (
+    <div style={{ width: '200px', height: '100%', justifyContent: 'space-between', backgroundColor: '#2588F1', color: 'white', display: 'flex', flexDirection: 'column',  boxSizing: 'border-box'}}>
+        <div>
+            <h3 style={{ marginBottom: '20px', marginLeft: '10px'}}>Chat Rooms</h3>
+            {chatRooms.map(room => (
+            <div key={room.id} style={{ padding: '10px'}}>
+                <div
+                style={{ display: 'flex', alignItems: 'center', cursor: 'pointer' }}
+                onClick={() => toggleRoom(room.id)}
+                >
+                <FaRegCommentDots style={{ marginRight: '8px' }} />
+                <span style={{ flex: 1 }}>{room.name}</span>
+                {expandedRoom === room.id ? <FaChevronDown /> : <FaChevronRight />}
+                </div>
+
+                {expandedRoom === room.id && (
+                <div style={{ paddingLeft: '20px', marginTop: '5px' }}>
+                    {room.participants.map((p, idx) => (
+                    <div key={idx} style={{ display: 'flex', alignItems: 'center', marginBottom: '5px', fontSize: '14px' }}>
+                        <FaUser style={{ marginRight: '6px' }} />
+                        {p}
+                    </div>
+                    ))}
+                </div>
+                )}
+            </div>
+            ))}
+        </div>
+
+        <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+        <button
+                style={{
+                width: '90%',
+                marginTop: '20px',
+                padding: '10px',
+                backgroundColor: '#2377FF',
+                color: 'white',
+                border: '1px solid #5AAAFF',
+                cursor: 'pointer',
+                borderRadius: '4px',
+                }}
+                onClick={() => navigate('/join')}
+            >
+                <FaComments style={{ marginRight: '8px' }} />
+                Join Chat Room
+            </button>
+
+            <button
+                style={{
+                width: '90%',
+                marginTop: '10px',
+                padding: '10px',
+                backgroundColor: '#2377FF',
+                color: 'white',
+                border: '1px solid #5AAAFF',
+                cursor: 'pointer',
+                borderRadius: '4px',
+                marginBottom: '10px'
+                }}
+                onClick={() => navigate('/create')}
+            >
+                <FaPlus style={{ marginRight: '8px' }} />
+                New Chat Room
+            </button>
+        </div>
+    </div>
+  );
+};
+
+export default Sidebar;

--- a/frontend/src/pages/BlankRoom.js
+++ b/frontend/src/pages/BlankRoom.js
@@ -1,42 +1,14 @@
 import React from 'react';
+import SideBar from '../fragments/SideBar';
 
 const BlankRoom = () => {
 
   return (
-    <div style={{ backgroundColor: '#e0e0e0', height: '100vh', padding: '20px', display: 'flex', flexDirection: 'column', boxSizing: 'border-box'}}>
+    <div style={{ backgroundColor: '#e0e0e0', height: '100vh', display: 'flex', flexDirection: 'column', boxSizing: 'border-box'}}>
 
       {/* Top Bar */}
-      <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '10px', marginBottom: '10px' }}>
-        {/* 방 생성 & 참가 그룹 */}
-        <div style={{ display: 'flex', gap: '10px', marginRight: '20px' }}>
-          <button
-            style={{
-              padding: '10px 15px',
-              backgroundColor: '#888',
-              color: 'white',
-              border: 'none',
-              cursor: 'pointer'
-            }}
-            onClick={() => window.location.href = '/create'}
-          >
-            방 생성
-          </button>
-          <button
-            style={{
-              padding: '10px 15px',
-              backgroundColor: '#aaa',
-              color: 'black',
-              border: 'none',
-              cursor: 'pointer'
-            }}
-            onClick={() => window.location.href = '/join'}
-          >
-            방 참가
-          </button>
-        </div>
-
-        {/* 로그아웃 & 마이페이지 그룹 */}
-        <div style={{ display: 'flex', gap: '10px' }}>
+      <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '10px', marginBottom: '10px', marginTop: '10px' }}>
+        <div style={{ display: 'flex', gap: '10px', marginRight: '10px' }}>
           <button
             style={{
               padding: '10px 15px',
@@ -66,16 +38,11 @@ const BlankRoom = () => {
 
       {/* 본문 전체 영역 */}
       <div style={{ flex:1, display: 'flex', overflow: 'hidden' }}>
-        {/* Sidebar */}
-        <div style={{ width: '200px', padding: '10px', backgroundColor: '#ffffff' }}>
-          <h3 style={{ color: 'black', fontWeight: 'bold' }}>채팅방 목록</h3>
-          <p>현재 참여 중인 채팅방이 없습니다.</p>
-        </div>
+        <SideBar />
 
         {/* Chat area */}
         <div style={{
           flex: 1,
-          marginLeft: '20px',
           width: '700px',
           backgroundColor: '#f9f9f9',
           borderRadius: '8px',
@@ -115,7 +82,7 @@ const BlankRoom = () => {
               <textarea
                 style={{
                   flex: 1,
-                  height: '50px',
+                  height: '30px',
                   resize: 'none',
                   padding: '15px',
                   fontSize: '16px',

--- a/frontend/src/pages/ChatRoom.js
+++ b/frontend/src/pages/ChatRoom.js
@@ -4,6 +4,7 @@ import { Stomp } from '@stomp/stompjs';
 import { useParams } from 'react-router-dom'
 import Highlight from 'react-highlight';
 import 'highlight.js/styles/github.css';
+import Sidebar from '../fragments/SideBar';
 
 const ChatRoom = () => {
   const [messages, setMessages]=useState([]);
@@ -73,40 +74,12 @@ const ChatRoom = () => {
   };
 
   return (
-    <div style={{ backgroundColor: '#e0e0e0', height: '100vh', padding: '20px', display: 'flex', flexDirection: 'column', boxSizing: 'border-box'}}>
+    <div style={{ backgroundColor: '#e0e0e0', height: '100vh', display: 'flex', flexDirection: 'column', boxSizing: 'border-box'}}>
 
       {/* Top Bar */}
-      <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '10px', marginBottom: '10px' }}>
-        {/* 방 생성 & 참가 그룹 */}
-        <div style={{ display: 'flex', gap: '10px', marginRight: '20px' }}>
-          <button
-            style={{
-              padding: '10px 15px',
-              backgroundColor: '#888',
-              color: 'white',
-              border: 'none',
-              cursor: 'pointer'
-            }}
-            onClick={() => window.location.href = '/create'}
-          >
-            방 생성
-          </button>
-          <button
-            style={{
-              padding: '10px 15px',
-              backgroundColor: '#aaa',
-              color: 'black',
-              border: 'none',
-              cursor: 'pointer'
-            }}
-            onClick={() => window.location.href = '/join'}
-          >
-            방 참가
-          </button>
-        </div>
+      <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '10px', marginBottom: '10px', marginTop: '10px' }}>
 
-        {/* 로그아웃 & 마이페이지 그룹 */}
-        <div style={{ display: 'flex', gap: '10px' }}>
+        <div style={{ display: 'flex', gap: '10px', marginRight: '10px'}}>
           <button
             style={{
               padding: '10px 15px',
@@ -136,19 +109,11 @@ const ChatRoom = () => {
 
       {/* 본문 전체 영역 */}
       <div style={{ flex:1, display: 'flex', overflow: 'hidden'}}>
-        {/* Sidebar */}
-        <div style={{ width: '200px', padding: '10px', backgroundColor: '#ffffff' }}>
-          <h3 style={{ color: 'black', fontWeight: 'bold' }}>채팅방 목록</h3>
-          <div style={{ backgroundColor: '#2c2f7e', color: 'white', padding: '10px', borderRadius: '4px', marginTop: '10px' }}>
-            {/* <p style={{ margin: 0 }}>{roomName}</p> 채팅방 조회 로직 필요*/}
-            <p style={{ margin: 0 }}>핸고8</p>
-          </div>
-        </div>
+        <Sidebar />
 
         {/* Chat area */}
         <div style={{
           flex: 1,
-          marginLeft: '20px',
           width: '700px',
           backgroundColor: '#f9f9f9',
           borderRadius: '8px',
@@ -157,28 +122,6 @@ const ChatRoom = () => {
           padding: '20px',
           boxShadow: '0 0 10px rgba(0, 0, 0, 0.1)'
         }}>
-
-          {/* 방 제목 + 드롭다운 */}
-          {/* <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '10px' }}>
-            <h2>{roomName}</h2>
-            <button
-              onClick={() => setShowParticipants(prev => !prev)}
-              style={{ padding: '5px 10px', fontSize: '14px' }}
-            >
-              참여자 ▼
-            </button>
-          </div> */}
-
-          {/* 참여자 목록 (토글) */}
-          {/* {showParticipants && (
-            <div style={{ marginBottom: '10px', paddingLeft: '10px' }}>
-              <ul style={{ margin: 0, paddingLeft: '20px' }}>
-                {participants.map((name, i) => (
-                  <li key={i}>{name}</li>
-                ))}
-              </ul>
-            </div>
-          )} */}
 
           {/* 메시지 목록 */}
           <div style={{
@@ -193,13 +136,15 @@ const ChatRoom = () => {
           }}>
             {messages.map((msg, index) => (
               <div key={index} style={{ marginBottom: '15px', display: 'flex', alignItems: 'center' }}>
+                {/*프로필 이미지 출력*/}
                 <div style={{
                   width: '30px',
                   height: '30px',
                   borderRadius: '50%',
                   backgroundColor: '#7ec8e3',
                   marginRight: '10px'
-                }}></div>
+                }}>
+                </div>
                 <div>
                   <div style={{ fontWeight: 'bold' }}>
                     {msg.senderName}
@@ -228,9 +173,6 @@ const ChatRoom = () => {
             flexDirection: 'column'
           }}>
             <div style={{ marginBottom: '5px' }}>
-              {/* <span style={{ marginRight: '10px' }}>사진</span>
-              <span>코드</span> */}
-
             <span
               onClick={() => {
                 if (inputMode === 'IMAGE') {
@@ -281,7 +223,7 @@ const ChatRoom = () => {
                 placeholder={inputMode === 'CODE' ? "코드를 입력하세요." : "메시지를 입력하세요."}
                 style={{
                   flex: 1,
-                  height: '50px',
+                  height: '30px',
                   resize: 'none',
                   padding: '15px',
                   fontSize: '16px',


### PR DESCRIPTION
## 🛰️ Issue Number
#8

## 🪐 작업 내용
![image](https://github.com/user-attachments/assets/2a26208f-dc96-425a-9ade-1c4fd95108d3)
위 사진처럼 사이드바 변경
<img width="122" alt="image" src="https://github.com/user-attachments/assets/0b6a31fd-b307-4822-b607-65b4df821a4a" />
다음 위치에 SideBar 컴포넌트를 뒀습니다. 채팅방, 참여자 목록 조회하시는 분은 프론트 SideBar에서 작업해주시면 됩니다!
지금은 임의의 채팅방 데이터를 넣어놨습니다

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?