### PR TITLE
Fix: blankroom에서 채팅방 참가, 생성 버튼 눌렀을 때 올바른 url로 가도록 수정

### DIFF
--- a/backend/src/main/java/project/backend/domain/chat/chatmessage/mapper/ChatMessageMapper.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatmessage/mapper/ChatMessageMapper.java
@@ -16,89 +16,90 @@ import project.backend.domain.imagefile.ImageFile;
 @Component
 public class ChatMessageMapper {
 
-    public ChatMessage toEntityWithText(ChatRoom room, ChatParticipant sender,
-        ChatMessageRequest request) {
-        return ChatMessage.builder()
-            .chatRoom(room)
-            .sender(sender)
-            .content(request.getContent())
-            .type(MessageType.TEXT)
-            .sendAt(LocalDateTime.now())
-            .build();
-    }
+	public ChatMessage toEntityWithText(ChatRoom room, ChatParticipant sender,
+		ChatMessageRequest request) {
+		return ChatMessage.builder()
+			.chatRoom(room)
+			.sender(sender)
+			.content(request.getContent())
+			.type(MessageType.TEXT)
+			.sendAt(LocalDateTime.now())
+			.build();
+	}
 
-    public ChatMessage toEntityWithCode(ChatRoom room, ChatParticipant sender,
-        ChatMessageRequest request) {
-        return ChatMessage.builder()
-            .chatRoom(room)
-            .sender(sender)
-            .content(request.getContent())
-            .type(MessageType.CODE)
-            .sendAt(LocalDateTime.now())
-            .codeLanguage(request.getLanguage())
-            .build();
-    }
+	public ChatMessage toEntityWithCode(ChatRoom room, ChatParticipant sender,
+		ChatMessageRequest request) {
+		return ChatMessage.builder()
+			.chatRoom(room)
+			.sender(sender)
+			.content(request.getContent())
+			.type(MessageType.CODE)
+			.sendAt(LocalDateTime.now())
+			.codeLanguage(request.getLanguage())
+			.build();
+	}
 
-    public ChatMessage toEntityWithImage(ChatRoom room, ChatParticipant sender,
-        ImageFile chatImage) {
-        return ChatMessage.builder()
-            .chatRoom(room)
-            .sender(sender)
-            .type(MessageType.IMAGE)
-            .sendAt(LocalDateTime.now())
-            .chatImage(chatImage)
-            .build();
-    }
+	public ChatMessage toEntityWithImage(ChatRoom room, ChatParticipant sender,
+		ImageFile chatImage) {
+		return ChatMessage.builder()
+			.chatRoom(room)
+			.sender(sender)
+			.type(MessageType.IMAGE)
+			.sendAt(LocalDateTime.now())
+			.chatImage(chatImage)
+			.build();
+	}
 
-    public ChatMessage toEntityWithGit(GitMessage gitMessage) {
-        return ChatMessage.builder()
-            .chatRoom(gitMessage.getRoom())
-            .type(MessageType.GIT)
-            .content(gitMessage.getContent())
-            .sendAt(LocalDateTime.now())
-            .build();
-    }
+	public ChatMessage toEntityWithGit(GitMessage gitMessage) {
+		return ChatMessage.builder()
+			.chatRoom(gitMessage.getRoom())
+			.type(MessageType.GIT)
+			.content(gitMessage.getContent())
+			.sendAt(LocalDateTime.now())
+			.build();
+	}
 
-    public ChatMessageResponse toResponse(ChatMessage message) {
-        String senderName = message.getSender().getParticipant().getNickname();
+	public ChatMessageResponse toResponse(ChatMessage message) {
+		String senderName = message.getSender().getParticipant().getNickname();
 
-        return ChatMessageResponse.builder()
-            .senderName(senderName)
-            .content(message.getContent())
-            .type(message.getType())
-            .sendAt(message.getSendAt())
-            .language(message.getCodeLanguage())
-            .profileImageUrl(
-                Optional.ofNullable(message.getSender().getParticipant().getProfileImage())
-                    .map(ImageFile::getStoreFileName)
-                    .orElse("default_image.jpg"))
-            .chatImageUrl(
-                Optional.ofNullable(message.getChatImage())
-                    .map(ImageFile::getStoreFileName)
-                    .orElse(null)
-            )
-            .senderId(message.getSender().getParticipant().getId())
-            .messageId(message.getId())
-            .build();
-    }
+		return ChatMessageResponse.builder()
+			.senderName(senderName)
+			.content(message.getContent())
+			.type(message.getType())
+			.sendAt(message.getSendAt())
+			.language(message.getCodeLanguage())
+			.profileImageUrl(
+				Optional.ofNullable(message.getSender().getParticipant().getProfileImage())
+					.map(ImageFile::getStoreFileName)
+					.orElse("default_image.jpg"))
+			.chatImageUrl(
+				Optional.ofNullable(message.getChatImage())
+					.map(ImageFile::getStoreFileName)
+					.orElse(null)
+			)
+			.senderId(message.getSender().getParticipant().getId())
+			.messageId(message.getId())
+			.build();
+	}
 
-    public ChatMessageSearchResponse toSearchResponse(ChatMessage message) {
-        return ChatMessageSearchResponse.builder()
-            .messageId(message.getId())
-            .content(message.getContent())
-            .senderName(message.getSender().getParticipant().getNickname())
-            .sendAt(message.getSendAt())
-            .type(message.getType())
-            .build();
-    }
+	public ChatMessageSearchResponse toSearchResponse(ChatMessage message) {
+		return ChatMessageSearchResponse.builder()
+			.messageId(message.getId())
+			.content(message.getContent())
+			.senderName(message.getSender().getParticipant().getNickname())
+			.sendAt(message.getSendAt())
+			.type(message.getType())
+			.build();
+	}
 
-    public ChatMessageResponse toGitResponse(ChatMessage message) {
-        return ChatMessageResponse.builder()
-            .senderName("GitHub")
-            .content(message.getContent())
-            .type(message.getType())
-            .sendAt(message.getSendAt())
-            .build();
-    }
+	public ChatMessageResponse toGitResponse(ChatMessage message) {
+		return ChatMessageResponse.builder()
+			.senderName("GitHub")
+			.content(message.getContent())
+			.type(message.getType())
+			.sendAt(message.getSendAt())
+			.messageId(message.getId())
+			.build();
+	}
 
 }

