### PR TITLE
Feat: 입장 메시지 추가

### DIFF
--- a/backend/src/main/java/project/backend/BackendApplication.java
+++ b/backend/src/main/java/project/backend/BackendApplication.java
@@ -2,7 +2,9 @@ package project.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableAsync;
 
+@EnableAsync
 @SpringBootApplication
 public class BackendApplication {
 
@@ -14,3 +16,4 @@ public class BackendApplication {
 
 
 }
+

--- a/backend/src/main/java/project/backend/domain/chat/chatmessage/entity/MessageType.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatmessage/entity/MessageType.java
@@ -1,5 +1,5 @@
 package project.backend.domain.chat.chatmessage.entity;
 
 public enum MessageType {
-    CODE, TEXT, IMAGE, GIT
+	CODE, TEXT, IMAGE, GIT, EVENT
 }

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomEventService.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomEventService.java
@@ -1,0 +1,31 @@
+package project.backend.domain.chat.chatroom.app;
+
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import project.backend.domain.chat.chatmessage.entity.ChatMessage;
+import project.backend.domain.chat.chatmessage.entity.MessageType;
+import project.backend.domain.chat.chatroom.dao.ChatRoomRepository;
+import project.backend.domain.chat.chatroom.entity.ChatParticipant;
+import project.backend.domain.chat.chatroom.entity.ChatRoom;
+
+@Service
+@RequiredArgsConstructor
+public class ChatRoomEventService {
+
+	private final ChatRoomRepository chatRoomRepository;
+
+	public void saveJoinMessage(ChatParticipant sender, ChatRoom chatRoom,
+		LocalDateTime joinedAt) {
+		ChatMessage.builder()
+			.chatRoom(chatRoom)
+			.sender(sender)
+			.type(MessageType.EVENT)
+			.sendAt(joinedAt)
+			.content(sender.getParticipant().getNickname() + "님이 입장했습니다.")
+			.build();
+
+		chatRoomRepository.save(chatRoom);
+	}
+}
+

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/dao/ChatParticipantRepository.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/dao/ChatParticipantRepository.java
@@ -30,5 +30,8 @@ public interface ChatParticipantRepository extends JpaRepository<ChatParticipant
 	List<ChatParticipant> findByChatRoom(ChatRoom chatRoom);
 
 	Optional<ChatParticipant> findByChatRoomIdAndParticipantId(Long chatRoomId, Long participantId);
+
+	Optional<ChatParticipant> findByChatRoom_IdAndParticipant_Id(Long ChatRoomId,
+		Long participantId);
 }
 

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/dto/event/EventMessageResponse.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/dto/event/EventMessageResponse.java
@@ -1,4 +1,4 @@
-package project.backend.domain.chat.chatroom.dto;
+package project.backend.domain.chat.chatroom.dto.event;
 
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/dto/event/EventMessageResponse.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/dto/event/EventMessageResponse.java
@@ -1,0 +1,27 @@
+package project.backend.domain.chat.chatroom.dto;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import project.backend.domain.chat.chatmessage.entity.MessageType;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class EventMessageResponse {
+
+	private MessageType type;
+
+	private String sender;
+
+	private Long roomId;
+
+	private String content;
+
+	private LocalDateTime joinedAt;
+
+}
+

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/dto/event/JoinChatRoomEvent.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/dto/event/JoinChatRoomEvent.java
@@ -1,0 +1,9 @@
+package project.backend.domain.chat.chatroom.dto.event;
+
+import java.time.LocalDateTime;
+
+public record JoinChatRoomEvent(Long roomId, Long memberId, String nickname,
+								LocalDateTime joinedAt) {
+
+}
+

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/listener/ChatRoomEventListener.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/listener/ChatRoomEventListener.java
@@ -1,0 +1,65 @@
+package project.backend.domain.chat.chatroom.listener;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import project.backend.domain.chat.chatmessage.dao.ChatMessageRepository;
+import project.backend.domain.chat.chatmessage.entity.ChatMessage;
+import project.backend.domain.chat.chatmessage.entity.MessageType;
+import project.backend.domain.chat.chatroom.dao.ChatParticipantRepository;
+import project.backend.domain.chat.chatroom.dao.ChatRoomRepository;
+import project.backend.domain.chat.chatroom.dto.EventMessageResponse;
+import project.backend.domain.chat.chatroom.entity.ChatParticipant;
+import project.backend.domain.chat.chatroom.entity.ChatRoom;
+import project.backend.domain.chat.chatroom.dto.event.JoinChatRoomEvent;
+import project.backend.domain.chat.chatroom.mapper.ChatRoomMapper;
+import project.backend.global.exception.errorcode.ChatRoomErrorCode;
+import project.backend.global.exception.ex.ChatRoomException;
+
+@Component
+@RequiredArgsConstructor
+public class ChatRoomEventListener {
+
+	private final SimpMessagingTemplate simpMessagingTemplate;
+	private final ChatMessageRepository chatMessageRepository;
+	private final ChatRoomRepository chatRoomRepository;
+	private final ChatParticipantRepository chatParticipantRepository;
+
+	@Async
+	@EventListener
+	public void handleMemberJoin(JoinChatRoomEvent joinEvent) {
+		ChatRoom chatRoom = chatRoomRepository.findById(joinEvent.roomId())
+			.orElseThrow(() -> new ChatRoomException(ChatRoomErrorCode.CHATROOM_NOT_FOUND));
+
+		// 2. ChatParticipant 엔티티 조회 (입장하는 사용자)
+		ChatParticipant participant = chatParticipantRepository
+			.findByChatRoom_IdAndParticipant_Id(joinEvent.roomId(), joinEvent.memberId())
+			.orElseThrow(() -> new ChatRoomException(ChatRoomErrorCode.CHATROOM_NOT_FOUND));
+
+		// 3. ChatMessage 엔티티 생성 및 저장 -> 매퍼로 분리 예정
+		ChatMessage chatMessage = ChatMessage.builder()
+			.chatRoom(chatRoom)
+			.sender(participant)
+			.type(MessageType.EVENT)
+			.content(joinEvent.nickname() + "님이 입장했습니다.")
+			.sendAt(joinEvent.joinedAt())
+			.build();
+
+		chatMessageRepository.save(chatMessage);
+
+		EventMessageResponse eventMessageResponse = ChatRoomMapper.toEventMessageResponse(
+			joinEvent);
+
+		// 입장 메시지 전송
+		simpMessagingTemplate.convertAndSend("/topic/chat/" + joinEvent.roomId(),
+			eventMessageResponse);
+
+		// 입장한 인원에 대한 채팅방 인원 갱신 트리거
+		simpMessagingTemplate.convertAndSend("/topic/chat/" + joinEvent.roomId() + "/refresh",
+			joinEvent.roomId()
+		);
+	}
+}
+

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/mapper/ChatRoomMapper.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/mapper/ChatRoomMapper.java
@@ -9,8 +9,11 @@ import java.util.stream.Collectors;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.springframework.stereotype.Component;
+import project.backend.domain.chat.chatmessage.entity.MessageType;
 import project.backend.domain.chat.chatroom.dto.*;
 
