### PR TITLE
Refactor: 채팅룸, 채팅내역, 채팅 메시지(검색) 조회 성능 개선

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -38,9 +38,11 @@ dependencies {
     testImplementation 'io.projectreactor:reactor-test'
 
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
-    
+
     implementation 'org.flywaydb:flyway-core'
     implementation 'org.flywaydb:flyway-mysql'
+
+    implementation 'io.netty:netty-resolver-dns-native-macos:4.1.107.Final:osx-aarch_64'
 
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -35,9 +35,6 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
-    testImplementation 'io.projectreactor:reactor-test'
-
-    implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
     implementation 'org.flywaydb:flyway-core'
     implementation 'org.flywaydb:flyway-mysql'

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -35,6 +35,7 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    testImplementation 'io.projectreactor:reactor-test'
 
     implementation 'org.flywaydb:flyway-core'
     implementation 'org.flywaydb:flyway-mysql'

--- a/backend/src/main/java/project/backend/domain/chat/chatmessage/api/ChatMessageController.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatmessage/api/ChatMessageController.java
@@ -28,38 +28,38 @@ import project.backend.domain.imagefile.ImageType;
 @RequiredArgsConstructor
 public class ChatMessageController {
 
-    private final ChatMessageService chatMessageService;
-    private final ImageFileService imageFileService;
-    private final SimpMessagingTemplate messagingTemplate;
+	private final ChatMessageService chatMessageService;
+	private final ImageFileService imageFileService;
+	private final SimpMessagingTemplate messagingTemplate;
 
-    @MessageMapping("/send-message/{roomId}") //클라이언트가 메세지를 보낼 경로
-    public ChatMessageResponse sendMessage(@DestinationVariable Long roomId,
-        @Payload ChatMessageRequest request, Principal principal) {
-        ChatMessageResponse response = chatMessageService.save(roomId, request,
-            principal.getName());
+	@MessageMapping("/send-message/{roomId}") //클라이언트가 메세지를 보낼 경로
+	public ChatMessageResponse sendMessage(@DestinationVariable Long roomId,
+		@Payload ChatMessageRequest request, Principal principal) {
+		ChatMessageResponse response = chatMessageService.save(roomId, request,
+			principal.getName());
 
-        messagingTemplate.convertAndSend("/topic/chat/" + roomId, response);
+		messagingTemplate.convertAndSend("/topic/chat/" + roomId, response);
 
-        return response;
-    }
+		return response;
+	}
 
-    @MessageMapping("/edit-message/{roomId}")
-    public ChatMessageResponse editMessage(@DestinationVariable Long roomId, @Payload
-    ChatMessageEditRequest request, Principal principal) {
-        ChatMessageResponse response = chatMessageService.editMessage(roomId, request,
-            principal.getName());
+	@MessageMapping("/edit-message/{roomId}")
+	public ChatMessageResponse editMessage(@DestinationVariable Long roomId, @Payload
+	ChatMessageEditRequest request, Principal principal) {
+		ChatMessageResponse response = chatMessageService.editMessage(roomId, request,
+			principal.getName());
 
-        messagingTemplate.convertAndSend("/topic/chat/" + roomId, response);
+		messagingTemplate.convertAndSend("/topic/chat/" + roomId, response);
 
-        return response;
-    }
+		return response;
+	}
 
 	@GetMapping("/chat/search/{roomId}")
 	public Page<ChatMessageSearchResponse> searchMessages(
 		@PathVariable("roomId") Long roomId,
 		@RequestParam("keyword") String keyword,
 		@RequestParam(defaultValue = "0") int page,
-		@RequestParam(defaultValue = "20") int size
+		@RequestParam(defaultValue = "10") int size
 	) {
 		ChatMessageSearchRequest request = ChatMessageSearchRequest.of(keyword, page, size);
 

--- a/backend/src/main/java/project/backend/domain/chat/chatmessage/dao/ChatMessageRepository.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatmessage/dao/ChatMessageRepository.java
@@ -32,5 +32,5 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
 
 	List<ChatMessage> findByChatRoom_IdOrderBySendAtAsc(Long roomId);
 
-	List<ChatMessage> findByIdInOrderBySendAtDesc(List<Long> ids);
+	List<ChatMessage> findByIdIn(List<Long> ids);
 }

--- a/backend/src/main/resources/db/migration/V2__add_roomid_sendat_index.sql
+++ b/backend/src/main/resources/db/migration/V2__add_roomid_sendat_index.sql
@@ -1,0 +1,2 @@
+ALTER TABLE chat_message
+    ADD INDEX idx_chat_room_sendat (room_id, send_at ASC);

--- a/frontend/src/pages/ChatRoom.jsx
+++ b/frontend/src/pages/ChatRoom.jsx
@@ -452,7 +452,7 @@ const ChatRoom = () => {
     try {
       // 백엔드 API 엔드포인트 수정 - 작동하는 URL 패턴으로 변경
       const response = await fetch(
-        `http://localhost:8080/chat/search/${roomId}?keyword=${keyword}&page=${page}&size=20`,
+        `http://localhost:8080/chat/search/${roomId}?keyword=${keyword}&page=${page}&size=10`,
         {
           // Add credentials to include cookies for authentication
           credentials: 'include',


### PR DESCRIPTION
## 🛰️ Issue Number
#95 

## 🪐 작업 내용
- [x] 채팅 내역 검색 성능 개선(정렬된 chat_message_search 결과 리스트 순으로, 응답DTO에 담을 chat_message 결과 리스트 정렬)
- [x] 채팅방 별 채팅 메시지를 불러오는 부분을 room_Id으로 오름차순 인덱스를 추가해서 채팅방 조회를 인덱싱으로 빠르게 검색하도록 수정
- [x] 페이지 FE 부분 수정
- [ ] 추후 검색 필터를 위해 ChatMessageSearchRequest에 정렬 방향 필드를 추가해도 좋을 듯!!

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?