### PR TITLE
refactor: 채팅방 목록 조회 방식 변경

### DIFF
--- a/backend/src/main/java/project/backend/domain/chat/chatroom/api/ChatRoomController.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/api/ChatRoomController.java
@@ -93,10 +93,14 @@ public class ChatRoomController {
 		return new RecentChatRoomResponse(roomId);
 	}
 
-	@GetMapping // URL 매핑 -> 추후 인증객체 id로 조회 예정
-	public Page<ChatRoomDetailResponse> findAllChatRooms(@PathVariable Long memberId,
+	@GetMapping
+	public Page<ChatRoomDetailResponse> findAllChatRooms(
+		@AuthenticationPrincipal MemberDetails memberDetails,
 		@PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
-		log.info("chatRoom 조회 요청 들어옴: memberId = " + memberId);
+		if (memberDetails == null) {
+			throw new AuthException(AuthErrorCode.UNAUTHORIZED_USER);
+		}
+		Long memberId = memberDetails.getId();
 		// 채팅방 목록 리스트로 가져오기
 		return chatRoomService.findAllByMemberId(memberId, pageable);
 	}

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/api/ChatRoomController.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/api/ChatRoomController.java
@@ -102,7 +102,7 @@ public class ChatRoomController {
 		}
 		Long memberId = memberDetails.getId();
 		// 채팅방 목록 리스트로 가져오기
-		return chatRoomService.findAllByMemberId(memberId, pageable);
+		return chatRoomService.findChatRoomsByParticipantId(memberId, pageable);
 	}
 
 

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomService.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomService.java
@@ -114,13 +114,13 @@ public class ChatRoomService {
 	@Transactional(readOnly = true)
 	public Page<ChatRoomDetailResponse> findAllByMemberId(Long memberId, Pageable pageable) {
 
-		chatRoomRepository.findById(memberId)
-			.orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+		Page<ChatRoom> chatRooms = chatRoomRepository.findByParticipants_Participant_Id(memberId,
+			pageable);
 
-		Page<ChatRoom> chatRooms = chatRoomRepository.findAllRoomsByMemberId(memberId, pageable);
 		if (chatRooms.isEmpty()) {
 			throw new ChatRoomException(ChatRoomErrorCode.CHATROOM_NOT_FOUND);
 		}
+
 		return chatRooms.map(ChatRoomMapper::toDetailResponse);
 	}
 

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomService.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomService.java
@@ -112,7 +112,8 @@ public class ChatRoomService {
 	}
 
 	@Transactional(readOnly = true)
-	public Page<ChatRoomDetailResponse> findAllByMemberId(Long memberId, Pageable pageable) {
+	public Page<ChatRoomDetailResponse> findChatRoomsByParticipantId(Long memberId,
+		Pageable pageable) {
 
 		Page<ChatRoom> chatRooms = chatRoomRepository.findByParticipants_Participant_Id(memberId,
 			pageable);

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/dao/ChatRoomRepository.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/dao/ChatRoomRepository.java
@@ -1,10 +1,10 @@
 package project.backend.domain.chat.chatroom.dao;
 
 
-
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import project.backend.domain.chat.chatroom.entity.ChatRoom;
@@ -12,11 +12,8 @@ import project.backend.domain.chat.chatroom.entity.ChatRoom;
 
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
-	@Query("SELECT cr FROM ChatRoom cr " +
-		"JOIN FETCH cr.participants ps " +
-		"JOIN FETCH ps.participant " +
-		"WHERE ps.participant.id = :memberId")
-	Page<ChatRoom> findAllRoomsByMemberId(Long memberId, Pageable pageable);
+	@EntityGraph(attributePaths = {"participants", "participants.participant"})
+	Page<ChatRoom> findByParticipants_Participant_Id(Long memberId, Pageable pageable);
 
 	Optional<ChatRoom> findByInviteCode(String inviteCode);
 }


### PR DESCRIPTION
## 🛰️ Issue Number
#19 

## 🪐 작업 내용
JPQL의 fetch join을 제거하고, @EntityGraph를 활용한 조회 방식으로 리팩터링
채팅방 목록 가져오는 메서드명 변경

## 📚 Reference


## ✅ Check List
- [X] 코드가 정상적으로 컴파일되나요?
- [X] 테스트 코드를 통과했나요?
- [X] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?