--- a/frontend/src/pages/BlankRoom.jsx
+++ b/frontend/src/pages/BlankRoom.jsx
@@ -13,6 +13,7 @@ const BlankRoom = () => {
   const [repoUrl, setRepoUrl] = useState('');
   const [inviteCode, setInviteCode] = useState('');
 
+
   const handleCreate = async (e) => {
     e.preventDefault();
     if (!roomName.trim()) {
@@ -39,44 +40,43 @@ const BlankRoom = () => {
       setRepoUrl('');
       
       if (created?.id) {
-        navigate(`/chat/${created.id}`);
+        navigate(`/chat/${created.id}/${created.inviteCode}`);
       }
     } catch (err) {
       alert(err.message);
     }
-};
+  };
 
-const handleJoin = async (e) => {
-  e.preventDefault();
-  if (!inviteCode.trim()) {
-    alert('초대 코드를 입력해주세요.');
-    return;
-  }
-  
-  try {
-    const res = await fetch('http://localhost:8080/chat-rooms/join', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      credentials: 'include',
-      body: JSON.stringify({ inviteCode })
-    });
-    
-    if (!res.ok) {
-      const errorData = await res.json().catch(() => ({}));
-      throw new Error(errorData.message || '방 입장에 실패했습니다.');
+  const handleJoin = async (e) => {
+    e.preventDefault();
+    if (!inviteCode.trim()) {
+      alert('초대 코드를 입력해주세요.');
+      return;
     }
     
-    const { id: roomId } = await res.json();
-    setShowJoinModal(false);
-    setInviteCode('');
-    
-    if (roomId) {
-      navigate(`/chat/${roomId}`);
+    try {
+      const res = await fetch('http://localhost:8080/chat-rooms/join', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ inviteCode })
+      });
+      
+      if (!res.ok) {
+        const errorData = await res.json().catch(() => ({}));
+        throw new Error(errorData.message || '방 입장에 실패했습니다.');
+      }
+      
+      const data = await res.json();
+      setShowJoinModal(false);
+      setInviteCode('');
+      
+      navigate(`/chat/${data.id}/${data.inviteCode}`);
+
+    } catch (err) {
+      alert(err.message);
     }
-  } catch (err) {
-    alert(err.message);
-  }
-};
+  };
   
   // 버튼 스타일 공통화
   const buttonStyle = {
@@ -253,7 +253,6 @@ const Modal = ({ title, onClose, onSubmit, children }) => (
           >
             취소
           </button>
-          
           <button
             type="submit"
             style={{

--- a/frontend/src/pages/ChatRoom.jsx
+++ b/frontend/src/pages/ChatRoom.jsx
@@ -752,7 +752,7 @@ const ChatRoom = () => {
           </div>
 
           {/* 본문 영역 - 수정 중인 메시지는 textarea, 나머지는 content 렌더 */}
-          {editMessageId === msg.messageId ? (
+          {editMessageId === msg.messageId && msg.type !== 'GIT' ?( //지은 GIT 조건 추가
             <div style={{ display: 'flex', gap: '8px', flexDirection: 'column' }}>
               <textarea
                 value={editContent}
@@ -827,7 +827,7 @@ const ChatRoom = () => {
                     borderRadius: '2px'
                 }} />
                 {/* <div style={{ whiteSpace: 'pre-line', padding: '10px' }}>{msg.content}</div> */}
-                <div style={{ whiteSpace: 'pre-line', lineHeight: '1.5', padding: '10px' }}>
+                {/* <div style={{ whiteSpace: 'pre-line', lineHeight: '1.5', padding: '10px' }}>
                     <strong style={{ display: 'block', marginBottom: '6px' }}>
                     {msg.content.split('\n')[0]}
                     </strong>
@@ -837,7 +837,22 @@ const ChatRoom = () => {
                         <br />
                     </React.Fragment>
                     ))}
-                </div>
+                </div> */}
+                {/*지은 변경 시작*/}
+                {msg.content && (
+                  <div style={{ whiteSpace: 'pre-wrap', lineHeight: '1.5', padding: '10px' }}>
+                    {msg.content.split('\n').map((line, i) => (
+                      <div key={i}>
+                        {i === 0 ? (
+                          <strong>{renderWithLink(line)}</strong>
+                        ) : (
+                          <>{renderWithLink(line)}</>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                )}
+                {/*지은 변경 끝*/}
               </div>
             ): msg.type === 'CODE' || (msg.content && msg.content.startsWith('```')) ? (
               <div style={{ 


### PR DESCRIPTION
## 🛰️ Issue Number
#61 

## 🪐 작업 내용
- blankroom에서 채팅방 참가, 생성 버튼 눌렀을 때 올바른 url로 가도록 수정
- 깃허브 메세지가 수정 모드로 보임 + content가 비어있음 문제를 고쳤습니다.
- 현재 깃허브 메세지
![image](https://github.com/user-attachments/assets/549aadbf-0973-4bd0-a337-ddda6749e34b)


## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?