+import project.backend.domain.chat.chatroom.dto.EventMessageResponse;
+import project.backend.domain.chat.chatroom.dto.event.JoinChatRoomEvent;
 import project.backend.domain.chat.chatroom.entity.ChatParticipant;
 import project.backend.domain.chat.chatroom.entity.ChatRoom;
 import project.backend.domain.imagefile.ImageFile;
@@ -85,5 +88,15 @@ public class ChatRoomMapper {
 
 	private static String generateInviteCode() {
 		return UUID.randomUUID().toString();
+	}
+
+	public static EventMessageResponse toEventMessageResponse(JoinChatRoomEvent joinEvent) {
+		return EventMessageResponse.builder()
+			.type(MessageType.EVENT)
+			.roomId(joinEvent.roomId())
+			.sender(joinEvent.nickname())
+			.content(joinEvent.nickname() + "님이 입장했습니다.")
+			.joinedAt(joinEvent.joinedAt())
+			.build();
 	}
 }


### PR DESCRIPTION
## 🛰️ Issue Number
#59

## 🪐 작업 내용
- messageType에 EVENT 추가
- 입장 시, 해당 채팅방의 모든 멤버에게, 입장 메시지 전송 및 chat_message에 저장
- 입장 메시지 chat_message 테이블에 EVENT 타입으로 저장
- 입장 메시지를 비동기로 처리 @Async 사용

## 📚 Reference


## ✅ Check List
- [X] 코드가 정상적으로 컴파일되나요?
- [X] 테스트 코드를 통과했나요?
- [X] merge할 브랜치의 위치를 확인했나요?
- [X] Label을 지정했나요?