### PR TITLE
refactor: 채팅방 조회, 채팅방 별 인원 조회 분리

### DIFF
--- a/backend/src/main/java/project/backend/domain/chat/chatroom/api/ChatRoomController.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/api/ChatRoomController.java
@@ -2,6 +2,7 @@ package project.backend.domain.chat.chatroom.api;
 
 
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import project.backend.domain.chat.chatroom.app.ChatRoomService;
+import project.backend.domain.chat.chatroom.dto.ChatRoomNameResponse;
 import project.backend.domain.chat.chatroom.dto.ChatRoomRequest;
 import project.backend.domain.chat.chatroom.dto.ChatRoomSimpleResponse;
 import project.backend.domain.chat.chatroom.dto.InviteJoinRequest;
@@ -25,6 +27,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import project.backend.domain.chat.chatroom.dto.MyChatRoomResponse;
 import project.backend.domain.chat.chatroom.dto.ChatRoomDetailResponse;
+import project.backend.domain.chat.chatroom.dto.ParticipantResponse;
 import project.backend.domain.chat.chatroom.dto.RecentChatRoomResponse;
 import project.backend.domain.member.dto.MemberDetails;
 import project.backend.global.exception.errorcode.AuthErrorCode;
@@ -70,7 +73,7 @@ public class ChatRoomController {
 	}
 
 	@GetMapping
-	public Page<ChatRoomDetailResponse> findAllChatRooms(
+	public Page<ChatRoomNameResponse> getChatRooms(
 		@AuthenticationPrincipal MemberDetails memberDetails,
 		@PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
 		if (memberDetails == null) {
@@ -78,7 +81,19 @@ public class ChatRoomController {
 		}
 		Long memberId = memberDetails.getId();
 		// 채팅방 목록 리스트로 가져오기
-		return chatRoomService.findChatRoomsByParticipantId(memberId, pageable);
+		return chatRoomService.findChatRoomsByMemberId(memberId, pageable);
+	}
+
+	@GetMapping("/{roomId}/participants")
+	public List<ParticipantResponse> getParticipants(
+		@PathVariable Long roomId,
+		@AuthenticationPrincipal MemberDetails memberDetails) {
+
+		if (memberDetails == null) {
+			throw new AuthException(AuthErrorCode.UNAUTHORIZED_USER);
+		}
+
+		return chatRoomService.getParticipants(roomId);
 	}
 
 	// 자신이 만든 채팅방 가져오기 -> 주후 인증객체 id로 조회가능 할듯(Authentication)

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/dao/ChatParticipantRepository.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/dao/ChatParticipantRepository.java
@@ -1,6 +1,7 @@
 package project.backend.domain.chat.chatroom.dao;
 
 import java.util.List;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -24,6 +25,9 @@ public interface ChatParticipantRepository extends JpaRepository<ChatParticipant
 	Optional<Long> findMostLargeRoomIdByEmail(@Param("email") String email);
 
 	boolean existsByParticipantIdAndChatRoomId(Long participantId, Long chatRoomId);
+
+	@EntityGraph(attributePaths = {"participant"})
+	List<ChatParticipant> findByChatRoom(ChatRoom chatRoom);
 
 	Optional<ChatParticipant> findByChatRoomIdAndParticipantId(Long chatRoomId, Long participantId);
 }

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/dao/ChatRoomRepository.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/dao/ChatRoomRepository.java
@@ -6,13 +6,21 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import project.backend.domain.chat.chatroom.entity.ChatRoom;
 
 
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
-	@EntityGraph(attributePaths = {"participants", "participants.participant"})
-	Page<ChatRoom> findByParticipants_Participant_Id(Long memberId, Pageable pageable);
+	@Query("""
+		SELECT DISTINCT cr
+		FROM ChatRoom cr
+		JOIN cr.participants cp
+		WHERE cp.participant.id = :memberId
+		""")
+	Page<ChatRoom> findChatRoomsByParticipantId(@Param("memberId") Long memberId,
+		Pageable pageable);
 
 	Optional<ChatRoom> findByInviteCode(String inviteCode);
 

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/dto/ChatRoomNameResponse.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/dto/ChatRoomNameResponse.java
@@ -1,0 +1,22 @@
+package project.backend.domain.chat.chatroom.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+
+public class ChatRoomNameResponse {
+
+	private Long roomId;
+
+	private String roomName;
+
+}
+
+
+

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/dto/ChatRoomNameResponse.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/dto/ChatRoomNameResponse.java
@@ -16,6 +16,8 @@ public class ChatRoomNameResponse {
 
 	private String roomName;
 
+	private String inviteCode;
+
 }
 
 

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/dto/ParticipantResponse.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/dto/ParticipantResponse.java
@@ -1,0 +1,12 @@
+package project.backend.domain.chat.chatroom.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class ParticipantResponse {
+
+	private String nickname;
+	private boolean owner;
+}

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/mapper/ChatRoomMapper.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/mapper/ChatRoomMapper.java
@@ -20,19 +20,10 @@ import project.backend.domain.member.entity.Member;
 public class ChatRoomMapper {
 
 
-	// 강현님: 상세 응답 변환
-	public static ChatRoomDetailResponse toDetailResponse(ChatRoom chatRoom) {
-		List<ChatParticipantResponse> participants = chatRoom.getParticipants().stream()
-			.map(ChatRoomMapper::toParticipantResponse)
-			.collect(Collectors.toList());
-
-		return ChatRoomDetailResponse.builder()
+	public static ChatRoomNameResponse toListResponse(ChatRoom chatRoom) {
+		return ChatRoomNameResponse.builder()
 			.roomId(chatRoom.getId())
 			.roomName(chatRoom.getName())
-			.ownerId(chatRoom.getOwner().getId())
-			.repositoryUrl(chatRoom.getRepositoryUrl())
-			.participants(participants)
-			.participantCount(chatRoom.getParticipants().size())
 			.build();
 	}
 

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/mapper/ChatRoomMapper.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/mapper/ChatRoomMapper.java
@@ -24,6 +24,7 @@ public class ChatRoomMapper {
 		return ChatRoomNameResponse.builder()
 			.roomId(chatRoom.getId())
 			.roomName(chatRoom.getName())
+			.inviteCode(chatRoom.getInviteCode())
 			.build();
 	}
 


### PR DESCRIPTION
## 🛰️ Issue Number
#58 

## 🪐 작업 내용
- ChatRoomService의 findChatRoomsByParticipantId 분리
- ChatRoomNameResponse에 inviteCode 추가
- ChatRoomContoller 분리(getChatRooms, getParticipants)


## 📚 Reference


## ✅ Check List
- [X] 코드가 정상적으로 컴파일되나요?
- [X] 테스트 코드를 통과했나요?
- [X] merge할 브랜치의 위치를 확인했나요?
- [X] Label을 지정했나요?