### PR TITLE
Refactor: 프론트 chatRoom 분리

### DIFF
--- a/backend/src/main/java/project/backend/domain/chat/chatmessage/mapper/ChatMessageMapper.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatmessage/mapper/ChatMessageMapper.java
@@ -70,7 +70,7 @@ public class ChatMessageMapper {
 			.sender(participant)
 			.content(joinEvent.nickname() + "님이 입장했습니다.")
 			.type(MessageType.EVENT)
-			.sendAt(joinEvent.joinedAt())
+			.sendAt(joinEvent.joinAt())
 			.build();
 	}
 

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/dto/event/EventMessageResponse.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/dto/event/EventMessageResponse.java
@@ -21,7 +21,7 @@ public class EventMessageResponse {
 
 	private String content;
 
-	private LocalDateTime joinedAt;
+	private LocalDateTime sendAt;
 
 }
 

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/dto/event/JoinChatRoomEvent.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/dto/event/JoinChatRoomEvent.java
@@ -3,7 +3,7 @@ package project.backend.domain.chat.chatroom.dto.event;
 import java.time.LocalDateTime;
 
 public record JoinChatRoomEvent(Long roomId, Long memberId, String nickname,
-								LocalDateTime joinedAt) {
+								LocalDateTime joinAt) {
 
 }
 

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/mapper/ChatRoomMapper.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/mapper/ChatRoomMapper.java
@@ -96,7 +96,7 @@ public class ChatRoomMapper {
 			.roomId(joinEvent.roomId())
 			.sender(joinEvent.nickname())
 			.content(joinEvent.nickname() + "님이 입장했습니다.")
-			.joinedAt(joinEvent.joinedAt())
+			.sendAt(joinEvent.joinAt())
 			.build();
 	}
 }

--- a/backend/src/main/java/project/backend/domain/member/dto/MemberUpdateRequest.java
+++ b/backend/src/main/java/project/backend/domain/member/dto/MemberUpdateRequest.java
@@ -4,29 +4,28 @@ import jakarta.validation.constraints.AssertTrue;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.Data;
-import lombok.Value;
 import org.springframework.web.multipart.MultipartFile;
 
 @Data
 public class MemberUpdateRequest {
 
-    @NotBlank(message = "비밀번호는 필수입니다.")
-    @Size(min = 12, message = "비밀번호는 최소 12자 이상이여야 합니다.")
-    private String password;
+	@NotBlank(message = "비밀번호는 필수입니다.")
+	@Size(min = 12, message = "비밀번호는 최소 12자 이상이여야 합니다.")
+	private String password;
 
-    @NotBlank(message = "비밀번호 확인은 필수입니다.")
-    @Size(min = 12, message = "비밀번호는 최소 12자 이상이여야 합니다.")
-    private String confirmPassword;
+	@NotBlank(message = "비밀번호 확인은 필수입니다.")
+	@Size(min = 4, message = "비밀번호는 최소 4자 이상이여야 합니다.")
+	private String confirmPassword;
 
-    @AssertTrue(message = "비밀번호와 확인값이 일치하지 않습니다.")
-    public boolean isPasswordMatch() {
-        return password.equals(confirmPassword);
-    }
+	@AssertTrue(message = "비밀번호와 확인값이 일치하지 않습니다.")
+	public boolean isPasswordMatch() {
+		return password.equals(confirmPassword);
+	}
 
-    @NotBlank(message = "닉네임은 필수입니다.")
-    @Size(min = 3, message = "닉네임은 최소 3자 이상이여야 합니다.")
-    private String nickname;
+	@NotBlank(message = "닉네임은 필수입니다.")
+	@Size(min = 3, message = "닉네임은 최소 3자 이상이여야 합니다.")
+	private String nickname;
 
-    private MultipartFile profileImg;
+	private MultipartFile profileImg;
 
 }

--- a/backend/src/main/java/project/backend/domain/member/dto/SignUpRequest.java
+++ b/backend/src/main/java/project/backend/domain/member/dto/SignUpRequest.java
@@ -14,7 +14,7 @@ public class SignUpRequest {
 	private String email;
 
 	@NotBlank(message = "비밀번호는 필수입니다.")
-	@Size(min = 12, message = "비밀번호는 최소 12자 이상이여야 합니다.")
+	@Size(min = 4, message = "비밀번호는 최소 4자 이상이여야 합니다.")
 	private String password;
 
 	@NotBlank(message = "닉네임은 필수입니다.")

--- a/frontend/src/components/SideBar.jsx
+++ b/frontend/src/components/SideBar.jsx
@@ -109,7 +109,7 @@ const Sidebar = () => {
 
   const fetchCurrentUser = async () => {
     try {
-      const res = await axiosInstance.get('/users/current');
+      const res = await axiosInstance.get('/user/details');
       setCurrentUser(res.data);
     } catch (err) {
       console.error('사용자 정보 로딩 오류:', err);

--- a/frontend/src/components/SideBar.jsx
+++ b/frontend/src/components/SideBar.jsx
@@ -1,13 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import { 
-  FaRegCommentDots,
-  FaInfoCircle,
-  FaAngleLeft, 
-  FaAngleRight,
-  FaComments,
-  FaPlus
-} from 'react-icons/fa';
+import { FaRegCommentDots, FaInfoCircle, FaAngleLeft, FaAngleRight, FaComments, FaPlus } from 'react-icons/fa';
 import { Client } from '@stomp/stompjs';
 import SockJS from 'sockjs-client';
 

--- a/frontend/src/components/chatroom/MessageInput.jsx
+++ b/frontend/src/components/chatroom/MessageInput.jsx
@@ -17,34 +17,6 @@ const MessageInput = ({
 }) => {
     const fileInputRef = useRef(null);
     const isComposingRef = useRef(false);
-
-    const inputStyle = {
-        fontSize: '14px',
-        padding: '10px 14px',
-        border: '1px solid #e0e4e8',
-        borderRadius: '4px',
-        outline: 'none',
-        transition: 'border-color 0.2s',
-        boxShadow: 'inset 0 1px 2px rgba(0,0,0,0.05)'
-    };
-    
-    // 버튼 스타일 공통화
-    const buttonStyle = {
-        backgroundColor: '#4a6cf7',
-        color: 'white',
-        border: 'none',
-        borderRadius: '4px',
-        padding: '0 20px',
-        height: '40px',
-        fontSize: '14px',
-        fontWeight: '500',
-        cursor: 'pointer',
-        transition: 'background-color 0.2s',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        boxShadow: '0 2px 4px rgba(0, 0, 0, 0.1)'
-    };
     
     return (
         <>
@@ -101,7 +73,7 @@ const MessageInput = ({
                   value={language}
                   onChange={(e) => setLanguage(e.target.value)}
                   style={{
-                    ...inputStyle,
+                    boxShadow: 'inset 0 1px 2px rgba(0,0,0,0.05)',
                     backgroundColor: '#f8fafc',
                     border: '1px solid #e2e8f0',
                     borderRadius: '4px',
@@ -231,7 +203,23 @@ const MessageInput = ({
 
                   <button
                     onClick={handleUnifiedSend}
-                    style={{ ...buttonStyle, height: '80px' }}
+                    style={{
+                      backgroundColor: '#4a6cf7',
+                      color: 'white',
+                      border: 'none',
+                      borderRadius: '4px',
+                      padding: '0 20px',
+                      height: '40px',
+                      fontSize: '14px',
+                      fontWeight: '500',
+                      cursor: 'pointer',
+                      transition: 'background-color 0.2s',
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      boxShadow: '0 2px 4px rgba(0, 0, 0, 0.1)',
+                      height: '80px'
+                    }}
                   >
                     전송
                   </button>

--- a/frontend/src/components/chatroom/MessageInput.jsx
+++ b/frontend/src/components/chatroom/MessageInput.jsx
@@ -1,0 +1,261 @@
+//입력 모드 전환과 입력 필드
+import React, { useRef } from 'react';
+import { FaTrashAlt } from 'react-icons/fa';
+
+const MessageInput = ({
+  inputMode,
+  setInputMode,
+  content,
+  setContent,
+  language,
+  setLanguage,
+  sendMessage,
+  handleUnifiedSend,
+  imageFile,
+  setImageFile,
+  imagePreviewUrl,
+  setImagePreviewUrl,
+}) => {
+    const fileInputRef = useRef(null);
+    const isComposingRef = useRef(false);
+
+    const inputStyle = {
+        fontSize: '14px',
+        padding: '10px 14px',
+        border: '1px solid #e0e4e8',
+        borderRadius: '4px',
+        outline: 'none',
+        transition: 'border-color 0.2s',
+        boxShadow: 'inset 0 1px 2px rgba(0,0,0,0.05)'
+    };
+    
+    // 버튼 스타일 공통화
+    const buttonStyle = {
+        backgroundColor: '#4a6cf7',
+        color: 'white',
+        border: 'none',
+        borderRadius: '4px',
+        padding: '0 20px',
+        height: '40px',
+        fontSize: '14px',
+        fontWeight: '500',
+        cursor: 'pointer',
+        transition: 'background-color 0.2s',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        boxShadow: '0 2px 4px rgba(0, 0, 0, 0.1)'
+    };
+    
+    return (
+        <>
+          <div style={{
+              marginBottom: '12px',
+              display: 'flex',
+              alignItems: 'center'
+            }}>
+              <div style={{
+                display: 'flex',
+                backgroundColor: '#f1f5f9',
+                borderRadius: '6px',
+                padding: '2px',
+                marginRight: '12px'
+              }}>
+                <span
+                  onClick={() => {
+                    const nextMode = inputMode === 'IMAGE' ? 'TEXT' : 'IMAGE';
+                    setInputMode(nextMode);
+
+                    // 모드가 IMAGE로 바뀌었으면 파일 선택창 자동 오픈
+                    if (nextMode === 'IMAGE' && fileInputRef.current) {
+                      fileInputRef.current.click();
+                    }
+                  }}
+                  style={{
+                    padding: '6px 12px',
+                    borderRadius: '4px',
+                    cursor: 'pointer',
+                    fontWeight: '500',
+                    fontSize: '13px',
+                    backgroundColor: inputMode === 'IMAGE' ? '#ffffff' : 'transparent',
+                    color: inputMode === 'IMAGE' ? '#4a6cf7' : '#64748b',
+                    boxShadow: inputMode === 'IMAGE' ? '0 1px 3px rgba(0,0,0,0.1)' : 'none',
+                    transition: 'all 0.2s'
+                  }}
+                >
+                  사진
+                </span>
+                <span
+                  onClick={() => {
+                    const nextMode = inputMode === 'CODE' ? 'TEXT' : 'CODE';
+                    setInputMode(nextMode);
+                  }}
+                  style={{
+                    padding: '6px 12px',
+                    borderRadius: '4px',
+                    cursor: 'pointer',
+                    fontWeight: '500',
+                    fontSize: '13px',
+                    backgroundColor: inputMode === 'CODE' ? '#ffffff' : 'transparent',
+                    color: inputMode === 'CODE' ? '#4a6cf7' : '#64748b',
+                    boxShadow: inputMode === 'CODE' ? '0 1px 3px rgba(0,0,0,0.1)' : 'none',
+                    transition: 'all 0.2s'
+                  }}
+                >
+                  코드
+                </span>
+              </div>
+
+              {/* 언어 선택 옵션을 코드 버튼 바로 옆으로 이동 */}
+              {inputMode === 'CODE' && (
+                <select
+                  value={language}
+                  onChange={(e) => setLanguage(e.target.value)}
+                  style={{
+                    ...inputStyle,
+                    backgroundColor: '#f8fafc',
+                    border: '1px solid #e2e8f0',
+                    borderRadius: '4px',
+                    padding: '6px 10px',
+                    fontSize: '13px',
+                    color: '#475569',
+                    cursor: 'pointer'
+                  }}
+                >
+                  <option value="javascript">JavaScript</option>
+                  <option value="java">Java</option>
+                  <option value="python">Python</option>
+                  <option value="html">HTML</option>
+                  <option value="css">CSS</option>
+                </select>
+              )}
+            </div>
+
+            <div style={{ display: 'flex', gap: '10px' }}>
+              <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+
+                {/* 썸네일 미리보기 이미지 */}
+                {inputMode === 'IMAGE' && imagePreviewUrl && (
+                  <div style={{
+                    position: 'relative',
+                    marginBottom: '10px',
+                    padding: '8px',
+                    backgroundColor: '#f8fafc',
+                    border: '2px solid #e2e8f0',
+                    borderRadius: '8px',
+                    maxWidth: '10%',
+                    boxShadow: '0 1px 4px rgba(0,0,0,0.05)',
+                    display: 'inline-block'
+                  }}>
+                    <img
+                      src={imagePreviewUrl}
+                      alt="미리보기"
+                      style={{
+                        maxWidth: '100%',
+                        objectFit: 'contain',
+                        borderRadius: '6px',
+                        display: 'block'
+                      }}
+                    />
+
+                    <button
+                      onClick={() => {
+                        setImageFile(null);
+                        setImagePreviewUrl(null);
+                        setInputMode('TEXT');
+
+                        if (fileInputRef.current) {
+                          fileInputRef.current.value = null;
+                        }
+                      }}
+                      title="삭제"
+                      style={{
+                        position: 'absolute',
+                        top: '2px',
+                        right: '2px',
+                        backgroundColor: 'rgba(255, 255, 255, 0.9)',
+                        border: '1px solid #e2e8f0',
+                        borderRadius: '50%',
+                        width: '28px',
+                        height: '28px',
+                        color: '#e53e3e',
+                        cursor: 'pointer',
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        boxShadow: '0 1px 4px rgba(0,0,0,0.15)'
+                      }}
+                    >
+                      <FaTrashAlt color="#e53e3e" size={16} />
+                    </button>
+                  </div>
+                )}
+
+                <div style={{ display: 'flex', alignItems: 'flex-end', gap: '10px' }}>
+                  <textarea
+                    disabled={inputMode === 'IMAGE'}
+                    value={content}
+                    onChange={handleInputChange}
+                    onCompositionStart={() => (isComposingRef.current = true)}
+                    onCompositionEnd={() => (isComposingRef.current = false)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' && !e.shiftKey && !isComposingRef.current) {
+                        e.preventDefault();
+                        sendMessage(e.target.value);
+                      }
+                    }}
+                    placeholder={inputMode === 'CODE' ? '코드를 입력하세요.' : inputMode === 'IMAGE' ? '이미지를 업로드 해주세요.' : '메시지를 입력하세요.'}
+                    style={{
+                      flex: 1,
+                      height: '80px',
+                      resize: 'none',
+                      padding: '12px 16px',
+                      fontSize: '14px',
+                      backgroundColor: inputMode === 'IMAGE' ? '#f1f5f9' : inputMode === 'CODE' ? '#f8fafc' : 'white',
+                      border: '1px solid #e2e8f0',
+                      borderRadius: '8px',
+                      lineHeight: '1.5',
+                      color: '#4a5568',
+                      boxShadow: 'inset 0 1px 2px rgba(0,0,0,0.05)',
+                      transition: 'border-color 0.2s',
+                      cursor: inputMode === 'IMAGE' ? 'not-allowed' : 'text'
+                    }}
+                  />
+
+                  <input
+                    type="file"
+                    ref={fileInputRef}
+                    // accept="image/*"
+                    onChange={(e) => {
+                      if (e.target.files?.[0]) {
+                        const file = e.target.files[0];
+                        setImageFile(file);
+
+                        // 파일 URL 생성
+                        const reader = new FileReader();
+                        reader.onloadend = () => {
+                          setImagePreviewUrl(reader.result);
+                        };
+                        reader.readAsDataURL(file);
+                      }
+                    }}
+                    style={{ display: 'none' }} // 숨김
+                  />
+
+                  <button
+                    // onClick={() => sendMessage()}
+                    onClick={handleUnifiedSend}
+                    style={{
+                      ...buttonStyle,
+                      height: '80px'
+                    }}
+                  >
+                    전송
+                  </button>
+                </div>
+              </div>
+            </div>
+        </>
+    );
+};
+export default MessageInput;

--- a/frontend/src/components/chatroom/MessageInput.jsx
+++ b/frontend/src/components/chatroom/MessageInput.jsx
@@ -11,7 +11,6 @@ const MessageInput = ({
   setLanguage,
   sendMessage,
   handleUnifiedSend,
-  imageFile,
   setImageFile,
   imagePreviewUrl,
   setImagePreviewUrl,
@@ -49,24 +48,14 @@ const MessageInput = ({
     
     return (
         <>
-          <div style={{
-              marginBottom: '12px',
-              display: 'flex',
-              alignItems: 'center'
-            }}>
-              <div style={{
-                display: 'flex',
-                backgroundColor: '#f1f5f9',
-                borderRadius: '6px',
-                padding: '2px',
-                marginRight: '12px'
-              }}>
+          <div style={{ marginBottom: '12px', display: 'flex', alignItems: 'center'}}>
+              <div style={{ display: 'flex', backgroundColor: '#f1f5f9', borderRadius: '6px', padding: '2px', marginRight: '12px' }}>
                 <span
                   onClick={() => {
                     const nextMode = inputMode === 'IMAGE' ? 'TEXT' : 'IMAGE';
                     setInputMode(nextMode);
 
-                    // 모드가 IMAGE로 바뀌었으면 파일 선택창 자동 오픈
+                    // 모드가 IMAGE로 바뀌면 파일 선택창 자동 오픈
                     if (nextMode === 'IMAGE' && fileInputRef.current) {
                       fileInputRef.current.click();
                     }
@@ -195,7 +184,7 @@ const MessageInput = ({
                   <textarea
                     disabled={inputMode === 'IMAGE'}
                     value={content}
-                    onChange={handleInputChange}
+                    onChange={(e) => setContent(e.target.value)}
                     onCompositionStart={() => (isComposingRef.current = true)}
                     onCompositionEnd={() => (isComposingRef.current = false)}
                     onKeyDown={(e) => {
@@ -233,9 +222,7 @@ const MessageInput = ({
 
                         // 파일 URL 생성
                         const reader = new FileReader();
-                        reader.onloadend = () => {
-                          setImagePreviewUrl(reader.result);
-                        };
+                        reader.onloadend = () => setImagePreviewUrl(reader.result);
                         reader.readAsDataURL(file);
                       }
                     }}
@@ -243,12 +230,8 @@ const MessageInput = ({
                   />
 
                   <button
-                    // onClick={() => sendMessage()}
                     onClick={handleUnifiedSend}
-                    style={{
-                      ...buttonStyle,
-                      height: '80px'
-                    }}
+                    style={{ ...buttonStyle, height: '80px' }}
                   >
                     전송
                   </button>

--- a/frontend/src/components/chatroom/MessageList.jsx
+++ b/frontend/src/components/chatroom/MessageList.jsx
@@ -1,26 +1,430 @@
-const formatDate = (dateString) => {
-try {
-    const date = new Date(dateString);
+import React from 'react';
 
-    if (isNaN(date.getTime())) {
-    return new Date().toLocaleDateString('ko-KR', {
-        year: 'numeric',
-        month: '2-digit',
-        day: '2-digit'
-    });
-    }
+const MessageItem = ({ msg, currentUser, contextMenuId, setContextMenuId, setEditMessageId, setEditContent, handleEditMessage, handleDeleteMessage }) => {
+    const formatDate = (dateString) => {
+        const date = new Date(dateString);
 
-    return date.toLocaleDateString('ko-KR', {
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit'
-    });
-} catch (error) {
-    console.error('날짜 형식 변환 오류:', error);
-    return new Date().toLocaleDateString('ko-KR', {
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit'
-    });
+        if (isNaN(date.getTime())) {
+            return new Date().toLocaleDateString('ko-KR', {
+                year: 'numeric', month: '2-digit', day: '2-digit'
+            });
+        }
+
+        return date.toLocaleDateString('ko-KR', {
+            year: 'numeric', month: '2-digit', day: '2-digit'
+        });
+    };
+
+    
+  const renderWithLink = (text) => {
+    const urlRegex = /(https?:\/\/[^\s]+)/g;
+    return text.split(urlRegex).map((part, i) =>
+      urlRegex.test(part) ? (
+        <a
+          key={i}
+          href={part}
+          target="_blank"
+          rel="noopener noreferrer"
+          style={{ color: '#0366d6', textDecoration: 'underline' }}
+        >
+          {part}
+        </a>
+      ) : (
+        part
+      )
+    );
+  };
+
+  return (
+       <div key={`msg-${index}`} style={{
+          marginBottom: '18px',
+          display: 'flex',
+          alignItems: 'flex-start',
+        }}>
+          {/* 프로필 이미지 */}
+          <div style={{
+            width: '38px',
+            height: '38px',
+            borderRadius: '50%',
+            marginRight: '12px',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            color: 'white',
+            fontWeight: '600',
+            fontSize: '16px',
+            flexShrink: 0,
+            backgroundImage: `url("http://localhost:8080/images/profile/${msg.profileImageUrl}")`,
+            backgroundSize: 'cover'
+          }}>
+          </div>
+          <div style={{ flex: 1, maxWidth: 'calc(100% - 50px)' }}>
+            <div style={{
+              display: 'flex',
+              marginBottom: '6px',
+              justifyContent: 'space-between',
+            }}>
+              <div style={{ display: 'flex', alignItems: 'baseline' }}>
+                <span style={{
+                  fontWeight: '600',
+                  fontSize: '15px',
+                  color: '#2d3748'
+                }}>
+                  {msg.senderName}
+                </span>
+                <span style={{
+                  fontWeight: 'normal',
+                  fontSize: '12px',
+                  color: '#718096',
+                  marginLeft: '8px'
+                }}>
+                  {new Date(msg.sendAt).toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit' })}
+                </span>
+              </div>
+
+              {/* 점 세개 메뉴는 조건부 렌더링 */}
+              {currentUser?.id === msg.senderId && !msg.deleted && msg.type !== 'GIT' && (
+                <div style={{ position: 'relative' }}>
+                  <button
+                    onClick={() =>
+                      setContextMenuId(contextMenuId === msg.messageId ? null : msg.messageId)
+                    }
+                    style={{
+                      position: 'absolute',
+                      right: '0px',
+                      border: 'none',
+                      background: 'transparent',
+                      cursor: 'pointer',
+                      fontSize: '18px',
+                      color: '#94a3b8'
+                    }}
+                  >
+                    ⋯
+                  </button>
+
+                  {contextMenuId === msg.messageId && (
+                    <div style={{
+                      position: 'absolute',
+                      top: '24px',
+                      right: '0',
+                      backgroundColor: '#fff',
+                      border: '1px solid #e2e8f0',
+                      borderRadius: '6px',
+                      boxShadow: '0 2px 6px rgba(0,0,0,0.15)',
+                      zIndex: 1000,
+                      padding: '6px 0',
+                      minWidth: '140px'
+                    }}>
+                      {/* 수정 버튼은 이미지 메시지가 아닌 경우에만 표시 */}
+                      {msg.type !== 'IMAGE' && (
+                        <>
+                          <button
+                            onClick={() => {
+                              setEditMessageId(msg.messageId);
+                              setEditContent(msg.content);
+                              setContextMenuId(null);
+                            }}
+                            style={{
+                              display: 'block',
+                              width: '100%',
+                              padding: '10px 16px',
+                              textAlign: 'left',
+                              background: 'none',
+                              border: 'none',
+                              fontSize: '14px',
+                              cursor: 'pointer'
+                            }}
+                          >
+                            메세지 수정하기
+                          </button>
+
+                          {/* 구분선 추가 */}
+                          <div style={{
+                            height: '1px',
+                            backgroundColor: '#e2e8f0',
+                            margin: '0 8px'
+                          }} />
+                        </>
+                      )}
+
+                      <button
+                        onClick={() => {
+                          const confirmed = window.confirm("정말 삭제하시겠습니까?");
+                          if (confirmed) {
+                            handleDeleteMessage(msg.messageId);
+                          }
+                          setContextMenuId(null);
+                        }}
+                        style={{
+                          display: 'block',
+                          width: '100%',
+                          padding: '10px 16px',
+                          textAlign: 'left',
+                          background: 'none',
+                          border: 'none',
+                          fontSize: '14px',
+                          color: '#e53e3e',
+                          cursor: 'pointer'
+                        }}
+                      >
+                        삭제
+                      </button>
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+
+            {/* 본문 영역 - 수정 중인 메시지는 textarea, 나머지는 content 렌더 */}
+            {editMessageId === msg.messageId && msg.type !== 'GIT' ? (
+              <div style={{ display: 'flex', gap: '8px', flexDirection: 'column' }}>
+                <textarea
+                  value={editContent}
+                  onChange={(e) => setEditContent(e.target.value)}
+                  style={{
+                    width: '100%',
+                    minHeight: '80px',
+                    border: '1px solid #e2e8f0',
+                    borderRadius: '6px',
+                    padding: '10px',
+                    fontSize: '14px',
+                    resize: 'vertical'
+                  }}
+                />
+                <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '10px' }}>
+                  <button
+                    onClick={() => handleEditMessage(msg.messageId)}
+                    style={{
+                      backgroundColor: '#4a6cf7',
+                      color: 'white',
+                      border: 'none',
+                      borderRadius: '4px',
+                      padding: '6px 12px',
+                      fontSize: '14px',
+                      cursor: 'pointer'
+                    }}
+                  >
+                    저장
+                  </button>
+                  <button
+                    onClick={() => {
+                      setEditMessageId(null);
+                      setEditContent('');
+                    }}
+                    style={{
+                      backgroundColor: '#e2e8f0',
+                      color: '#1a202c',
+                      border: 'none',
+                      borderRadius: '4px',
+                      padding: '6px 12px',
+                      fontSize: '14px',
+                      cursor: 'pointer'
+                    }}
+                  >
+                    취소
+                  </button>
+                </div>
+              </div>
+            )
+              :(msg.deleted || msg.isDeleted) ? (
+                <div style={{
+                  fontSize: '14px',
+                  lineHeight: '1.5',
+                  color: '#a0aec0',
+                  fontStyle: 'italic'
+                }}>
+                  삭제된 메시지입니다.
+                </div>
+              )
+                : msg.type === 'GIT' ? (
+                  <div style={{
+                    backgroundColor: '#f6f8fa',
+                    borderRadius: '6px',
+                    color: '#24292e',
+                    display: 'flex'
+                  }}>
+                    {/* 왼쪽 검정색 선 */}
+                    <div style={{
+                      width: '6px',
+                      backgroundColor: '#000',
+                      marginRight: '10px',
+                      borderRadius: '2px'
+                    }} />
+                    {msg.content && (
+                      <div style={{ whiteSpace: 'pre-wrap', lineHeight: '1.5', padding: '10px' }}>
+                        {msg.content.split('\n').map((line, i) => (
+                          <div key={i}>
+                            {i === 0 ? (
+                              <strong>{renderWithLink(line)}</strong>
+                            ) : (
+                              <>{renderWithLink(line)}</>
+                            )}
+                          </div>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                ) : msg.type === 'CODE' || (msg.content && msg.content.startsWith('```')) ? (
+                  <div style={{
+                    borderRadius: '6px',
+                    overflow: 'hidden',
+                    border: '1px solid #e2e8f0'
+                  }}>
+                    <HighlightedCode
+                      content={msg.content.replace(/```/g, '')}
+                      language={msg.language || 'java'}
+                    />
+                    {msg.edited && (
+                      <span style={{
+                        marginLeft: '6px',
+                        fontSize: '11px',
+                        color: '#a0aec0',
+                        fontStyle: 'italic'
+                      }}>
+                        (수정됨)
+                      </span>
+                    )}
+                  </div>
+                ) : msg.type === 'IMAGE' ? (
+                  <div style={{
+                    maxWidth: '30%',
+                    backgroundColor: '#f8fafc',
+                    border: '1px solid #e2e8f0',
+                    borderRadius: '8px',
+                    padding: '8px',
+                    boxShadow: '0 1px 4px rgba(0, 0, 0, 0.05)'
+                  }}>
+                    <img
+                      src={`http://localhost:8080/images/chat/${msg.chatImageUrl}`}
+                      alt="업로드된 이미지"
+                      style={{
+                        width: '100%',
+                        maxHeight: '400px',
+                        objectFit: 'contain',
+                        borderRadius: '6px'
+                      }}
+                    />
+                  </div>
+                )
+                  : (
+                    <div style={{
+                      fontSize: '14px',
+                      lineHeight: '1.5',
+                      color: '#4a5568',
+                      wordBreak: 'break-word',
+                      whiteSpace: 'pre-wrap'
+                    }}>
+                      {msg.content}
+                      {(msg.edited || msg.isEdited) && (
+                        <span style={{
+                          marginLeft: '6px',
+                          fontSize: '11px',
+                          color: '#a0aec0',
+                          fontStyle: 'italic'
+                        }}>
+                          (수정됨)
+                        </span>
+                      )}
+                    </div>
+                  )}
+          </div>
+        </div>
+  )
+
 }
-};
+
+
+const MessageList = ({ messages, currentUser, contextMenuId, setContextMenuId, setEditMessageId, setEditContent, handleEditMessage, handleDeleteMessage }) => {
+      if (!messages.length) return null;
+
+    const result = [];
+    let currentDate = null;
+
+    // 메시지를 순회하며 날짜별로 구분
+    messages.forEach((msg, index) => {
+      const messageDate = formatDate(msg.sendAt);
+
+      // 날짜가 바뀌었다면 구분선 추가
+      if (messageDate !== currentDate) {
+        currentDate = messageDate;
+        result.push(
+          <div key={`date-${index}`}
+            style={{ display: 'flex',
+                alignItems: 'center',
+                margin: '24px 0',
+                color: '#64748b',
+                fontSize: '14px',
+                fontWeight: '500'
+          }}>
+            <div style={{
+              flex: '1',
+              height: '1px',
+              backgroundColor: '#e2e8f0'
+            }} />
+            <div style={{
+              margin: '0 16px',
+              padding: '4px 12px',
+              backgroundColor: '#f8fafc',
+              borderRadius: '12px',
+              border: '1px solid #e2e8f0'
+            }}>
+              {messageDate}
+            </div>
+            <div style={{
+              flex: '1',
+              height: '1px',
+              backgroundColor: '#e2e8f0'
+            }}/>
+          </div>
+        );
+      }
+
+      // 메시지 추가
+      result.push(
+        <div key={`msg-${index}`} style={{
+          marginBottom: '18px',
+          display: 'flex',
+          alignItems: 'flex-start',
+        }}>
+          {/* 프로필 이미지 */}
+          <div style={{
+            width: '38px',
+            height: '38px',
+            borderRadius: '50%',
+            marginRight: '12px',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            color: 'white',
+            fontWeight: '600',
+            fontSize: '16px',
+            flexShrink: 0,
+            backgroundImage: `url("http://localhost:8080/images/profile/${msg.profileImageUrl}")`,
+            backgroundSize: 'cover'
+          }}>
+          </div>
+          <div style={{ flex: 1, maxWidth: 'calc(100% - 50px)' }}>
+            <div style={{
+              display: 'flex',
+              marginBottom: '6px',
+              justifyContent: 'space-between',
+            }}>
+              <div style={{ display: 'flex', alignItems: 'baseline' }}>
+                <span style={{
+                  fontWeight: '600',
+                  fontSize: '15px',
+                  color: '#2d3748'
+                }}>
+                  {msg.senderName}
+                </span>
+                <span style={{
+                  fontWeight: 'normal',
+                  fontSize: '12px',
+                  color: '#718096',
+                  marginLeft: '8px'
+                }}>
+                  {new Date(msg.sendAt).toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit' })}
+                </span>
+              </div>
+
+}

--- a/frontend/src/components/chatroom/MessageList.jsx
+++ b/frontend/src/components/chatroom/MessageList.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Highlight from 'react-highlight';
 import { FaCopy, FaTrashAlt, FaUserPlus, FaClock } from 'react-icons/fa';
 
- // 날짜를 YYYY-MM-DD 형식으로 변환하는 함수 (수정됨)
+// 날짜를 YYYY-MM-DD 형식으로 변환하는 함수
 const formatDate = (dateString) => {
   const date = new Date(dateString);
   return date.toLocaleDateString('ko-KR', {
@@ -12,7 +12,7 @@ const formatDate = (dateString) => {
   });
 };
 
-// 시간을 HH:MM 형식으로 변환하는 함수 (수정됨)
+// 시간을 HH:MM 형식으로 변환하는 함수
 const formatTime = (dateString) => {
   const date = new Date(dateString);
   return date.toLocaleTimeString('ko-KR', {

--- a/frontend/src/components/chatroom/MessageList.jsx
+++ b/frontend/src/components/chatroom/MessageList.jsx
@@ -1,0 +1,26 @@
+const formatDate = (dateString) => {
+try {
+    const date = new Date(dateString);
+
+    if (isNaN(date.getTime())) {
+    return new Date().toLocaleDateString('ko-KR', {
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit'
+    });
+    }
+
+    return date.toLocaleDateString('ko-KR', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit'
+    });
+} catch (error) {
+    console.error('날짜 형식 변환 오류:', error);
+    return new Date().toLocaleDateString('ko-KR', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit'
+    });
+}
+};

--- a/frontend/src/components/chatroom/MessageList.jsx
+++ b/frontend/src/components/chatroom/MessageList.jsx
@@ -1,158 +1,121 @@
 import React from 'react';
+import Highlight from 'react-highlight';
 
-const MessageItem = ({ msg, currentUser, contextMenuId, setContextMenuId, setEditMessageId, setEditContent, handleEditMessage, handleDeleteMessage }) => {
-    const formatDate = (dateString) => {
-        const date = new Date(dateString);
+const formatDate = (dateString) => {
+  const date = new Date(dateString);
+  return date.toLocaleDateString('ko-KR', {
+      year: 'numeric', month: '2-digit', day: '2-digit'
+  });
+};
 
-        if (isNaN(date.getTime())) {
-            return new Date().toLocaleDateString('ko-KR', {
-                year: 'numeric', month: '2-digit', day: '2-digit'
-            });
-        }
+const renderWithLink = (text) => {
+  const urlRegex = /(https?:\/\/[^\s]+)/g;
+  return text.split(urlRegex).map((part, i) =>
+    urlRegex.test(part) ? (
+      <a
+        key={i}
+        href={part}
+        target="_blank"
+        rel="noopener noreferrer"
+        style={{ color: '#0366d6', textDecoration: 'underline' }}
+      >
+        {part}
+      </a>
+    ) : (
+      part
+    )
+  );
+};
 
-        return date.toLocaleDateString('ko-KR', {
-            year: 'numeric', month: '2-digit', day: '2-digit'
-        });
-    };
+const HighlightedCode = ({ content, language }) => {
+  return (
+    <Highlight className={language}>{content}</Highlight>
+  );
+};
 
-    
-  const renderWithLink = (text) => {
-    const urlRegex = /(https?:\/\/[^\s]+)/g;
-    return text.split(urlRegex).map((part, i) =>
-      urlRegex.test(part) ? (
-        <a
-          key={i}
-          href={part}
-          target="_blank"
-          rel="noopener noreferrer"
-          style={{ color: '#0366d6', textDecoration: 'underline' }}
-        >
-          {part}
-        </a>
-      ) : (
-        part
-      )
-    );
-  };
+//프로필 이미지, 날짜, 수정 삭제 메뉴
+const MessageItem = ({ msg, currentUser, contextMenuId, setContextMenuId, setEditMessageId, setEditContent, handleEditMessage, handleDeleteMessage, editMessageId, editContent }) => {
 
   return (
-       <div key={`msg-${index}`} style={{
-          marginBottom: '18px',
+    <div style={{ marginBottom: '18px', display: 'flex', alignItems: 'flex-start' }}>
+      {/* 프로필 이미지 */}
+      <div style={{
+        width: '38px',
+        height: '38px',
+        borderRadius: '50%',
+        marginRight: '12px',
+        display: 'flex',
+        fontWeight: '600',
+        fontSize: '16px',
+        backgroundImage: `url("http://localhost:8080/images/profile/${msg.profileImageUrl}")`,
+        backgroundSize: 'cover'
+      }}>
+      </div>
+
+      <div style={{ flex: 1}}>
+        <div style={{
           display: 'flex',
-          alignItems: 'flex-start',
+          marginBottom: '6px',
+          justifyContent: 'space-between',
         }}>
-          {/* 프로필 이미지 */}
-          <div style={{
-            width: '38px',
-            height: '38px',
-            borderRadius: '50%',
-            marginRight: '12px',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            color: 'white',
-            fontWeight: '600',
-            fontSize: '16px',
-            flexShrink: 0,
-            backgroundImage: `url("http://localhost:8080/images/profile/${msg.profileImageUrl}")`,
-            backgroundSize: 'cover'
-          }}>
-          </div>
-          <div style={{ flex: 1, maxWidth: 'calc(100% - 50px)' }}>
-            <div style={{
-              display: 'flex',
-              marginBottom: '6px',
-              justifyContent: 'space-between',
+          <div style={{ display: 'flex', alignItems: 'baseline' }}>
+            <span style={{
+              fontWeight: '600',
+              fontSize: '15px',
+              color: '#2d3748'
             }}>
-              <div style={{ display: 'flex', alignItems: 'baseline' }}>
-                <span style={{
-                  fontWeight: '600',
-                  fontSize: '15px',
-                  color: '#2d3748'
+              {msg.senderName}
+            </span>
+            <span style={{
+              fontWeight: 'normal',
+              fontSize: '12px',
+              color: '#718096',
+              marginLeft: '8px'
+            }}>
+              {new Date(msg.sendAt).toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit' })}
+            </span>
+          </div>
+
+          {/* 점 세개 메뉴는 조건부 렌더링 */}
+          {currentUser?.id === msg.senderId && !msg.deleted && (
+            <div style={{ position: 'relative' }}>
+              <button
+                onClick={() =>
+                  setContextMenuId(contextMenuId === msg.messageId ? null : msg.messageId)
+                }
+                style={{
+                  position: 'absolute',
+                  right: '0px',
+                  border: 'none',
+                  background: 'transparent',
+                  cursor: 'pointer',
+                  fontSize: '18px',
+                  color: '#94a3b8'
+                }}
+              >
+                ⋯
+              </button>
+
+              {contextMenuId === msg.messageId && (
+                <div style={{
+                  position: 'absolute',
+                  top: '24px',
+                  right: '0',
+                  backgroundColor: '#fff',
+                  border: '1px solid #e2e8f0',
+                  borderRadius: '6px',
+                  boxShadow: '0 2px 6px rgba(0,0,0,0.15)',
+                  zIndex: 1000,
+                  padding: '6px 0',
+                  minWidth: '140px'
                 }}>
-                  {msg.senderName}
-                </span>
-                <span style={{
-                  fontWeight: 'normal',
-                  fontSize: '12px',
-                  color: '#718096',
-                  marginLeft: '8px'
-                }}>
-                  {new Date(msg.sendAt).toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit' })}
-                </span>
-              </div>
-
-              {/* 점 세개 메뉴는 조건부 렌더링 */}
-              {currentUser?.id === msg.senderId && !msg.deleted && msg.type !== 'GIT' && (
-                <div style={{ position: 'relative' }}>
-                  <button
-                    onClick={() =>
-                      setContextMenuId(contextMenuId === msg.messageId ? null : msg.messageId)
-                    }
-                    style={{
-                      position: 'absolute',
-                      right: '0px',
-                      border: 'none',
-                      background: 'transparent',
-                      cursor: 'pointer',
-                      fontSize: '18px',
-                      color: '#94a3b8'
-                    }}
-                  >
-                    ⋯
-                  </button>
-
-                  {contextMenuId === msg.messageId && (
-                    <div style={{
-                      position: 'absolute',
-                      top: '24px',
-                      right: '0',
-                      backgroundColor: '#fff',
-                      border: '1px solid #e2e8f0',
-                      borderRadius: '6px',
-                      boxShadow: '0 2px 6px rgba(0,0,0,0.15)',
-                      zIndex: 1000,
-                      padding: '6px 0',
-                      minWidth: '140px'
-                    }}>
-                      {/* 수정 버튼은 이미지 메시지가 아닌 경우에만 표시 */}
-                      {msg.type !== 'IMAGE' && (
-                        <>
-                          <button
-                            onClick={() => {
-                              setEditMessageId(msg.messageId);
-                              setEditContent(msg.content);
-                              setContextMenuId(null);
-                            }}
-                            style={{
-                              display: 'block',
-                              width: '100%',
-                              padding: '10px 16px',
-                              textAlign: 'left',
-                              background: 'none',
-                              border: 'none',
-                              fontSize: '14px',
-                              cursor: 'pointer'
-                            }}
-                          >
-                            메세지 수정하기
-                          </button>
-
-                          {/* 구분선 추가 */}
-                          <div style={{
-                            height: '1px',
-                            backgroundColor: '#e2e8f0',
-                            margin: '0 8px'
-                          }} />
-                        </>
-                      )}
-
+                  {/* 수정 버튼은 이미지 메시지가 아닌 경우에만 표시 */}
+                  {msg.type !== 'IMAGE' && (
+                    <>
                       <button
                         onClick={() => {
-                          const confirmed = window.confirm("정말 삭제하시겠습니까?");
-                          if (confirmed) {
-                            handleDeleteMessage(msg.messageId);
-                          }
+                          setEditMessageId(msg.messageId);
+                          setEditContent(msg.content);
                           setContextMenuId(null);
                         }}
                         style={{
@@ -163,268 +126,293 @@ const MessageItem = ({ msg, currentUser, contextMenuId, setContextMenuId, setEdi
                           background: 'none',
                           border: 'none',
                           fontSize: '14px',
-                          color: '#e53e3e',
                           cursor: 'pointer'
                         }}
                       >
-                        삭제
+                        메세지 수정하기
                       </button>
-                    </div>
+
+                      {/* 구분선 추가 */}
+                      <div style={{
+                        height: '1px',
+                        backgroundColor: '#e2e8f0',
+                        margin: '0 8px'
+                      }} />
+                    </>
                   )}
+
+                  <button
+                    onClick={() => {
+                      const confirmed = window.confirm("정말 삭제하시겠습니까?");
+                      if (confirmed) {
+                        handleDeleteMessage(msg.messageId);
+                      }
+                      setContextMenuId(null);
+                    }}
+                    style={{
+                      display: 'block',
+                      width: '100%',
+                      padding: '10px 16px',
+                      textAlign: 'left',
+                      background: 'none',
+                      border: 'none',
+                      fontSize: '14px',
+                      color: '#e53e3e',
+                      cursor: 'pointer'
+                    }}
+                  >
+                    삭제
+                  </button>
                 </div>
               )}
             </div>
-
-            {/* 본문 영역 - 수정 중인 메시지는 textarea, 나머지는 content 렌더 */}
-            {editMessageId === msg.messageId && msg.type !== 'GIT' ? (
-              <div style={{ display: 'flex', gap: '8px', flexDirection: 'column' }}>
-                <textarea
-                  value={editContent}
-                  onChange={(e) => setEditContent(e.target.value)}
-                  style={{
-                    width: '100%',
-                    minHeight: '80px',
-                    border: '1px solid #e2e8f0',
-                    borderRadius: '6px',
-                    padding: '10px',
-                    fontSize: '14px',
-                    resize: 'vertical'
-                  }}
-                />
-                <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '10px' }}>
-                  <button
-                    onClick={() => handleEditMessage(msg.messageId)}
-                    style={{
-                      backgroundColor: '#4a6cf7',
-                      color: 'white',
-                      border: 'none',
-                      borderRadius: '4px',
-                      padding: '6px 12px',
-                      fontSize: '14px',
-                      cursor: 'pointer'
-                    }}
-                  >
-                    저장
-                  </button>
-                  <button
-                    onClick={() => {
-                      setEditMessageId(null);
-                      setEditContent('');
-                    }}
-                    style={{
-                      backgroundColor: '#e2e8f0',
-                      color: '#1a202c',
-                      border: 'none',
-                      borderRadius: '4px',
-                      padding: '6px 12px',
-                      fontSize: '14px',
-                      cursor: 'pointer'
-                    }}
-                  >
-                    취소
-                  </button>
-                </div>
-              </div>
-            )
-              :(msg.deleted || msg.isDeleted) ? (
-                <div style={{
-                  fontSize: '14px',
-                  lineHeight: '1.5',
-                  color: '#a0aec0',
-                  fontStyle: 'italic'
-                }}>
-                  삭제된 메시지입니다.
-                </div>
-              )
-                : msg.type === 'GIT' ? (
-                  <div style={{
-                    backgroundColor: '#f6f8fa',
-                    borderRadius: '6px',
-                    color: '#24292e',
-                    display: 'flex'
-                  }}>
-                    {/* 왼쪽 검정색 선 */}
-                    <div style={{
-                      width: '6px',
-                      backgroundColor: '#000',
-                      marginRight: '10px',
-                      borderRadius: '2px'
-                    }} />
-                    {msg.content && (
-                      <div style={{ whiteSpace: 'pre-wrap', lineHeight: '1.5', padding: '10px' }}>
-                        {msg.content.split('\n').map((line, i) => (
-                          <div key={i}>
-                            {i === 0 ? (
-                              <strong>{renderWithLink(line)}</strong>
-                            ) : (
-                              <>{renderWithLink(line)}</>
-                            )}
-                          </div>
-                        ))}
-                      </div>
-                    )}
-                  </div>
-                ) : msg.type === 'CODE' || (msg.content && msg.content.startsWith('```')) ? (
-                  <div style={{
-                    borderRadius: '6px',
-                    overflow: 'hidden',
-                    border: '1px solid #e2e8f0'
-                  }}>
-                    <HighlightedCode
-                      content={msg.content.replace(/```/g, '')}
-                      language={msg.language || 'java'}
-                    />
-                    {msg.edited && (
-                      <span style={{
-                        marginLeft: '6px',
-                        fontSize: '11px',
-                        color: '#a0aec0',
-                        fontStyle: 'italic'
-                      }}>
-                        (수정됨)
-                      </span>
-                    )}
-                  </div>
-                ) : msg.type === 'IMAGE' ? (
-                  <div style={{
-                    maxWidth: '30%',
-                    backgroundColor: '#f8fafc',
-                    border: '1px solid #e2e8f0',
-                    borderRadius: '8px',
-                    padding: '8px',
-                    boxShadow: '0 1px 4px rgba(0, 0, 0, 0.05)'
-                  }}>
-                    <img
-                      src={`http://localhost:8080/images/chat/${msg.chatImageUrl}`}
-                      alt="업로드된 이미지"
-                      style={{
-                        width: '100%',
-                        maxHeight: '400px',
-                        objectFit: 'contain',
-                        borderRadius: '6px'
-                      }}
-                    />
-                  </div>
-                )
-                  : (
-                    <div style={{
-                      fontSize: '14px',
-                      lineHeight: '1.5',
-                      color: '#4a5568',
-                      wordBreak: 'break-word',
-                      whiteSpace: 'pre-wrap'
-                    }}>
-                      {msg.content}
-                      {(msg.edited || msg.isEdited) && (
-                        <span style={{
-                          marginLeft: '6px',
-                          fontSize: '11px',
-                          color: '#a0aec0',
-                          fontStyle: 'italic'
-                        }}>
-                          (수정됨)
-                        </span>
-                      )}
-                    </div>
-                  )}
-          </div>
+          )}
         </div>
-  )
+        <MessageContent
+          msg={msg}
+          editMessageId={editMessageId}
+          editContent={editContent}
+          setEditContent={setEditContent}
+          handleEditMessage={handleEditMessage}
+          setEditMessageId={setEditMessageId}
+        />
+      </div>
+    </div>
+  );
+};
 
-}
+const MessageContent = ({msg, editMessageId, editContent, setEditContent, handleEditMessage, setEditMessageId}) => {
 
+  // 수정 중인 메시지는 textarea 렌더
+  if(editMessageId === msg.messageId) {
+    return (
+      <div style={{ display: 'flex', gap: '8px', flexDirection: 'column' }}>
+        <textarea
+          value={editContent}
+          onChange={(e) => setEditContent(e.target.value)}
+          style={{
+            width: '100%',
+            minHeight: '80px',
+            border: '1px solid #e2e8f0',
+            borderRadius: '6px',
+            padding: '10px',
+            fontSize: '14px',
+            resize: 'vertical'
+          }}
+        />
+        <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '10px' }}>
+          <button
+            onClick={() => handleEditMessage(msg.messageId)}
+            style={{
+              backgroundColor: '#4a6cf7',
+              color: 'white',
+              border: 'none',
+              borderRadius: '4px',
+              padding: '6px 12px',
+              fontSize: '14px',
+              cursor: 'pointer'
+            }}
+          >
+            저장
+          </button>
+          <button
+            onClick={() => {
+              setEditMessageId(null);
+              setEditContent('');
+            }}
+            style={{
+              backgroundColor: '#e2e8f0',
+              color: '#1a202c',
+              border: 'none',
+              borderRadius: '4px',
+              padding: '6px 12px',
+              fontSize: '14px',
+              cursor: 'pointer'
+            }}
+          >
+            취소
+          </button>
+        </div>
+      </div>
+    );
+  }
 
-const MessageList = ({ messages, currentUser, contextMenuId, setContextMenuId, setEditMessageId, setEditContent, handleEditMessage, handleDeleteMessage }) => {
-      if (!messages.length) return null;
+  if (msg.deleted) {
+    return <div style={{
+      fontSize: '14px',
+      lineHeight: '1.5',
+      color: '#a0aec0',
+      fontStyle: 'italic'
+    }}>
+      삭제된 메시지입니다.
+    </div>;
+  }
 
-    const result = [];
-    let currentDate = null;
-
-    // 메시지를 순회하며 날짜별로 구분
-    messages.forEach((msg, index) => {
-      const messageDate = formatDate(msg.sendAt);
-
-      // 날짜가 바뀌었다면 구분선 추가
-      if (messageDate !== currentDate) {
-        currentDate = messageDate;
-        result.push(
-          <div key={`date-${index}`}
-            style={{ display: 'flex',
-                alignItems: 'center',
-                margin: '24px 0',
-                color: '#64748b',
-                fontSize: '14px',
-                fontWeight: '500'
-          }}>
-            <div style={{
-              flex: '1',
-              height: '1px',
-              backgroundColor: '#e2e8f0'
-            }} />
-            <div style={{
-              margin: '0 16px',
-              padding: '4px 12px',
-              backgroundColor: '#f8fafc',
-              borderRadius: '12px',
-              border: '1px solid #e2e8f0'
-            }}>
-              {messageDate}
+  if(msg.type === 'GIT'){
+    return (
+      <div style={{
+        backgroundColor: '#f6f8fa',
+        borderRadius: '6px',
+        color: '#24292e',
+        display: 'flex'
+      }}>
+        {/* 왼쪽 검정색 선 */}
+        <div style={{
+          width: '6px',
+          backgroundColor: '#000',
+          marginRight: '10px',
+          borderRadius: '2px'
+        }} />
+        <div style={{ whiteSpace: 'pre-wrap', lineHeight: '1.5', padding: '10px' }}>
+          {msg.content.split('\n').map((line, i) => (
+             <div key={i}>
+              {i === 0 ? (
+                <strong>{line}</strong>
+              ) : (
+                <>{renderWithLink(line)}</>
+              )}
             </div>
-            <div style={{
-              flex: '1',
-              height: '1px',
-              backgroundColor: '#e2e8f0'
-            }}/>
-          </div>
-        );
-      }
+          ))}
+        </div>
+      </div>
+    );
+  }
 
-      // 메시지 추가
-      result.push(
-        <div key={`msg-${index}`} style={{
-          marginBottom: '18px',
-          display: 'flex',
-          alignItems: 'flex-start',
-        }}>
-          {/* 프로필 이미지 */}
-          <div style={{
-            width: '38px',
-            height: '38px',
-            borderRadius: '50%',
-            marginRight: '12px',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            color: 'white',
-            fontWeight: '600',
-            fontSize: '16px',
-            flexShrink: 0,
-            backgroundImage: `url("http://localhost:8080/images/profile/${msg.profileImageUrl}")`,
-            backgroundSize: 'cover'
+  if(msg.type === 'CODE') {
+    return (
+      <div style={{
+        borderRadius: '6px',
+        overflow: 'hidden',
+        border: '1px solid #e2e8f0'
+      }}>
+        <HighlightedCode
+          content={msg.content}
+          language={msg.language || 'java'} //java가 디폴트 언어
+        />
+        {msg.edited && (
+          <span style={{
+            marginLeft: '6px',
+            fontSize: '11px',
+            color: '#a0aec0',
+            fontStyle: 'italic'
           }}>
-          </div>
-          <div style={{ flex: 1, maxWidth: 'calc(100% - 50px)' }}>
-            <div style={{
-              display: 'flex',
-              marginBottom: '6px',
-              justifyContent: 'space-between',
-            }}>
-              <div style={{ display: 'flex', alignItems: 'baseline' }}>
-                <span style={{
-                  fontWeight: '600',
-                  fontSize: '15px',
-                  color: '#2d3748'
-                }}>
-                  {msg.senderName}
-                </span>
-                <span style={{
-                  fontWeight: 'normal',
-                  fontSize: '12px',
-                  color: '#718096',
-                  marginLeft: '8px'
-                }}>
-                  {new Date(msg.sendAt).toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit' })}
-                </span>
-              </div>
+            (수정됨)
+          </span>
+        )}
+      </div>
+    );
+  }
 
+  if(msg.type === 'IMAGE'){
+     return (
+      <div style={{
+        maxWidth: '30%',
+        backgroundColor: '#f8fafc',
+        border: '1px solid #e2e8f0',
+        borderRadius: '8px',
+        padding: '8px',
+        boxShadow: '0 1px 4px rgba(0, 0, 0, 0.05)'
+      }}>
+        <img
+          src={`http://localhost:8080/images/chat/${msg.chatImageUrl}`}
+          alt="업로드된 이미지"
+          style={{
+            width: '100%',
+            maxHeight: '400px',
+            objectFit: 'contain',
+            borderRadius: '6px'
+          }}
+        />
+      </div>
+    )
+  }
+
+  return (
+    <div style={{
+      fontSize: '14px',
+      lineHeight: '1.5',
+      color: '#4a5568',
+      wordBreak: 'break-word',
+      whiteSpace: 'pre-wrap'
+    }}>
+      {msg.content}
+      {(msg.edited) && (
+        <span style={{
+          marginLeft: '6px',
+          fontSize: '11px',
+          color: '#a0aec0',
+          fontStyle: 'italic'
+        }}>
+          (수정됨)
+        </span>
+      )}
+    </div>
+  )
 }
+
+const MessageList = ({ messages, currentUser, contextMenuId, setContextMenuId, setEditMessageId, setEditContent, editMessageId, editContent, handleEditMessage, handleDeleteMessage }) => {
+  if (!messages.length) return null;
+  const result = [];
+  let currentDate = null;
+
+  // 메시지를 순회하며 날짜별로 구분
+  messages.forEach((msg, index) => {
+    const messageDate = formatDate(msg.sendAt);
+
+    // 날짜가 바뀌었다면 구분선 추가
+    if (messageDate !== currentDate) {
+      currentDate = messageDate;
+      result.push(
+        <div key={`date-${index}`}
+          style={{ display: 'flex',
+              alignItems: 'center',
+              margin: '24px 0',
+              color: '#64748b',
+              fontSize: '14px',
+              fontWeight: '500'
+        }}>
+          <div style={{
+            flex: '1',
+            height: '1px',
+            backgroundColor: '#e2e8f0'
+          }} />
+          <div style={{
+            margin: '0 16px',
+            padding: '4px 12px',
+            backgroundColor: '#f8fafc',
+            borderRadius: '12px',
+            border: '1px solid #e2e8f0'
+          }}>
+            {messageDate}
+          </div>
+          <div style={{
+            flex: '1',
+            height: '1px',
+            backgroundColor: '#e2e8f0'
+          }}/>
+        </div>
+      );
+    }
+
+    // 메시지 추가
+    result.push(
+      <MessageItem
+      key={`msg-${index}`}
+      msg={msg}
+      currentUser={currentUser}
+      contextMenuId={contextMenuId}
+      setContextMenuId={setContextMenuId}
+      setEditMessageId={setEditMessageId}
+      setEditContent={setEditContent}
+      handleDeleteMessage={handleDeleteMessage}
+      editMessageId={editMessageId}
+      editContent={editContent}
+      handleEditMessage={handleEditMessage}
+      />
+    );
+  });
+  return <>{result}</>
+};
+
+export default MessageList;
+  

--- a/frontend/src/components/chatroom/MessageList.jsx
+++ b/frontend/src/components/chatroom/MessageList.jsx
@@ -1,10 +1,24 @@
 import React from 'react';
 import Highlight from 'react-highlight';
+import { FaCopy, FaTrashAlt, FaUserPlus, FaClock } from 'react-icons/fa';
 
+ // 날짜를 YYYY-MM-DD 형식으로 변환하는 함수 (수정됨)
 const formatDate = (dateString) => {
   const date = new Date(dateString);
   return date.toLocaleDateString('ko-KR', {
-      year: 'numeric', month: '2-digit', day: '2-digit'
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit'
+  });
+};
+
+// 시간을 HH:MM 형식으로 변환하는 함수 (수정됨)
+const formatTime = (dateString) => {
+  const date = new Date(dateString);
+  return date.toLocaleTimeString('ko-KR', {
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: true  // 오전/오후 표시 활성화
   });
 };
 
@@ -36,8 +50,24 @@ const HighlightedCode = ({ content, language }) => {
 //프로필 이미지, 날짜, 수정 삭제 메뉴
 const MessageItem = ({ msg, currentUser, contextMenuId, setContextMenuId, setEditMessageId, setEditContent, handleEditMessage, handleDeleteMessage, editMessageId, editContent }) => {
 
+  //이벤트 타입은 메세지만 렌더링
+  if(msg.type === 'EVENT'){
+    return(
+      <MessageContent
+        msg={msg}
+        editMessageId={editMessageId}
+        editContent={editContent}
+        setEditContent={setEditContent}
+        handleEditMessage={handleEditMessage}
+        setEditMessageId={setEditMessageId}
+      />
+    )
+  }
+
   return (
-    <div style={{ marginBottom: '18px', display: 'flex', alignItems: 'flex-start' }}>
+    <div
+      id= {`message-${msg.messageId}`} // 추가
+      style={{ marginBottom: '18px', display: 'flex', alignItems: 'flex-start' }}>
       {/* 프로필 이미지 */}
       <div style={{
         width: '38px',
@@ -327,6 +357,54 @@ const MessageContent = ({msg, editMessageId, editContent, setEditContent, handle
     )
   }
 
+  if (msg.type === 'EVENT') {
+    return (
+      <div style={{
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        margin: '12px 0', // 상하 마진 줄임
+        padding: '0 16px'
+      }}>
+        <div style={{
+          backgroundColor: '#f0f9ff',
+          borderRadius: '16px',
+          padding: '8px 16px', // 패딩 줄임
+          display: 'flex',
+          alignItems: 'center', // 가로 정렬로 변경
+          gap: '8px',
+          color: '#0369a1',
+          fontSize: '13px',
+          fontWeight: '500',
+          boxShadow: '0 1px 2px rgba(0, 0, 0, 0.05)',
+          border: '1px solid #e0f2fe',
+          maxWidth: '80%'
+        }}>
+          {/* 유저 아이콘 */}
+          <FaUserPlus size={12} style={{ flexShrink: 0 }} />
+          
+          {/* 메인 메시지 */}
+          <span>{msg.content}</span>
+          
+          {/* 입장 시간 표시 (구분선과 함께) */}
+          <div style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '4px',
+            fontSize: '12px',
+            color: '#60a5fa',
+            borderLeft: '1px solid #bfdbfe',
+            paddingLeft: '8px',
+            marginLeft: '4px'
+          }}>
+            <FaClock size={10} />
+            {formatTime(msg.sendAt||msg.joinAt)}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div style={{
       fontSize: '14px',
@@ -357,7 +435,7 @@ const MessageList = ({ messages, currentUser, contextMenuId, setContextMenuId, s
 
   // 메시지를 순회하며 날짜별로 구분
   messages.forEach((msg, index) => {
-    const messageDate = formatDate(msg.sendAt);
+    const messageDate = formatDate(msg.sendAt||msg.joinAt);
 
     // 날짜가 바뀌었다면 구분선 추가
     if (messageDate !== currentDate) {

--- a/frontend/src/components/chatroom/RoomHeader.jsx
+++ b/frontend/src/components/chatroom/RoomHeader.jsx
@@ -1,0 +1,226 @@
+import React, { useState } from 'react';
+import { FaCopy } from 'react-icons/fa';
+import { useNavigate } from 'react-router-dom';
+
+const RoomHeader= ({roomName, inviteCode, onSearch, onLeaveRoom}) => {
+
+    const navigate = useNavigate();  
+    const [showNotification, setShowModal] = useState(false);
+    const [showLeaveConfirm, setShowLeaveConfirm] = useState(false);
+    const [showLeaveSuccess, setShowLeaveSuccess] = useState(false);
+    const [menuOpen, setMenuOpen] = useState(false); 
+
+    //채팅방 나가기 핸들러 (API는 chatRoom에서 호출)
+    const handleLeave = async () => {
+        const result = await onLeaveRoom(); // ChatRoom에서 props로 전달
+
+        if (result.success) {
+            setShowLeaveConfirm(false);
+            setShowLeaveSuccess(true);
+            setTimeout(() => {
+                setShowLeaveSuccess(false);
+                navigate('/');
+            }, 500);
+        } else {
+            alert(result.error);
+        }
+    };
+
+    //메세지 검색 핸들러 (API는 ChatRoom에서 호출)
+    const handleSearch = (keyword) => {
+        if (onSearch && typeof onSearch === 'function') {
+            onSearch(keyword); // ChatRoom에서 전달받은 검색 로직 실행
+        }
+    };
+
+    //초대 코드 복사
+    const handleCopy = async () => {
+        try {
+        await navigator.clipboard.writeText(inviteCode); // 백엔드 없이 바로 복사
+        setShowModal(true);
+        setTimeout(() => setShowModal(false), 2000);
+        } catch (err) {
+        console.error(err);
+        alert('초대 코드 복사 중 오류가 발생했습니다.');
+        }
+    };
+
+    return (
+        <div style={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            padding: '6px 20px',
+            borderBottom: '1px solid #eaedf0',
+            backgroundColor: '#fff'
+          }}>
+            <div style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '12px',
+              position: 'relative'
+            }}>
+              <span style={{
+                fontWeight: '600',
+                fontSize: '18px',
+                color: '#2d3748'
+              }}>
+                {roomName}
+              </span>
+
+              {/* 초대 코드 복사 버튼 */}
+              <button
+                onClick={handleCopy}
+                style={{
+                  backgroundColor: '#2588F1',
+                  color: 'white',
+                  border: 'none',
+                  borderRadius: '4px',
+                  padding: '6px 12px',
+                  fontSize: '13px',
+                  fontWeight: '500',
+                  cursor: 'pointer',
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '6px'
+                }}
+              >
+                <FaCopy size={14} />
+                초대 코드 복사
+              </button>
+
+              <button
+                onClick={() => setMenuOpen(prev => !prev)}
+                style={{
+                  fontSize: '25px',
+                  background: 'none',
+                  border: 'none',
+                  cursor: 'pointer',
+                  color: '#94a3b8',    
+              }}
+              >
+                ⋮
+              </button>
+
+              {/* 드롭다운 메뉴 */}
+              {menuOpen && (
+                <div style={{
+                  position: 'absolute',
+                  top: '0',
+                  left: '100%',
+                  marginLeft: '8px',  
+                  backgroundColor: 'white',  
+                  border: '1px solid #ccc',
+                  borderRadius: '6px',
+                  boxShadow: '0 2px 8px rgba(0,0,0,0.1)',
+                  zIndex: 1000,
+                  minWidth: '100px' 
+                }}>
+                  <button
+                    onClick={() => setShowLeaveConfirm(true)}
+                    style={{
+                      padding: '10px 16px',
+                      background: 'none',
+                      border: 'none',
+                      width: '100%',
+                      textAlign: 'left',
+                      cursor: 'pointer',
+                      fontSize: '14px',
+                      color: '#e53e3e',
+                      whiteSpace: 'nowrap',
+                      display: 'flex'
+                    }}
+                  >
+                    채팅방 나가기
+                  </button>
+                </div>
+              )}
+            </div>
+
+            <div>
+              <input
+                type="text"
+                placeholder="메시지 검색"
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    handleSearch(e.target.value);
+                  }
+                }}
+                style={{
+                  width: '220px',
+                  backgroundColor: '#f9fafc',
+                  fontSize: '14px'
+                }}
+              />
+            </div>
+
+            {/* 초대 코드 복사 완료 알림 */}
+            {showNotification && (
+            <div style={{
+              position: 'fixed',
+              top: '15px',
+              right: '15px',
+              backgroundColor: '#333',
+              color: '#fff',
+              padding: '10px 16px',
+              borderRadius: '6px',
+              boxShadow: '0 4px 8px rgba(0, 0, 0, 0.2)',
+              zIndex: 1000
+            }}>
+              초대 코드가 복사되었습니다.
+            </div>
+          )}
+
+            {/* 나가기 확인 모달 */}
+            {showLeaveConfirm && (
+            <div style={{
+              position: 'fixed', top: 0, left: 0, width: '100vw', height: '100vh',
+              backgroundColor: 'rgba(0, 0, 0, 0.4)', display: 'flex',
+              alignItems: 'center', justifyContent: 'center', zIndex: 2000
+            }}>
+              <div style={{
+                backgroundColor: 'white', padding: '24px', borderRadius: '8px',
+                minWidth: '280px', textAlign: 'center', boxShadow: '0 4px 12px rgba(0,0,0,0.2)'
+              }}>
+                <p style={{ fontSize: '16px', marginBottom: '20px' }}>
+                  정말 이 채팅방을 나가시겠습니까?
+                </p>
+                <div style={{ display: 'flex', justifyContent: 'center', gap: '12px' }}>
+                  <button
+                    onClick={() => setShowLeaveConfirm(false)}
+                    style={{
+                      padding: '8px 16px', backgroundColor: '#eee',
+                      border: 'none', borderRadius: '4px', cursor: 'pointer'
+                    }}
+                  >
+                    취소
+                  </button>
+                  <button
+                    onClick={handleLeave}
+                    style={{
+                      padding: '8px 16px', backgroundColor: '#e53e3e', color: 'white',
+                      border: 'none', borderRadius: '4px', cursor: 'pointer'
+                    }}
+                  >
+                    나가기
+                  </button>
+                </div>
+              </div>
+            </div>)}
+
+            {/* 나가기 완료 모달 */}
+            {showLeaveSuccess && (
+                <div style={{
+                position: 'fixed', top: '20px', right: '20px',
+                backgroundColor: '#333', color: 'white',
+                padding: '12px 20px', borderRadius: '6px',
+                boxShadow: '0 4px 8px rgba(0,0,0,0.2)', zIndex: 2000
+                }}>
+                채팅방에서 나갔습니다.
+                </div>
+            )}
+          </div>
+    )
+}
+
+export default RoomHeader;

--- a/frontend/src/components/common/useWebSocket.jsx
+++ b/frontend/src/components/common/useWebSocket.jsx
@@ -103,7 +103,7 @@ const useWebSocket = ({
                 });
             }
         };
-        }, [roomId, navigate]);
+    }, [roomId]);
 
     return stompClientRef;
 };

--- a/frontend/src/components/common/useWebSocket.jsx
+++ b/frontend/src/components/common/useWebSocket.jsx
@@ -1,0 +1,112 @@
+import { useEffect, useRef } from "react";
+import SockJS from 'sockjs-client';
+import { Client } from '@stomp/stompjs';
+import { useNavigate } from 'react-router-dom';
+
+const useWebSocket = ({
+    roomId,
+    onMessageReceived,
+}) => {
+    const stompClientRef = useRef(null);
+    const subscriptionRef = useRef(null);
+    const hasConnectedRef = useRef(false); // 실제 연결에 성공했는지 추적
+    const keepAliveIntervalRef = useRef(null);
+
+    const navigate = useNavigate(); 
+
+    useEffect(() => {
+        const client = new Client({
+            webSocketFactory: () => new SockJS('http://localhost:8080/ws'),
+            reconnectDelay: 1000,
+            heartbeatIncoming: 15000,
+            heartbeatOutgoing: 10000,
+            debug: (str) => console.log(`[STOMP] ${str}`),
+
+            onConnect: () => {
+            console.log('✅ Connected to WebSocket');
+            hasConnectedRef.current = true;
+
+            if (subscriptionRef.current) {
+                subscriptionRef.current.unsubscribe();
+                console.log("🔁 Previous subscription cleared.");
+            }
+
+            subscriptionRef.current = client.subscribe(`/topic/chat/${roomId}`, (message) => {
+                try {
+                    const received = JSON.parse(message.body);
+                    // received.sendAt ||= new Date().toISOString();
+                    
+                    // isEdited와 isDeleted 속성을 편집 및 삭제 상태로 변환
+                    // if (received.isEdited !== undefined) received.edited = received.isEdited;
+                    // if (received.isDeleted !== undefined) received.deleted = received.isDeleted;
+                    onMessageReceived(received)
+                } catch (e) {
+                console.error("📛 Failed to parse incoming message", e);
+                }
+            });
+
+            if (keepAliveIntervalRef.current) clearInterval(keepAliveIntervalRef.current);
+
+            keepAliveIntervalRef.current = setInterval(() => {
+                if (client && client.connected) {
+                client.publish({
+                    destination: '/app/ping',
+                    body: 'ping'
+                });
+                console.log("📡 Sent keep-alive ping");
+                }
+            }, 20000);
+            },
+
+            onWebSocketClose: async () => {
+                try {
+                    const res = await fetch('http://localhost:8080/auth', {
+                    credentials: "include"
+                    });
+
+                    if (res.status === 401) {
+                    console.warn("세션 만료 → 로그인 페이지로 이동");
+                    window.location.href = '/login';
+                }
+            } catch (err) {
+                console.warn("네트워크 오류 → 로그인 페이지로 이동", err);
+                window.location.href = '/login';
+            }
+            },
+
+            onStompError: (frame) => {
+                console.error("💥 STOMP error:", frame.headers['message']);
+                if (frame.headers['message']?.includes('Unauthorized') || frame.body?.includes('expired')) {
+                    navigate("/login");
+                }
+            }
+        });
+
+        client.activate();
+        stompClientRef.current = client;
+
+        return () => {
+            console.log("🧹 Cleaning up WebSocket...");
+
+            if (keepAliveIntervalRef.current) {
+                clearInterval(keepAliveIntervalRef.current);
+                keepAliveIntervalRef.current = null;
+                console.log("🔕 Stopped keep-alive ping");
+            }
+            if (subscriptionRef.current) {
+                subscriptionRef.current.unsubscribe();
+                subscriptionRef.current = null;
+                console.log("🔌 Subscription unsubscribed.");
+            }
+            if (client && client.active) {
+                client.deactivate().then(() => {
+                    console.log("🛑 Disconnected from WebSocket");
+                });
+            }
+        };
+        }, [roomId, navigate]);
+
+    return stompClientRef;
+};
+
+export default useWebSocket;

--- a/frontend/src/components/common/useWebSocket.jsx
+++ b/frontend/src/components/common/useWebSocket.jsx
@@ -35,10 +35,9 @@ const useWebSocket = ({
                 try {
                     const received = JSON.parse(message.body);
                     // received.sendAt ||= new Date().toISOString();
-                    
-                    // isEdited와 isDeleted 속성을 편집 및 삭제 상태로 변환
-                    // if (received.isEdited !== undefined) received.edited = received.isEdited;
-                    // if (received.isDeleted !== undefined) received.deleted = received.isDeleted;
+                    // sendAt → 없으면 joinAt → 없으면 현재 시간
+                    received.sendAt = received.sendAt || received.joinAt || new Date().toISOString();
+
                     onMessageReceived(received)
                 } catch (e) {
                 console.error("📛 Failed to parse incoming message", e);

--- a/frontend/src/pages/BlankRoom.jsx
+++ b/frontend/src/pages/BlankRoom.jsx
@@ -55,11 +55,9 @@ const BlankRoom = () => {
       alert(err.response?.data?.message || err.message || "방 입장에 실패했습니다.");
       throw err;
     }
-  };
-  
+  };  
   // 버튼 스타일 공통화
   const buttonStyle = {
-    backgroundColor: '#4a6cf7',
     color: 'white',
     border: 'none',
     borderRadius: '4px',
@@ -68,11 +66,9 @@ const BlankRoom = () => {
     fontSize: '14px',
     fontWeight: '500',
     cursor: 'pointer',
-    transition: 'background-color 0.2s',
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
-    boxShadow: '0 2px 4px rgba(0, 0, 0, 0.1)'
   };
 
   return (

--- a/frontend/src/pages/ChatRoom.jsx
+++ b/frontend/src/pages/ChatRoom.jsx
@@ -1,6 +1,4 @@
 import React, { useEffect, useState, useRef } from 'react';
-import SockJS from 'sockjs-client';
-import { Client } from '@stomp/stompjs';
 import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import Sidebar from '../components/SideBar';
 import Header from '../components/header';
@@ -9,6 +7,7 @@ import { FaCopy, FaTrashAlt } from 'react-icons/fa';
 import axiosInstance from '../components/api/axiosInstance';
 import MessageInput from '../components/chatroom/MessageInput';
 import MessageList from '../components/chatroom/MessageList';
+import useWebSocket from '../components/common/useWebSocket';
 const ChatRoom = () => {
 
   const { roomId, inviteCode } = useParams();
@@ -28,7 +27,6 @@ const ChatRoom = () => {
 
   const [contextMenuVisible, setContextMenuVisible] = useState(false);
   const [contextMenuPosition, setContextMenuPosition] = useState({ x: 0, y: 0 });
-
 
   const [showNotification, setShowModal] = useState(false);
   const [showUrlCopiedModal, setShowUrlCopiedModal] = useState(false);
@@ -90,7 +88,6 @@ const ChatRoom = () => {
       setMenuOpen(false);
     }
   };
-
 
   useEffect(() => {
     if (joinedOnceRef.current) return;   // 이미 한 번 호출됐다면 스킵
@@ -180,14 +177,71 @@ const ChatRoom = () => {
   const [errorMessage, setErrorMessage] = useState(null);
 
 
+  //웹소켓 연결
+  const stompClientRef = useWebSocket({
+    roomId,
+    onMessageReceived: (received)=> {
+      //메세지 상태 업데이트
+      setMessages(prev =>
+        prev.some(m => m.messageId === received.messageId)
+        ? prev.map(m => m.messageId === received.messageId ? received : m)
+        : [...prev, received]
+      );
+    }
+  });
+
   const scrollToBottom = () => {
     messagesEndRef.current?.scrollIntoView({ behavior: "instant" });
   };
 
-  const stompClientRef = useRef(null);
-  const subscriptionRef = useRef(null);
-  const hasConnectedRef = useRef(false); // 실제 연결에 성공했는지 추적
-  const keepAliveIntervalRef = useRef(null); // 추가
+  // 메시지 초기화
+  const fetchMessages = async () => {
+    try {
+      const res = await axiosInstance.get(`/${roomId}/messages`);
+      const data = res.data;
+
+      const validatedData = data.map(msg => {
+        // 날짜 유효성 검사
+        if (!msg.sendAt || new Date(msg.sendAt).getFullYear() === 1970) {
+          msg = { ...msg, sendAt: new Date().toISOString() };
+        }
+
+        // isEdited와 isDeleted 속성이 undefined이면 기본값 설정
+        if (msg.edited === undefined) msg.edited = !!msg.isEdited;
+        if (msg.deleted === undefined) msg.deleted = !!msg.isDeleted;
+
+        return msg;
+      });
+
+      const sortedData = validatedData.sort(
+          (a, b) => new Date(a.sendAt).getTime() - new Date(b.sendAt).getTime()
+      );
+
+      setMessages(sortedData);
+    } catch (error) {
+      console.error('Error fetching messages:', error);
+    }
+  };
+
+  // 로그인 유저 정보 가져오기
+  const fetchCurrentUser = async () => {
+    try {
+      const res = await fetch('http://localhost:8080/user/details', {
+        method: 'GET',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+      });
+
+      if (!res.ok) {
+        throw new Error('로그인 정보를 가져오지 못했습니다.');
+      }
+
+      const user = await res.json(); // { id, email, nickname, profileImg }
+      setCurrentUser(user);
+    } catch (error) {
+      console.error('사용자 정보 요청 실패:', error);
+    }
+  };
 
   useEffect(() => {
     if (!roomId) {
@@ -198,156 +252,11 @@ const ChatRoom = () => {
 
     setMessages([]); // 이전 채팅방 메세지 제거
 
-    // 로그인 유저 정보 가져오기
-    const fetchCurrentUser = async () => {
-      try {
-        const res = await fetch('http://localhost:8080/user/details', {
-          method: 'GET',
-          headers: { 'Content-Type': 'application/json' },
-          credentials: 'include',
-        });
-
-        if (!res.ok) {
-          throw new Error('로그인 정보를 가져오지 못했습니다.');
-        }
-
-        const user = await res.json(); // { id, email, nickname, profileImg }
-        setCurrentUser(user);
-      } catch (error) {
-        console.error('사용자 정보 요청 실패:', error);
-      }
-    };
-
     fetchCurrentUser();
     fetchRoomInfo(); // 방 정보 가져오기 함수 호출 추가
-
-    // 메시지 초기화
-    const fetchMessages = async () => {
-      try {
-        const res = await axiosInstance.get(`/${roomId}/messages`);
-        const data = res.data;
-
-        const validatedData = data.map(msg => {
-          // 날짜 유효성 검사
-          if (!msg.sendAt || new Date(msg.sendAt).getFullYear() === 1970) {
-            msg = { ...msg, sendAt: new Date().toISOString() };
-          }
-
-          // isEdited와 isDeleted 속성이 undefined이면 기본값 설정
-          if (msg.edited === undefined) msg.edited = !!msg.isEdited;
-          if (msg.deleted === undefined) msg.deleted = !!msg.isDeleted;
-
-          return msg;
-        });
-
-        const sortedData = validatedData.sort(
-            (a, b) => new Date(a.sendAt).getTime() - new Date(b.sendAt).getTime()
-        );
-
-        setMessages(sortedData);
-      } catch (error) {
-        console.error('Error fetching messages:', error);
-      }
-    };
-
     fetchMessages();
 
-    // WebSocket 연결 설정
-    const client = new Client({
-      webSocketFactory: () => new SockJS('http://localhost:8080/ws'),
-      reconnectDelay: 1000,
-      heartbeatIncoming: 15000,
-      heartbeatOutgoing: 10000,
-      debug: (str) => console.log(`[STOMP] ${str}`),
-
-      onConnect: () => {
-        console.log('✅ Connected to WebSocket');
-        hasConnectedRef.current = true;
-
-        if (subscriptionRef.current) {
-          subscriptionRef.current.unsubscribe();
-          console.log("🔁 Previous subscription cleared.");
-        }
-
-        subscriptionRef.current = client.subscribe(`/topic/chat/${roomId}`, (message) => {
-          try {
-            const received = JSON.parse(message.body);
-            received.sendAt ||= new Date().toISOString();
-            
-            // isEdited와 isDeleted 속성을 편집 및 삭제 상태로 변환
-            if (received.isEdited !== undefined) received.edited = received.isEdited;
-            if (received.isDeleted !== undefined) received.deleted = received.isDeleted;
-            
-            setMessages(prev =>
-              prev.some(m => m.messageId === received.messageId)
-                ? prev.map(m => m.messageId === received.messageId ? received : m)
-                : [...prev, received]
-            );
-          } catch (e) {
-            console.error("📛 Failed to parse incoming message", e);
-          }
-        });
-
-        if (keepAliveIntervalRef.current) clearInterval(keepAliveIntervalRef.current);
-
-        keepAliveIntervalRef.current = setInterval(() => {
-          if (client && client.connected) {
-            client.publish({
-              destination: '/app/ping',
-              body: 'ping'
-            });
-            console.log("📡 Sent keep-alive ping");
-          }
-        }, 20000);
-      },
-
-      onWebSocketClose: async () => {
-        try {
-          const res = await fetch('http://localhost:8080/auth', {
-            credentials: "include"
-          });
-
-          if (res.status === 401) {
-            console.warn("세션 만료 → 로그인 페이지로 이동");
-            window.location.href = '/login';
-          }
-        } catch (err) {
-          console.warn("네트워크 오류 → 로그인 페이지로 이동", err);
-          window.location.href = '/login';
-        }
-      },
-
-      onStompError: (frame) => {
-        console.error("💥 STOMP error:", frame.headers['message']);
-        if (frame.headers['message']?.includes('Unauthorized') || frame.body?.includes('expired')) {
-          navigate("/login");
-        }
-      }
-    });
-
-    client.activate();
-    stompClientRef.current = client;
-
-    return () => {
-      console.log("🧹 Cleaning up WebSocket...");
-
-      if (keepAliveIntervalRef.current) {
-        clearInterval(keepAliveIntervalRef.current);
-        keepAliveIntervalRef.current = null;
-        console.log("🔕 Stopped keep-alive ping");
-      }
-      if (subscriptionRef.current) {
-        subscriptionRef.current.unsubscribe();
-        subscriptionRef.current = null;
-        console.log("🔌 Subscription unsubscribed.");
-      }
-      if (client && client.active) {
-        client.deactivate().then(() => {
-          console.log("🛑 Disconnected from WebSocket");
-        });
-      }
-    };
-  }, [roomId, navigate]);
+  },[roomId]);
 
   // 메시지가 업데이트될 때마다 아래로 스크롤
   useEffect(() => {
@@ -430,39 +339,9 @@ const ChatRoom = () => {
     }
   };
 
-
-  // 날짜를 YYYY-MM-DD 형식으로 변환하는 함수 (수정됨)
-  // const formatDate = (dateString) => {
-  //   try {
-  //     const date = new Date(dateString);
-
-  //     // 유효한 날짜인지 확인 (1970년은 유효하지 않은 것으로 간주)
-  //     if (isNaN(date.getTime()) || date.getFullYear() === 1970) {
-  //       return new Date().toLocaleDateString('ko-KR', {
-  //         year: 'numeric',
-  //         month: '2-digit',
-  //         day: '2-digit'
-  //       });
-  //     }
-
-  //     return date.toLocaleDateString('ko-KR', {
-  //       year: 'numeric',
-  //       month: '2-digit',
-  //       day: '2-digit'
-  //     });
-  //   } catch (error) {
-  //     console.error('날짜 형식 변환 오류:', error);
-  //     return new Date().toLocaleDateString('ko-KR', {
-  //       year: 'numeric',
-  //       month: '2-digit',
-  //       day: '2-digit'
-  //     });
-  //   }
-  // };
-
   const [imageFile, setImageFile] = useState(null);
   const [imagePreviewUrl, setImagePreviewUrl] = useState(null);
-  const fileInputRef = useRef(null);
+  // const fileInputRef = useRef(null);
 
   // 전송 버튼 클릭 시 호출되는 공통 핸들러 함수 (이미지 업로드 고려)
   const handleUnifiedSend = async () => {
@@ -497,17 +376,6 @@ const ChatRoom = () => {
     } else {
       sendMessage();
     }
-  };
-
-  // 입력 필드 스타일 공통화
-  const inputStyle = {
-    fontSize: '14px',
-    padding: '10px 14px',
-    border: '1px solid #e0e4e8',
-    borderRadius: '4px',
-    outline: 'none',
-    transition: 'border-color 0.2s',
-    boxShadow: 'inset 0 1px 2px rgba(0,0,0,0.05)'
   };
 
   const handleEditMessage = (messageId) => {
@@ -633,7 +501,6 @@ const ChatRoom = () => {
                   }
                 }}
                 style={{
-                  ...inputStyle,
                   width: '220px',
                   backgroundColor: '#f9fafc',
                   fontSize: '14px'

--- a/frontend/src/pages/ChatRoom.jsx
+++ b/frontend/src/pages/ChatRoom.jsx
@@ -192,32 +192,23 @@ const ChatRoom = () => {
     );
   };
 
-  const renderWithLink = (text) => {
-    const urlRegex = /(https?:\/\/[^\s]+)/g;
-    return text.split(urlRegex).map((part, i) =>
-      urlRegex.test(part) ? (
-        <a
-          key={i}
-          href={part}
-          target="_blank"
-          rel="noopener noreferrer"
-          style={{ color: '#0366d6', textDecoration: 'underline' }}
-        >
-          {part}
-        </a>
-      ) : (
-        part
-      )
-    );
-  };
-
-  // const handleInputChange = (e) => {
-  //   const val = e.target.value;
-  //   setContent(val);
-  //   if (val.startsWith("```")) {
-  //     setInputMode("CODE");
-  //     setContent('');
-  //   }
+  // const renderWithLink = (text) => {
+  //   const urlRegex = /(https?:\/\/[^\s]+)/g;
+  //   return text.split(urlRegex).map((part, i) =>
+  //     urlRegex.test(part) ? (
+  //       <a
+  //         key={i}
+  //         href={part}
+  //         target="_blank"
+  //         rel="noopener noreferrer"
+  //         style={{ color: '#0366d6', textDecoration: 'underline' }}
+  //       >
+  //         {part}
+  //       </a>
+  //     ) : (
+  //       part
+  //     )
+  //   );
   // };
 
   const stompClientRef = useRef(null);
@@ -468,33 +459,33 @@ const ChatRoom = () => {
 
 
   // 날짜를 YYYY-MM-DD 형식으로 변환하는 함수 (수정됨)
-  const formatDate = (dateString) => {
-    try {
-      const date = new Date(dateString);
+  // const formatDate = (dateString) => {
+  //   try {
+  //     const date = new Date(dateString);
 
-      // 유효한 날짜인지 확인 (1970년은 유효하지 않은 것으로 간주)
-      if (isNaN(date.getTime()) || date.getFullYear() === 1970) {
-        return new Date().toLocaleDateString('ko-KR', {
-          year: 'numeric',
-          month: '2-digit',
-          day: '2-digit'
-        });
-      }
+  //     // 유효한 날짜인지 확인 (1970년은 유효하지 않은 것으로 간주)
+  //     if (isNaN(date.getTime()) || date.getFullYear() === 1970) {
+  //       return new Date().toLocaleDateString('ko-KR', {
+  //         year: 'numeric',
+  //         month: '2-digit',
+  //         day: '2-digit'
+  //       });
+  //     }
 
-      return date.toLocaleDateString('ko-KR', {
-        year: 'numeric',
-        month: '2-digit',
-        day: '2-digit'
-      });
-    } catch (error) {
-      console.error('날짜 형식 변환 오류:', error);
-      return new Date().toLocaleDateString('ko-KR', {
-        year: 'numeric',
-        month: '2-digit',
-        day: '2-digit'
-      });
-    }
-  };
+  //     return date.toLocaleDateString('ko-KR', {
+  //       year: 'numeric',
+  //       month: '2-digit',
+  //       day: '2-digit'
+  //     });
+  //   } catch (error) {
+  //     console.error('날짜 형식 변환 오류:', error);
+  //     return new Date().toLocaleDateString('ko-KR', {
+  //       year: 'numeric',
+  //       month: '2-digit',
+  //       day: '2-digit'
+  //     });
+  //   }
+  // };
 
   const [imageFile, setImageFile] = useState(null);
   const [imagePreviewUrl, setImagePreviewUrl] = useState(null);
@@ -533,24 +524,6 @@ const ChatRoom = () => {
     } else {
       sendMessage();
     }
-  };
-
-  // 버튼 스타일 공통화
-  const buttonStyle = {
-    backgroundColor: '#4a6cf7',
-    color: 'white',
-    border: 'none',
-    borderRadius: '4px',
-    padding: '0 20px',
-    height: '40px',
-    fontSize: '14px',
-    fontWeight: '500',
-    cursor: 'pointer',
-    transition: 'background-color 0.2s',
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    boxShadow: '0 2px 4px rgba(0, 0, 0, 0.1)'
   };
 
   // 입력 필드 스타일 공통화
@@ -649,299 +622,7 @@ const ChatRoom = () => {
 
       // 메시지 추가
       result.push(
-        <div key={`msg-${index}`} style={{
-          marginBottom: '18px',
-          display: 'flex',
-          alignItems: 'flex-start',
-        }}>
-          {/* 프로필 이미지 */}
-          <div style={{
-            width: '38px',
-            height: '38px',
-            borderRadius: '50%',
-            marginRight: '12px',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            color: 'white',
-            fontWeight: '600',
-            fontSize: '16px',
-            flexShrink: 0,
-            backgroundImage: `url("http://localhost:8080/images/profile/${msg.profileImageUrl}")`,
-            backgroundSize: 'cover'
-          }}>
-          </div>
-          <div style={{ flex: 1, maxWidth: 'calc(100% - 50px)' }}>
-            <div style={{
-              display: 'flex',
-              marginBottom: '6px',
-              justifyContent: 'space-between',
-            }}>
-              <div style={{ display: 'flex', alignItems: 'baseline' }}>
-                <span style={{
-                  fontWeight: '600',
-                  fontSize: '15px',
-                  color: '#2d3748'
-                }}>
-                  {msg.senderName}
-                </span>
-                <span style={{
-                  fontWeight: 'normal',
-                  fontSize: '12px',
-                  color: '#718096',
-                  marginLeft: '8px'
-                }}>
-                  {new Date(msg.sendAt).toLocaleTimeString('ko-KR', { hour: '2-digit', minute: '2-digit' })}
-                </span>
-              </div>
-
-              {/* 점 세개 메뉴는 조건부 렌더링 */}
-              {currentUser?.id === msg.senderId && !msg.deleted && msg.type !== 'GIT' && (
-                <div style={{ position: 'relative' }}>
-                  <button
-                    onClick={() =>
-                      setContextMenuId(contextMenuId === msg.messageId ? null : msg.messageId)
-                    }
-                    style={{
-                      position: 'absolute',
-                      right: '0px',
-                      border: 'none',
-                      background: 'transparent',
-                      cursor: 'pointer',
-                      fontSize: '18px',
-                      color: '#94a3b8'
-                    }}
-                  >
-                    ⋯
-                  </button>
-
-                  {contextMenuId === msg.messageId && (
-                    <div style={{
-                      position: 'absolute',
-                      top: '24px',
-                      right: '0',
-                      backgroundColor: '#fff',
-                      border: '1px solid #e2e8f0',
-                      borderRadius: '6px',
-                      boxShadow: '0 2px 6px rgba(0,0,0,0.15)',
-                      zIndex: 1000,
-                      padding: '6px 0',
-                      minWidth: '140px'
-                    }}>
-                      {/* 수정 버튼은 이미지 메시지가 아닌 경우에만 표시 */}
-                      {msg.type !== 'IMAGE' && (
-                        <>
-                          <button
-                            onClick={() => {
-                              setEditMessageId(msg.messageId);
-                              setEditContent(msg.content);
-                              setContextMenuId(null);
-                            }}
-                            style={{
-                              display: 'block',
-                              width: '100%',
-                              padding: '10px 16px',
-                              textAlign: 'left',
-                              background: 'none',
-                              border: 'none',
-                              fontSize: '14px',
-                              cursor: 'pointer'
-                            }}
-                          >
-                            메세지 수정하기
-                          </button>
-
-                          {/* 구분선 추가 */}
-                          <div style={{
-                            height: '1px',
-                            backgroundColor: '#e2e8f0',
-                            margin: '0 8px'
-                          }} />
-                        </>
-                      )}
-
-                      <button
-                        onClick={() => {
-                          const confirmed = window.confirm("정말 삭제하시겠습니까?");
-                          if (confirmed) {
-                            handleDeleteMessage(msg.messageId);
-                          }
-                          setContextMenuId(null);
-                        }}
-                        style={{
-                          display: 'block',
-                          width: '100%',
-                          padding: '10px 16px',
-                          textAlign: 'left',
-                          background: 'none',
-                          border: 'none',
-                          fontSize: '14px',
-                          color: '#e53e3e',
-                          cursor: 'pointer'
-                        }}
-                      >
-                        삭제
-                      </button>
-                    </div>
-                  )}
-                </div>
-              )}
-            </div>
-
-            {/* 본문 영역 - 수정 중인 메시지는 textarea, 나머지는 content 렌더 */}
-            {editMessageId === msg.messageId && msg.type !== 'GIT' ? (
-              <div style={{ display: 'flex', gap: '8px', flexDirection: 'column' }}>
-                <textarea
-                  value={editContent}
-                  onChange={(e) => setEditContent(e.target.value)}
-                  style={{
-                    width: '100%',
-                    minHeight: '80px',
-                    border: '1px solid #e2e8f0',
-                    borderRadius: '6px',
-                    padding: '10px',
-                    fontSize: '14px',
-                    resize: 'vertical'
-                  }}
-                />
-                <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '10px' }}>
-                  <button
-                    onClick={() => handleEditMessage(msg.messageId)}
-                    style={{
-                      backgroundColor: '#4a6cf7',
-                      color: 'white',
-                      border: 'none',
-                      borderRadius: '4px',
-                      padding: '6px 12px',
-                      fontSize: '14px',
-                      cursor: 'pointer'
-                    }}
-                  >
-                    저장
-                  </button>
-                  <button
-                    onClick={() => {
-                      setEditMessageId(null);
-                      setEditContent('');
-                    }}
-                    style={{
-                      backgroundColor: '#e2e8f0',
-                      color: '#1a202c',
-                      border: 'none',
-                      borderRadius: '4px',
-                      padding: '6px 12px',
-                      fontSize: '14px',
-                      cursor: 'pointer'
-                    }}
-                  >
-                    취소
-                  </button>
-                </div>
-              </div>
-            )
-              :(msg.deleted || msg.isDeleted) ? (
-                <div style={{
-                  fontSize: '14px',
-                  lineHeight: '1.5',
-                  color: '#a0aec0',
-                  fontStyle: 'italic'
-                }}>
-                  삭제된 메시지입니다.
-                </div>
-              )
-                : msg.type === 'GIT' ? (
-                  <div style={{
-                    backgroundColor: '#f6f8fa',
-                    borderRadius: '6px',
-                    color: '#24292e',
-                    display: 'flex'
-                  }}>
-                    {/* 왼쪽 검정색 선 */}
-                    <div style={{
-                      width: '6px',
-                      backgroundColor: '#000',
-                      marginRight: '10px',
-                      borderRadius: '2px'
-                    }} />
-                    {msg.content && (
-                      <div style={{ whiteSpace: 'pre-wrap', lineHeight: '1.5', padding: '10px' }}>
-                        {msg.content.split('\n').map((line, i) => (
-                          <div key={i}>
-                            {i === 0 ? (
-                              <strong>{renderWithLink(line)}</strong>
-                            ) : (
-                              <>{renderWithLink(line)}</>
-                            )}
-                          </div>
-                        ))}
-                      </div>
-                    )}
-                  </div>
-                ) : msg.type === 'CODE' || (msg.content && msg.content.startsWith('```')) ? (
-                  <div style={{
-                    borderRadius: '6px',
-                    overflow: 'hidden',
-                    border: '1px solid #e2e8f0'
-                  }}>
-                    <HighlightedCode
-                      content={msg.content.replace(/```/g, '')}
-                      language={msg.language || 'java'}
-                    />
-                    {msg.edited && (
-                      <span style={{
-                        marginLeft: '6px',
-                        fontSize: '11px',
-                        color: '#a0aec0',
-                        fontStyle: 'italic'
-                      }}>
-                        (수정됨)
-                      </span>
-                    )}
-                  </div>
-                ) : msg.type === 'IMAGE' ? (
-                  <div style={{
-                    maxWidth: '30%',
-                    backgroundColor: '#f8fafc',
-                    border: '1px solid #e2e8f0',
-                    borderRadius: '8px',
-                    padding: '8px',
-                    boxShadow: '0 1px 4px rgba(0, 0, 0, 0.05)'
-                  }}>
-                    <img
-                      src={`http://localhost:8080/images/chat/${msg.chatImageUrl}`}
-                      alt="업로드된 이미지"
-                      style={{
-                        width: '100%',
-                        maxHeight: '400px',
-                        objectFit: 'contain',
-                        borderRadius: '6px'
-                      }}
-                    />
-                  </div>
-                )
-                  : (
-                    <div style={{
-                      fontSize: '14px',
-                      lineHeight: '1.5',
-                      color: '#4a5568',
-                      wordBreak: 'break-word',
-                      whiteSpace: 'pre-wrap'
-                    }}>
-                      {msg.content}
-                      {(msg.edited || msg.isEdited) && (
-                        <span style={{
-                          marginLeft: '6px',
-                          fontSize: '11px',
-                          color: '#a0aec0',
-                          fontStyle: 'italic'
-                        }}>
-                          (수정됨)
-                        </span>
-                      )}
-                    </div>
-                  )}
-          </div>
-        </div>
+     
       );
     });
 

--- a/frontend/src/pages/ChatRoom.jsx
+++ b/frontend/src/pages/ChatRoom.jsx
@@ -1,16 +1,14 @@
 import React, { useEffect, useState, useRef } from 'react';
 import SockJS from 'sockjs-client';
 import { Client } from '@stomp/stompjs';
-import { useParams, useNavigate, useLocation } from 'react-router-dom'; //
-import Highlight from 'react-highlight';
-import 'highlight.js/styles/github.css';
+import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import Sidebar from '../components/SideBar';
 import Header from '../components/header';
 import SearchSidebar from '../components/SearchSideBar';
 import { FaCopy, FaTrashAlt } from 'react-icons/fa';
 import axiosInstance from '../components/api/axiosInstance';
 import MessageInput from '../components/chatroom/MessageInput';
-
+import MessageList from '../components/chatroom/MessageList';
 const ChatRoom = () => {
 
   const { roomId, inviteCode } = useParams();
@@ -185,31 +183,6 @@ const ChatRoom = () => {
   const scrollToBottom = () => {
     messagesEndRef.current?.scrollIntoView({ behavior: "instant" });
   };
-
-  const HighlightedCode = ({ content, language }) => {
-    return (
-      <Highlight className={language}>{content}</Highlight>
-    );
-  };
-
-  // const renderWithLink = (text) => {
-  //   const urlRegex = /(https?:\/\/[^\s]+)/g;
-  //   return text.split(urlRegex).map((part, i) =>
-  //     urlRegex.test(part) ? (
-  //       <a
-  //         key={i}
-  //         href={part}
-  //         target="_blank"
-  //         rel="noopener noreferrer"
-  //         style={{ color: '#0366d6', textDecoration: 'underline' }}
-  //       >
-  //         {part}
-  //       </a>
-  //     ) : (
-  //       part
-  //     )
-  //   );
-  // };
 
   const stompClientRef = useRef(null);
   const subscriptionRef = useRef(null);
@@ -574,61 +547,6 @@ const ChatRoom = () => {
     setContextMenuId(null); // 메뉴 닫기
   };
 
-  // 메시지 데이터 처리 및 날짜 구분선 추가
-  const renderMessagesWithDateSeparators = () => {
-    if (!messages.length) return null;
-
-    const result = [];
-    let currentDate = null;
-
-    // 메시지를 순회하며 날짜별로 구분
-    messages.forEach((msg, index) => {
-      const messageDate = formatDate(msg.sendAt);
-
-      // 날짜가 바뀌었다면 구분선 추가
-      if (messageDate !== currentDate) {
-        currentDate = messageDate;
-        result.push(
-          <div key={`date-${index}`} style={{
-            display: 'flex',
-            alignItems: 'center',
-            margin: '24px 0',
-            color: '#64748b',
-            fontSize: '14px',
-            fontWeight: '500'
-          }}>
-            <div style={{
-              flex: '1',
-              height: '1px',
-              backgroundColor: '#e2e8f0'
-            }}></div>
-            <div style={{
-              margin: '0 16px',
-              padding: '4px 12px',
-              backgroundColor: '#f8fafc',
-              borderRadius: '12px',
-              border: '1px solid #e2e8f0'
-            }}>
-              {messageDate}
-            </div>
-            <div style={{
-              flex: '1',
-              height: '1px',
-              backgroundColor: '#e2e8f0'
-            }}></div>
-          </div>
-        );
-      }
-
-      // 메시지 추가
-      result.push(
-     
-      );
-    });
-
-    return result;
-  };
-
   return (
     <div
       onContextMenu={handleContextMenu}
@@ -778,8 +696,18 @@ const ChatRoom = () => {
             minHeight: 0
           }}>
 
-            {renderMessagesWithDateSeparators()}
-
+          <MessageList
+            messages={messages}
+            currentUser={currentUser}
+            contextMenuId={contextMenuId}
+            setContextMenuId={setContextMenuId}
+            setEditMessageId={setEditMessageId}
+            setEditContent={setEditContent}
+            handleDeleteMessage={handleDeleteMessage}
+            editMessageId={editMessageId}
+            editContent={editContent}
+            handleEditMessage={handleEditMessage}
+          />
             <div ref={messagesEndRef} />
           </div>
 

--- a/frontend/src/pages/ChatRoom.jsx
+++ b/frontend/src/pages/ChatRoom.jsx
@@ -116,7 +116,6 @@ const ChatRoom = () => {
           throw new Error('채팅방 입장 실패');
         }
 
-
         // join 성공 → DB에 참가자 저장됨
         setJoined(true);
       } catch (err) {
@@ -182,11 +181,14 @@ const ChatRoom = () => {
     roomId,
     onMessageReceived: (received)=> {
       //메세지 상태 업데이트
-      setMessages(prev =>
-        prev.some(m => m.messageId === received.messageId)
+      setMessages(prev => {
+        const updated=prev.some(m => m.messageId === received.messageId)
         ? prev.map(m => m.messageId === received.messageId ? received : m)
-        : [...prev, received]
-      );
+        : [...prev, received];
+
+        // sendAt 기준으로 정렬 (문자열 ISO이므로 비교 가능)
+        return [...updated].sort((a, b) => new Date(a.sendAt) - new Date(b.sendAt));
+      });
     }
   });
 
@@ -205,10 +207,6 @@ const ChatRoom = () => {
         if (!msg.sendAt || new Date(msg.sendAt).getFullYear() === 1970) {
           msg = { ...msg, sendAt: new Date().toISOString() };
         }
-
-        // isEdited와 isDeleted 속성이 undefined이면 기본값 설정
-        if (msg.edited === undefined) msg.edited = !!msg.isEdited;
-        if (msg.deleted === undefined) msg.deleted = !!msg.isDeleted;
 
         return msg;
       });

--- a/frontend/src/pages/ChatRoom.jsx
+++ b/frontend/src/pages/ChatRoom.jsx
@@ -3,11 +3,12 @@ import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import Sidebar from '../components/SideBar';
 import Header from '../components/header';
 import SearchSidebar from '../components/SearchSideBar';
-import { FaCopy } from 'react-icons/fa';
 import axiosInstance from '../components/api/axiosInstance';
 import MessageInput from '../components/chatroom/MessageInput';
 import MessageList from '../components/chatroom/MessageList';
 import useWebSocket from '../components/common/useWebSocket';
+import RoomHeader from '../components/chatroom/RoomHeader';
+
 const ChatRoom = () => {
 
   const { roomId, inviteCode } = useParams();
@@ -23,14 +24,8 @@ const ChatRoom = () => {
   const [editContent, setEditContent] = useState(""); // 수정 중인 내용
 
   const messagesEndRef = useRef(null);
-  const [showNotification, setShowModal] = useState(false);
-
   const navigate = useNavigate();           // ← 네비게이트 훅
   const location = useLocation();           // ← 현재 URL 가져오기
-
-  const [menuOpen, setMenuOpen] = useState(false);
-  const [showLeaveConfirm, setShowLeaveConfirm] = useState(false);
-  const [showLeaveSuccess, setShowLeaveSuccess] = useState(false);
 
   const [roomName, setRoomName] = useState("로딩 중...");
 
@@ -129,41 +124,19 @@ const ChatRoom = () => {
 
   },[roomId]);
 
-  //초대 코드 복사
-  const copyInviteCode = async () => {
-    try {
-      await navigator.clipboard.writeText(inviteCode); // 백엔드 없이 바로 복사
-      setShowModal(true);
-      setTimeout(() => setShowModal(false), 2000);
-    } catch (err) {
-      console.error(err);
-      alert('초대 코드 복사 중 오류가 발생했습니다.');
-    }
-  };
-
-  //채팅방 나가기
   const handleLeaveRoom = async () => {
     try {
-      const res = await axiosInstance.delete(`/chat-rooms/${roomId}/leave`);
-      
-      // 성공 처리
-      setShowLeaveConfirm(false);
-      setShowLeaveSuccess(true);
+      await axiosInstance.delete(`/chat-rooms/${roomId}/leave`);
 
-      setTimeout(() => {
-        setShowLeaveSuccess(false);
-        navigate('/');
-      }, 500);
+      // ChatRoom 컴포넌트의 상태 업데이트는 RoomHeader가 처리하도록 처리
+      return { success: true };
     } catch (err) {
-      // 실패 처리
       const errorMsg =
-        err.response?.data?.message || // 백엔드에서 보낸 메시지
-        err.message ||                 // 일반 오류 메시지
-        '나가기 실패';                 // 기본 메시지
+        err.response?.data?.message ||
+        err.message ||
+        '나가기 실패';
 
-      alert(errorMsg);
-    } finally {
-      setMenuOpen(false);
+      return { success: false, error: errorMsg };
     }
   };
 
@@ -320,7 +293,6 @@ const ChatRoom = () => {
     setInputMode('TEXT');
   };
 
-
   //메세지 수정 요청
   const handleEditMessage = (messageId) => {
     const client = stompClientRef.current;
@@ -390,115 +362,13 @@ const ChatRoom = () => {
           overflow: 'hidden'
         }}>
 
-          {/* 채팅방 헤더 - 상단에 고정 */}
-          <div style={{
-            display: 'flex',
-            justifyContent: 'space-between',
-            alignItems: 'center',
-            padding: '6px 20px',
-            borderBottom: '1px solid #eaedf0',
-            backgroundColor: '#fff'
-          }}>
-            <div style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: '12px',
-              position: 'relative'
-            }}>
-              <span style={{
-                fontWeight: '600',
-                fontSize: '18px',
-                color: '#2d3748'
-              }}>
-                {roomName}
-              </span>
-
-              {/* 초대 코드 복사 버튼 */}
-              <button
-                onClick={copyInviteCode}
-                style={{
-                  backgroundColor: '#2588F1',
-                  color: 'white',
-                  border: 'none',
-                  borderRadius: '4px',
-                  padding: '6px 12px',
-                  fontSize: '13px',
-                  fontWeight: '500',
-                  cursor: 'pointer',
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: '6px'
-                }}
-              >
-                <FaCopy size={14} />
-                초대 코드 복사
-              </button>
-
-              <button
-                onClick={() => setMenuOpen(prev => !prev)}
-                style={{
-                  fontSize: '25px',
-                  background: 'none',
-                  border: 'none',
-                  cursor: 'pointer',
-                  color: '#94a3b8',    
-              }}
-              >
-                ⋮
-              </button>
-
-              {/* 드롭다운 메뉴 */}
-              {menuOpen && (
-                <div style={{
-                  position: 'absolute',
-                  top: '0',
-                  left: '100%',
-                  marginLeft: '8px',  
-                  backgroundColor: 'white',  
-                  border: '1px solid #ccc',
-                  borderRadius: '6px',
-                  boxShadow: '0 2px 8px rgba(0,0,0,0.1)',
-                  zIndex: 1000,
-                  minWidth: '100px' 
-                }}>
-                  <button
-                    onClick={() => setShowLeaveConfirm(true)}
-                    style={{
-                      padding: '10px 16px',
-                      background: 'none',
-                      border: 'none',
-                      width: '100%',
-                      textAlign: 'left',
-                      cursor: 'pointer',
-                      fontSize: '14px',
-                      color: '#e53e3e',
-                      whiteSpace: 'nowrap',
-                      display: 'flex'
-                    }}
-                  >
-                    채팅방 나가기
-                  </button>
-                </div>
-              )}
-            </div>
-
-            <div>
-              <input
-                type="text"
-                placeholder="메시지 검색"
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter') {
-                    handleSearch(e.target.value);
-                  }
-                }}
-                style={{
-                  width: '220px',
-                  backgroundColor: '#f9fafc',
-                  fontSize: '14px'
-                }}
-              />
-            </div>
-          </div>
+          {/* 채팅방 헤더 - 채팅방 이름, 초대 코드 복사 버튼, 나가기 버튼, 메세지 검색 창 */}
+          <RoomHeader
+            roomName={roomName}
+            inviteCode={inviteCode}
+            onSearch={handleSearch} // 메시지 검색 api 요청 함수
+            onLeaveRoom={handleLeaveRoom} // 방 나가기 api 요청 함수
+          />
 
           {/* 메시지 목록 */}
           <div style={{
@@ -508,19 +378,18 @@ const ChatRoom = () => {
             backgroundColor: '#fff',
             minHeight: 0
           }}>
-
-          <MessageList
-            messages={messages}
-            currentUser={currentUser}
-            contextMenuId={contextMenuId}
-            setContextMenuId={setContextMenuId}
-            setEditMessageId={setEditMessageId}
-            setEditContent={setEditContent}
-            handleDeleteMessage={handleDeleteMessage}
-            editMessageId={editMessageId}
-            editContent={editContent}
-            handleEditMessage={handleEditMessage}
-          />
+            <MessageList
+              messages={messages}
+              currentUser={currentUser}
+              contextMenuId={contextMenuId}
+              setContextMenuId={setContextMenuId}
+              setEditMessageId={setEditMessageId}
+              setEditContent={setEditContent}
+              handleDeleteMessage={handleDeleteMessage}
+              editMessageId={editMessageId}
+              editContent={editContent}
+              handleEditMessage={handleEditMessage}
+            />
             <div ref={messagesEndRef} />
           </div>
 
@@ -546,74 +415,9 @@ const ChatRoom = () => {
               setImagePreviewUrl={setImagePreviewUrl}
             />
           </div>
-
-          {showNotification && (
-            <div style={{
-              position: 'fixed',
-              top: '15px',
-              right: '15px',
-              backgroundColor: '#333',
-              color: '#fff',
-              padding: '10px 16px',
-              borderRadius: '6px',
-              boxShadow: '0 4px 8px rgba(0, 0, 0, 0.2)',
-              zIndex: 1000
-            }}>
-              초대 코드가 복사되었습니다.
-            </div>
-          )}
-
-          {/* 나가기 확인 모달 */}
-          {showLeaveConfirm && (
-            <div style={{
-              position: 'fixed', top: 0, left: 0, width: '100vw', height: '100vh',
-              backgroundColor: 'rgba(0, 0, 0, 0.4)', display: 'flex',
-              alignItems: 'center', justifyContent: 'center', zIndex: 2000
-            }}>
-              <div style={{
-                backgroundColor: 'white', padding: '24px', borderRadius: '8px',
-                minWidth: '280px', textAlign: 'center', boxShadow: '0 4px 12px rgba(0,0,0,0.2)'
-              }}>
-                <p style={{ fontSize: '16px', marginBottom: '20px' }}>
-                  정말 이 채팅방을 나가시겠습니까?
-                </p>
-                <div style={{ display: 'flex', justifyContent: 'center', gap: '12px' }}>
-                  <button
-                    onClick={() => setShowLeaveConfirm(false)}
-                    style={{
-                      padding: '8px 16px', backgroundColor: '#eee',
-                      border: 'none', borderRadius: '4px', cursor: 'pointer'
-                    }}
-                  >
-                    취소
-                  </button>
-                  <button
-                    onClick={handleLeaveRoom}
-                    style={{
-                      padding: '8px 16px', backgroundColor: '#e53e3e', color: 'white',
-                      border: 'none', borderRadius: '4px', cursor: 'pointer'
-                    }}
-                  >
-                    나가기
-                  </button>
-                </div>
-              </div>
-            </div>
-          )}
-
-          {/* 나가기 완료 모달 */}
-          {showLeaveSuccess && (
-            <div style={{
-              position: 'fixed', top: '20px', right: '20px',
-              backgroundColor: '#333', color: 'white',
-              padding: '12px 20px', borderRadius: '6px',
-              boxShadow: '0 4px 8px rgba(0,0,0,0.2)', zIndex: 2000
-            }}>
-              채팅방에서 나갔습니다.
-            </div>
-          )}
         </div>
 
+        {/* 메세지 검색 바 */}
         {showSearchSidebar && (
           <SearchSidebar
             searchKeyword={searchKeyword}
@@ -632,4 +436,5 @@ const ChatRoom = () => {
     </div>
   );
 };
+
 export default ChatRoom;

--- a/frontend/src/pages/ChatRoom.jsx
+++ b/frontend/src/pages/ChatRoom.jsx
@@ -402,7 +402,8 @@ const ChatRoom = () => {
             <div style={{
               display: 'flex',
               alignItems: 'center',
-              gap: '12px'
+              gap: '12px',
+              position: 'relative'
             }}>
               <span style={{
                 fontWeight: '600',
@@ -432,6 +433,53 @@ const ChatRoom = () => {
                 <FaCopy size={14} />
                 초대 코드 복사
               </button>
+
+              <button
+                onClick={() => setMenuOpen(prev => !prev)}
+                style={{
+                  fontSize: '25px',
+                  background: 'none',
+                  border: 'none',
+                  cursor: 'pointer',
+                  color: '#94a3b8',    
+              }}
+              >
+                ⋮
+              </button>
+
+              {/* 드롭다운 메뉴 */}
+              {menuOpen && (
+                <div style={{
+                  position: 'absolute',
+                  top: '0',
+                  left: '100%',
+                  marginLeft: '8px',  
+                  backgroundColor: 'white',  
+                  border: '1px solid #ccc',
+                  borderRadius: '6px',
+                  boxShadow: '0 2px 8px rgba(0,0,0,0.1)',
+                  zIndex: 1000,
+                  minWidth: '100px' 
+                }}>
+                  <button
+                    onClick={() => setShowLeaveConfirm(true)}
+                    style={{
+                      padding: '10px 16px',
+                      background: 'none',
+                      border: 'none',
+                      width: '100%',
+                      textAlign: 'left',
+                      cursor: 'pointer',
+                      fontSize: '14px',
+                      color: '#e53e3e',
+                      whiteSpace: 'nowrap',
+                      display: 'flex'
+                    }}
+                  >
+                    채팅방 나가기
+                  </button>
+                </div>
+              )}
             </div>
 
             <div>
@@ -450,51 +498,6 @@ const ChatRoom = () => {
                 }}
               />
             </div>
-          </div>
-
-          <div style={{ position: 'relative', display: 'flex', flexDirection: 'column', alignItems: 'flex-end', padding: '0 24px', marginRight: '20px',marginTop: '15px' }}>
-            <button
-              onClick={() => setMenuOpen(prev => !prev)}
-              style={{
-                fontSize: '25px',
-                background: 'none',
-                border: 'none',
-                cursor: 'pointer',
-                color: '#4a5568'
-              }}
-            >
-               ⋮
-            </button>
-
-            {/* 드롭다운 메뉴 */}
-            {menuOpen && (
-              <div style={{
-                position: 'absolute',
-                top: '32px',
-                right: '0',
-                backgroundColor: 'white',
-                border: '1px solid #ccc',
-                borderRadius: '6px',
-                boxShadow: '0 2px 8px rgba(0,0,0,0.1)',
-                zIndex: 1000
-              }}>
-                <button
-                  onClick={() => setShowLeaveConfirm(true)}
-                  style={{
-                    padding: '10px 16px',
-                    background: 'none',
-                    border: 'none',
-                    width: '100%',
-                    textAlign: 'left',
-                    cursor: 'pointer',
-                    fontSize: '14px',
-                    color: '#e53e3e'
-                  }}
-                >
-                  채팅방 나가기
-                </button>
-              </div>
-            )}
           </div>
 
           {/* 메시지 목록 */}

--- a/frontend/src/pages/ChatRoom.jsx
+++ b/frontend/src/pages/ChatRoom.jsx
@@ -9,6 +9,7 @@ import Header from '../components/header';
 import SearchSidebar from '../components/SearchSideBar';
 import { FaCopy, FaTrashAlt } from 'react-icons/fa';
 import axiosInstance from '../components/api/axiosInstance';
+import MessageInput from '../components/chatroom/MessageInput';
 
 const ChatRoom = () => {
 
@@ -210,14 +211,14 @@ const ChatRoom = () => {
     );
   };
 
-  const handleInputChange = (e) => {
-    const val = e.target.value;
-    setContent(val);
-    if (val.startsWith("```")) {
-      setInputMode("CODE");
-      setContent('');
-    }
-  };
+  // const handleInputChange = (e) => {
+  //   const val = e.target.value;
+  //   setContent(val);
+  //   if (val.startsWith("```")) {
+  //     setInputMode("CODE");
+  //     setContent('');
+  //   }
+  // };
 
   const stompClientRef = useRef(null);
   const subscriptionRef = useRef(null);
@@ -495,73 +496,44 @@ const ChatRoom = () => {
     }
   };
 
-  // 시간을 HH:MM 형식으로 변환하는 함수 (수정됨)
-  const formatTime = (dateString) => {
-    try {
-      const date = new Date(dateString);
-
-      // 유효한 날짜인지 확인
-      if (isNaN(date.getTime()) || date.getFullYear() === 1970) {
-        return new Date().toLocaleTimeString('ko-KR', {
-          hour: '2-digit',
-          minute: '2-digit',
-          hour12: true  // 오전/오후 표시 활성화
-        });
-      }
-
-      return date.toLocaleTimeString('ko-KR', {
-        hour: '2-digit',
-        minute: '2-digit',
-        hour12: true  // 오전/오후 표시 활성화
-      });
-    } catch (error) {
-      console.error('시간 형식 변환 오류:', error);
-      return new Date().toLocaleTimeString('ko-KR', {
-        hour: '2-digit',
-        minute: '2-digit',
-        hour12: true  // 오전/오후 표시 활성화
-      });
-    }
-  };
-
   const [imageFile, setImageFile] = useState(null);
   const [imagePreviewUrl, setImagePreviewUrl] = useState(null);
   const fileInputRef = useRef(null);
 
   // 전송 버튼 클릭 시 호출되는 공통 핸들러 함수 (이미지 업로드 고려)
-const handleUnifiedSend = async () => {
-  if (inputMode === 'IMAGE') {
-    if (!imageFile) {
-      alert("이미지를 선택하세요.");
-      return;
+  const handleUnifiedSend = async () => {
+    if (inputMode === 'IMAGE') {
+      if (!imageFile) {
+        alert("이미지를 선택하세요.");
+        return;
+      }
+
+      try {
+        const formData = new FormData();
+        formData.append('image', imageFile);
+
+        const response = await axiosInstance.post('/send-image', formData, {
+          headers: {
+            'Content-Type': 'multipart/form-data'
+          }
+        });
+
+        const imageId = response.data;
+        sendMessage({
+          type: 'IMAGE',
+          content: '',
+          imageFileId: imageId
+        });
+
+        setImageFile(null);
+        setImagePreviewUrl(null);
+      } catch (err) {
+        console.error("이미지 전송 실패: ", err);
+      }
+    } else {
+      sendMessage();
     }
-
-    try {
-      const formData = new FormData();
-      formData.append('image', imageFile);
-
-      const response = await axiosInstance.post('/send-image', formData, {
-        headers: {
-          'Content-Type': 'multipart/form-data'
-        }
-      });
-
-      const imageId = response.data;
-      sendMessage({
-        type: 'IMAGE',
-        content: '',
-        imageFileId: imageId
-      });
-
-      setImageFile(null);
-      setImagePreviewUrl(null);
-    } catch (err) {
-      console.error("이미지 전송 실패: ", err);
-    }
-  } else {
-    sendMessage();
-  }
-};
+  };
 
   // 버튼 스타일 공통화
   const buttonStyle = {
@@ -1138,212 +1110,19 @@ const handleUnifiedSend = async () => {
             display: 'flex',
             flexDirection: 'column'
           }}>
-            <div style={{
-              marginBottom: '12px',
-              display: 'flex',
-              alignItems: 'center'
-            }}>
-              <div style={{
-                display: 'flex',
-                backgroundColor: '#f1f5f9',
-                borderRadius: '6px',
-                padding: '2px',
-                marginRight: '12px'
-              }}>
-                <span
-                  onClick={() => {
-                    const nextMode = inputMode === 'IMAGE' ? 'TEXT' : 'IMAGE';
-                    setInputMode(nextMode);
-
-                    // 모드가 IMAGE로 바뀌었으면 파일 선택창 자동 오픈
-                    if (nextMode === 'IMAGE' && fileInputRef.current) {
-                      fileInputRef.current.click();
-                    }
-                  }}
-                  style={{
-                    padding: '6px 12px',
-                    borderRadius: '4px',
-                    cursor: 'pointer',
-                    fontWeight: '500',
-                    fontSize: '13px',
-                    backgroundColor: inputMode === 'IMAGE' ? '#ffffff' : 'transparent',
-                    color: inputMode === 'IMAGE' ? '#4a6cf7' : '#64748b',
-                    boxShadow: inputMode === 'IMAGE' ? '0 1px 3px rgba(0,0,0,0.1)' : 'none',
-                    transition: 'all 0.2s'
-                  }}
-                >
-                  사진
-                </span>
-                <span
-                  onClick={() => {
-                    const nextMode = inputMode === 'CODE' ? 'TEXT' : 'CODE';
-                    setInputMode(nextMode);
-                  }}
-                  style={{
-                    padding: '6px 12px',
-                    borderRadius: '4px',
-                    cursor: 'pointer',
-                    fontWeight: '500',
-                    fontSize: '13px',
-                    backgroundColor: inputMode === 'CODE' ? '#ffffff' : 'transparent',
-                    color: inputMode === 'CODE' ? '#4a6cf7' : '#64748b',
-                    boxShadow: inputMode === 'CODE' ? '0 1px 3px rgba(0,0,0,0.1)' : 'none',
-                    transition: 'all 0.2s'
-                  }}
-                >
-                  코드
-                </span>
-              </div>
-
-              {/* 언어 선택 옵션을 코드 버튼 바로 옆으로 이동 */}
-              {inputMode === 'CODE' && (
-                <select
-                  value={language}
-                  onChange={(e) => setLanguage(e.target.value)}
-                  style={{
-                    ...inputStyle,
-                    backgroundColor: '#f8fafc',
-                    border: '1px solid #e2e8f0',
-                    borderRadius: '4px',
-                    padding: '6px 10px',
-                    fontSize: '13px',
-                    color: '#475569',
-                    cursor: 'pointer'
-                  }}
-                >
-                  <option value="javascript">JavaScript</option>
-                  <option value="java">Java</option>
-                  <option value="python">Python</option>
-                  <option value="html">HTML</option>
-                  <option value="css">CSS</option>
-                </select>
-              )}
-            </div>
-
-            <div style={{ display: 'flex', gap: '10px' }}>
-              <div style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
-
-                {/* 썸네일 미리보기 이미지 */}
-                {inputMode === 'IMAGE' && imagePreviewUrl && (
-                  <div style={{
-                    position: 'relative',
-                    marginBottom: '10px',
-                    padding: '8px',
-                    backgroundColor: '#f8fafc',
-                    border: '2px solid #e2e8f0',
-                    borderRadius: '8px',
-                    maxWidth: '10%',
-                    boxShadow: '0 1px 4px rgba(0,0,0,0.05)',
-                    display: 'inline-block'
-                  }}>
-                    <img
-                      src={imagePreviewUrl}
-                      alt="미리보기"
-                      style={{
-                        maxWidth: '100%',
-                        objectFit: 'contain',
-                        borderRadius: '6px',
-                        display: 'block'
-                      }}
-                    />
-
-                    <button
-                      onClick={() => {
-                        setImageFile(null);
-                        setImagePreviewUrl(null);
-                        setInputMode('TEXT');
-
-                        if (fileInputRef.current) {
-                          fileInputRef.current.value = null;
-                        }
-                      }}
-                      title="삭제"
-                      style={{
-                        position: 'absolute',
-                        top: '2px',
-                        right: '2px',
-                        backgroundColor: 'rgba(255, 255, 255, 0.9)',
-                        border: '1px solid #e2e8f0',
-                        borderRadius: '50%',
-                        width: '28px',
-                        height: '28px',
-                        color: '#e53e3e',
-                        cursor: 'pointer',
-                        display: 'flex',
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                        boxShadow: '0 1px 4px rgba(0,0,0,0.15)'
-                      }}
-                    >
-                      <FaTrashAlt color="#e53e3e" size={16} />
-                    </button>
-                  </div>
-                )}
-
-                <div style={{ display: 'flex', alignItems: 'flex-end', gap: '10px' }}>
-                  <textarea
-                    disabled={inputMode === 'IMAGE'}
-                    value={content}
-                    onChange={handleInputChange}
-                    onCompositionStart={() => (isComposingRef.current = true)}
-                    onCompositionEnd={() => (isComposingRef.current = false)}
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter' && !e.shiftKey && !isComposingRef.current) {
-                        e.preventDefault();
-                        sendMessage(e.target.value);
-                      }
-                    }}
-                    placeholder={inputMode === 'CODE' ? '코드를 입력하세요.' : inputMode === 'IMAGE' ? '이미지를 업로드 해주세요.' : '메시지를 입력하세요.'}
-                    style={{
-                      flex: 1,
-                      height: '80px',
-                      resize: 'none',
-                      padding: '12px 16px',
-                      fontSize: '14px',
-                      backgroundColor: inputMode === 'IMAGE' ? '#f1f5f9' : inputMode === 'CODE' ? '#f8fafc' : 'white',
-                      border: '1px solid #e2e8f0',
-                      borderRadius: '8px',
-                      lineHeight: '1.5',
-                      color: '#4a5568',
-                      boxShadow: 'inset 0 1px 2px rgba(0,0,0,0.05)',
-                      transition: 'border-color 0.2s',
-                      cursor: inputMode === 'IMAGE' ? 'not-allowed' : 'text'
-                    }}
-                  />
-
-                  <input
-                    type="file"
-                    ref={fileInputRef}
-                    // accept="image/*"
-                    onChange={(e) => {
-                      if (e.target.files?.[0]) {
-                        const file = e.target.files[0];
-                        setImageFile(file);
-
-                        // 파일 URL 생성
-                        const reader = new FileReader();
-                        reader.onloadend = () => {
-                          setImagePreviewUrl(reader.result);
-                        };
-                        reader.readAsDataURL(file);
-                      }
-                    }}
-                    style={{ display: 'none' }} // 숨김
-                  />
-
-                  <button
-                    // onClick={() => sendMessage()}
-                    onClick={handleUnifiedSend}
-                    style={{
-                      ...buttonStyle,
-                      height: '80px'
-                    }}
-                  >
-                    전송
-                  </button>
-                </div>
-              </div>
-            </div>
+            <MessageInput
+              inputMode={inputMode}
+              setInputMode={setInputMode}
+              content={content}
+              setContent={setContent}
+              language={language}
+              setLanguage={setLanguage}
+              sendMessage={sendMessage}
+              handleUnifiedSend={handleUnifiedSend}
+              setImageFile={setImageFile}
+              imagePreviewUrl={imagePreviewUrl}
+              setImagePreviewUrl={setImagePreviewUrl}
+            />
           </div>
 
           {/* 우클릭 컨텍스트 메뉴 */}

--- a/frontend/src/pages/ChatRoom.jsx
+++ b/frontend/src/pages/ChatRoom.jsx
@@ -3,7 +3,7 @@ import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import Sidebar from '../components/SideBar';
 import Header from '../components/header';
 import SearchSidebar from '../components/SearchSideBar';
-import { FaCopy, FaTrashAlt, FaUserPlus, FaClock } from 'react-icons/fa';
+import { FaCopy } from 'react-icons/fa';
 import axiosInstance from '../components/api/axiosInstance';
 import MessageInput from '../components/chatroom/MessageInput';
 import MessageList from '../components/chatroom/MessageList';
@@ -23,46 +23,125 @@ const ChatRoom = () => {
   const [editContent, setEditContent] = useState(""); // 수정 중인 내용
 
   const messagesEndRef = useRef(null);
-  const isComposingRef = useRef(false);
-
-  const [contextMenuVisible, setContextMenuVisible] = useState(false);
-  const [contextMenuPosition, setContextMenuPosition] = useState({ x: 0, y: 0 });
-
   const [showNotification, setShowModal] = useState(false);
-  const [showUrlCopiedModal, setShowUrlCopiedModal] = useState(false);
-  const [modalPosition, setModalPosition] = useState({ x: 0, y: 0 });
 
   const navigate = useNavigate();           // ← 네비게이트 훅
   const location = useLocation();           // ← 현재 URL 가져오기
-  const joinedOnceRef = useRef(false);
 
-  // 참가 완료 여부
-  const [setJoined] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
-
-
-  //임창인
   const [showLeaveConfirm, setShowLeaveConfirm] = useState(false);
   const [showLeaveSuccess, setShowLeaveSuccess] = useState(false);
 
   const [roomName, setRoomName] = useState("로딩 중...");
 
-  // 방 정보를 가져오는 함수 - fetchCurrentUser 함수 위나 아래에 추가
+  // 1. 방 이름 불러오기
   const fetchRoomInfo = async () => {
     try {
       const res = await axiosInstance.get(`/chat-rooms/check?inviteCode=${inviteCode}`, {
       });
 
       const roomData = res.data;
-      setRoomName(roomData.roomName || `채팅방 #${roomId}`);
+      setRoomName(roomData.roomName);
     } catch (error) {
       console.error('방 정보 요청 실패:', error);
       setRoomName(`채팅방 #${roomId}`); // 오류 시 기본값으로 표시
     }
   };
 
+  // 2. 메시지 목록 불러오기
+  const fetchMessages = async () => {
+    try {
+      const res = await axiosInstance.get(`/${roomId}/messages`);
+      const data = res.data;
 
-  //임창인(채팅방 나가기)
+      // 날짜 유효성 검사
+      const validatedData = data.map(msg => {
+        const sendAt = new Date(msg.sendAt);
+        const isInvalidDate = isNaN(sendAt.getTime()); // getTime이 NaN이면 잘못된 날짜
+
+        if (!msg.sendAt || isInvalidDate) {
+          return { ...msg, sendAt: new Date().toISOString() };
+        }
+
+        return msg;
+      });
+
+      //sendAt 기준으로 메시지 정렬
+      const sortedData = validatedData.sort(
+          (a, b) => new Date(a.sendAt).getTime() - new Date(b.sendAt).getTime()
+      );
+
+      setMessages(sortedData);
+    } catch (error) {
+      console.error('Error fetching messages:', error);
+    }
+  };
+
+  // 3. 로그인 유저 정보 가져오기
+  const fetchCurrentUser = async () => {
+    try {
+      const res = await fetch('http://localhost:8080/user/details', {
+        method: 'GET',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+      });
+
+      if (!res.ok) {
+        throw new Error('로그인 정보를 가져오지 못했습니다.');
+      }
+
+      const user = await res.json(); // { id, email, nickname, profileImg }
+      setCurrentUser(user);
+    } catch (error) {
+      console.error('사용자 정보 요청 실패:', error);
+    }
+  };
+
+  //웹소켓 연결 (현재 채팅방 구독)
+  const stompClientRef = useWebSocket({
+    roomId,
+    onMessageReceived: (received)=> {
+      //메세지 상태 업데이트
+      setMessages(prev => {
+        const updated=prev.some(m => m.messageId === received.messageId)
+        ? prev.map(m => m.messageId === received.messageId ? received : m)
+        : [...prev, received];
+
+        // sendAt 기준으로 정렬
+        return [...updated].sort((a, b) => new Date(a.sendAt) - new Date(b.sendAt));
+      });
+    }
+  });
+
+  //roomId가 변할 때 초기 데이터 불러오기
+  useEffect(() => {
+    if (!roomId) {
+      console.error("No roomId available");
+      navigate("/");
+      return;
+    }
+
+    setMessages([]); // 이전 채팅방 메세지 제거
+
+    fetchCurrentUser();
+    fetchRoomInfo(); // 방 정보 가져오기 함수 호출 추가
+    fetchMessages();
+
+  },[roomId]);
+
+  //초대 코드 복사
+  const copyInviteCode = async () => {
+    try {
+      await navigator.clipboard.writeText(inviteCode); // 백엔드 없이 바로 복사
+      setShowModal(true);
+      setTimeout(() => setShowModal(false), 2000);
+    } catch (err) {
+      console.error(err);
+      alert('초대 코드 복사 중 오류가 발생했습니다.');
+    }
+  };
+
+  //채팅방 나가기
   const handleLeaveRoom = async () => {
     try {
       const res = await axiosInstance.delete(`/chat-rooms/${roomId}/leave`);
@@ -83,89 +162,12 @@ const ChatRoom = () => {
         '나가기 실패';                 // 기본 메시지
 
       alert(errorMsg);
-      console.error('채팅방 나가기 실패:', err);
     } finally {
       setMenuOpen(false);
     }
   };
 
-  useEffect(() => {
-    if (joinedOnceRef.current) return;   // 이미 한 번 호출됐다면 스킵
-    joinedOnceRef.current = true;
-
-    const checkAndJoin = async () => {
-      try {
-        const res = await fetch('http://localhost:8080/chat-rooms/join', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          credentials: 'include',                    // ← 세션(cookie) 포함
-          body: JSON.stringify({ inviteCode })
-        });
-
-        if (res.status === 401) {
-          const data = await res.json();
-          console.log("[DEBUG] 401 응답 data:", data);
-          const redirectPath = `/chat/${data.details.roomId}/${data.details.inviteCode}`;
-          navigate(`/login?redirect=${encodeURIComponent(redirectPath)}`);
-          return;
-        }
-
-        if (!res.ok) {
-          const text = await res.text(); // 응답 본문도 확인
-          console.error("[DEBUG] 실패 상태:", res.status, text);
-          throw new Error('채팅방 입장 실패');
-        }
-
-        // join 성공 → DB에 참가자 저장됨
-        setJoined(true);
-      } catch (err) {
-        console.error(err);
-
-      }
-    };
-    checkAndJoin();
-  }, [inviteCode, location.pathname, navigate, setJoined]);
-
-  const handleContextMenu = (e) => {
-    e.preventDefault();
-    setContextMenuVisible(true);
-    setContextMenuPosition({ x: e.pageX, y: e.pageY });
-  };
-
-  useEffect(() => {
-    const handleClick = () => setContextMenuVisible(false);
-    window.addEventListener('click', handleClick);
-    return () => window.removeEventListener('click', handleClick);
-  }, []);
-
-  //임창인(초대 코드만 복사 join chat room으로 입장해야함)
-  const copyInviteCode = async () => {
-    try {
-      await navigator.clipboard.writeText(inviteCode); // 백엔드 없이 바로 복사
-      setShowModal(true);
-      setTimeout(() => setShowModal(false), 2000);
-    } catch (err) {
-      console.error(err);
-      alert('초대 코드 복사 중 오류가 발생했습니다.');
-    }
-  };
-
-  //공유용 전체 url 복사
-  const copyInviteUrl = async () => {  // 변경: 전체 URL 복사
-    try {
-      const fullUrl = `${window.location.origin}/chat/${roomId}/${inviteCode}`;
-      await navigator.clipboard.writeText(fullUrl);
-      setModalPosition(contextMenuPosition);
-      setShowUrlCopiedModal(true);
-      setTimeout(() => setShowUrlCopiedModal(false), 2000);
-    } catch (err) {
-      console.error(err);
-      alert('초대 URL 복사 중 오류가 발생했습니다.');
-    }
-    setContextMenuVisible(false);  // 메뉴 닫기
-  };
-
-
+  //메세지 검색
   const [showSearchSidebar, setShowSearchSidebar] = useState(false);
   const [searchKeyword, setSearchKeyword] = useState('');
   const [searchResults, setSearchResults] = useState([]);
@@ -175,129 +177,54 @@ const ChatRoom = () => {
   const [totalElements, setTotalElements] = useState(0);
   const [errorMessage, setErrorMessage] = useState(null);
 
-
-  //웹소켓 연결
-  const stompClientRef = useWebSocket({
-    roomId,
-    onMessageReceived: (received)=> {
-      //메세지 상태 업데이트
-      setMessages(prev => {
-        const updated=prev.some(m => m.messageId === received.messageId)
-        ? prev.map(m => m.messageId === received.messageId ? received : m)
-        : [...prev, received];
-
-        // sendAt 기준으로 정렬 (문자열 ISO이므로 비교 가능)
-        return [...updated].sort((a, b) => new Date(a.sendAt) - new Date(b.sendAt));
-      });
-    }
-  });
-
-  const scrollToBottom = () => {
-    messagesEndRef.current?.scrollIntoView({ behavior: "instant" });
-  };
-
-  // 메시지 초기화
-  const fetchMessages = async () => {
-    try {
-      const res = await axiosInstance.get(`/${roomId}/messages`);
-      const data = res.data;
-
-      const validatedData = data.map(msg => {
-        // 날짜 유효성 검사
-        if (!msg.sendAt || new Date(msg.sendAt).getFullYear() === 1970) {
-          msg = { ...msg, sendAt: new Date().toISOString() };
-        }
-
-        return msg;
-      });
-
-      const sortedData = validatedData.sort(
-          (a, b) => new Date(a.sendAt).getTime() - new Date(b.sendAt).getTime()
-      );
-
-      setMessages(sortedData);
-    } catch (error) {
-      console.error('Error fetching messages:', error);
-    }
-  };
-
-  // 로그인 유저 정보 가져오기
-  const fetchCurrentUser = async () => {
-    try {
-      const res = await fetch('http://localhost:8080/user/details', {
-        method: 'GET',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-      });
-
-      if (!res.ok) {
-        throw new Error('로그인 정보를 가져오지 못했습니다.');
-      }
-
-      const user = await res.json(); // { id, email, nickname, profileImg }
-      setCurrentUser(user);
-    } catch (error) {
-      console.error('사용자 정보 요청 실패:', error);
-    }
-  };
-
-  useEffect(() => {
+  const handleSearch = async (keyword, page = 0) => {
+    // Check if roomId is defined before proceeding
     if (!roomId) {
-      console.error("No roomId available");
-      navigate("/");
+      setErrorMessage('채팅방 ID가 유효하지 않습니다.');
       return;
     }
+    setIsSearching(true);
+    setShowSearchSidebar(true);
+    setSearchKeyword(keyword);
+    setErrorMessage(null); // 이전 에러 메시지 초기화
 
-    setMessages([]); // 이전 채팅방 메세지 제거
+    try {
+      const response = await axiosInstance.get(`/chat/search/${roomId}`, {
+        params: {
+          keyword,
+          page,
+          size: 10
+        }
+      });
 
-    fetchCurrentUser();
-    fetchRoomInfo(); // 방 정보 가져오기 함수 호출 추가
-    fetchMessages();
+      const data = response.data;
+      const validatedResults = (data.content || []).map(msg => {
+      const sendAt = new Date(msg.sendAt);
+      const isInvalid = !msg.sendAt || isNaN(sendAt.getTime()); // NaN = Invalid Date
 
-  },[roomId]);
+      return isInvalid
+        ? { ...msg, sendAt: new Date().toISOString() }
+        : msg;
+    });
+
+      setSearchResults(validatedResults);
+      setCurrentPage(data.pageable?.pageNumber || 0);
+      setTotalPages(data.totalPages || 0);
+      setTotalElements(data.totalElements || 0);
+    } catch (err) {
+      console.error('Search error:', err);
+      setErrorMessage(err.response?.data?.message || '검색 중 오류가 발생했습니다.');
+    } finally {
+      setIsSearching(false);
+    }
+  };
 
   // 메시지가 업데이트될 때마다 아래로 스크롤
   useEffect(() => {
-    scrollToBottom();
+    messagesEndRef.current?.scrollIntoView({ behavior: "instant" });
   }, [messages]);
 
-  // 통합 메시지 전송 함수 (텍스트/코드/이미지 모두 처리)
-  const sendMessage = (overrideMessage = null) => {
-    const client = stompClientRef.current;
-    // 연결이 끊긴 경우 재연결 시도
-    if (!client.connected) {
-      client.activate();
-      alert('⚠️ 서버와 연결이 끊어졌습니다. 재연결을 시도합니다.');
-      return;
-    }
-
-    // 기본 메시지 구조
-    let baseMessage = {
-      content: content,
-      type: inputMode,
-      sendAt: new Date().toISOString(),
-      ...(inputMode === 'CODE' && { language })
-    };
-
-    // overrideMessage가 있으면 병합 (예: 이미지 메시지 전송 시)
-    const message = overrideMessage ? { ...baseMessage, ...overrideMessage } : baseMessage;
-
-    // 메시지 비어있는 경우 전송 방지
-    const trimmed = String(message.content).trim();
-    if (message.type !== 'IMAGE' && trimmed === '') {
-      return;
-    }
-
-    client.publish({
-      destination: `/chat/send-message/${roomId}`,
-      body: JSON.stringify(message)
-    });
-
-    setContent('');
-    setInputMode('TEXT');
-  };
-
-  // 검색 결과 이동
+  // 검색 결과로 스크롤 이동
   const scrollToMessage = (messageId) => {
     const messageElement = document.getElementById(`message-${messageId}`);
     if (messageElement) {
@@ -319,49 +246,8 @@ const ChatRoom = () => {
     }
   };
 
-  const handleSearch = async (keyword, page = 0) => {
-    // Check if roomId is defined before proceeding
-    if (!roomId) {
-      setErrorMessage('채팅방 ID가 유효하지 않습니다.');
-      return;
-    }
-    setIsSearching(true);
-    setShowSearchSidebar(true);
-    setSearchKeyword(keyword);
-    setErrorMessage(null); // 이전 에러 메시지 초기화
-
-  try {
-    const response = await axiosInstance.get(`/chat/search/${roomId}`, {
-      params: {
-        keyword,
-        page,
-        size: 10
-      }
-    });
-
-    const data = response.data;
-    const validatedResults = (data.content || []).map(msg => {
-      if (!msg.sendAt || new Date(msg.sendAt).getFullYear() === 1970) {
-        return { ...msg, sendAt: new Date().toISOString() };
-      }
-      return msg;
-    });
-
-      setSearchResults(validatedResults);
-      setCurrentPage(data.pageable?.pageNumber || 0);
-      setTotalPages(data.totalPages || 0);
-      setTotalElements(data.totalElements || 0);
-    } catch (err) {
-      console.error('Search error:', err);
-      setErrorMessage(err.response?.data?.message || '검색 중 오류가 발생했습니다.');
-    } finally {
-      setIsSearching(false);
-    }
-  };
-
   const [imageFile, setImageFile] = useState(null);
   const [imagePreviewUrl, setImagePreviewUrl] = useState(null);
-  // const fileInputRef = useRef(null);
 
   // 전송 버튼 클릭 시 호출되는 공통 핸들러 함수 (이미지 업로드 고려)
   const handleUnifiedSend = async () => {
@@ -398,6 +284,44 @@ const ChatRoom = () => {
     }
   };
 
+  // 메시지 전송 (텍스트/코드/이미지 모두 처리)
+  const sendMessage = (overrideMessage = null) => {
+    const client = stompClientRef.current;
+    // 연결이 끊긴 경우 재연결 시도
+    if (!client.connected) {
+      client.activate();
+      alert('⚠️ 서버와 연결이 끊어졌습니다. 재연결을 시도합니다.');
+      return;
+    }
+
+    // 기본 메시지 구조
+    let baseMessage = {
+      content: content,
+      type: inputMode,
+      sendAt: new Date().toISOString(),
+      ...(inputMode === 'CODE' && { language })
+    };
+
+    // overrideMessage가 있으면 병합 (예: 이미지 메시지 함께 전송)
+    const message = overrideMessage ? { ...baseMessage, ...overrideMessage } : baseMessage;
+
+    // 메시지 비어있는 경우 전송 방지
+    const trimmed = String(message.content).trim();
+    if (message.type !== 'IMAGE' && trimmed === '') {
+      return;
+    }
+
+    client.publish({
+      destination: `/chat/send-message/${roomId}`,
+      body: JSON.stringify(message)
+    });
+
+    setContent('');
+    setInputMode('TEXT');
+  };
+
+
+  //메세지 수정 요청
   const handleEditMessage = (messageId) => {
     const client = stompClientRef.current;
     if (!client || !client.connected) {
@@ -420,6 +344,7 @@ const ChatRoom = () => {
     setEditContent('');
   };
 
+  //메세지 삭제 요청
   const handleDeleteMessage = (messageId) => {
     const client = stompClientRef.current;
     if (!client || !client.connected) {
@@ -437,7 +362,6 @@ const ChatRoom = () => {
 
   return (
     <div
-      onContextMenu={handleContextMenu}
       style={{
         backgroundColor: '#f5f7fa',
         height: '100vh',
@@ -446,7 +370,6 @@ const ChatRoom = () => {
         boxSizing: 'border-box',
         fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif'
       }}>
-
 
       {/* Top Bar */}
       <Header></Header>
@@ -472,7 +395,7 @@ const ChatRoom = () => {
             display: 'flex',
             justifyContent: 'space-between',
             alignItems: 'center',
-            padding: '16px 24px',
+            padding: '6px 20px',
             borderBottom: '1px solid #eaedf0',
             backgroundColor: '#fff'
           }}>
@@ -533,7 +456,7 @@ const ChatRoom = () => {
             <button
               onClick={() => setMenuOpen(prev => !prev)}
               style={{
-                fontSize: '30px',
+                fontSize: '25px',
                 background: 'none',
                 border: 'none',
                 cursor: 'pointer',
@@ -621,38 +544,6 @@ const ChatRoom = () => {
             />
           </div>
 
-          {/* 우클릭 컨텍스트 메뉴 */}
-          {contextMenuVisible && (
-            <div
-              style={{
-                position: 'absolute',
-                top: contextMenuPosition.y,
-                left: contextMenuPosition.x,
-                backgroundColor: '#fff',
-                border: '1px solid #ccc',
-                borderRadius: '4px',
-                boxShadow: '0 2px 8px rgba(0,0,0,0.15)',
-                zIndex: 1000
-              }}
-            >
-              <button
-                onClick={copyInviteUrl}
-                style={{
-                  display: 'block',
-                  padding: '8px 12px',
-                  background: 'none',
-                  border: 'none',
-                  width: '100%',
-                  textAlign: 'left',
-                  cursor: 'pointer'
-                }}
-              >
-                공유 초대 링크 복사
-              </button>
-            </div>
-          )}
-
-
           {showNotification && (
             <div style={{
               position: 'fixed',
@@ -668,24 +559,6 @@ const ChatRoom = () => {
               초대 코드가 복사되었습니다.
             </div>
           )}
-
-          {showUrlCopiedModal && (
-            <div style={{
-              position: 'absolute',
-              top: modalPosition.y,
-              left: modalPosition.x,
-              transform: 'translateY(-100%)', // 모달이 클릭 위치 위로 뜨도록
-              backgroundColor: '#333',
-              color: 'white',
-              padding: '10px 16px',
-              borderRadius: '6px',
-              boxShadow: '0 4px 8px rgba(0, 0, 0, 0.2)',
-              zIndex: 2000
-            }}>
-              공유 초대 링크가 복사되었습니다
-            </div>
-          )}
-
 
           {/* 나가기 확인 모달 */}
           {showLeaveConfirm && (
@@ -725,7 +598,6 @@ const ChatRoom = () => {
             </div>
           )}
 
-
           {/* 나가기 완료 모달 */}
           {showLeaveSuccess && (
             <div style={{
@@ -738,6 +610,7 @@ const ChatRoom = () => {
             </div>
           )}
         </div>
+
         {showSearchSidebar && (
           <SearchSidebar
             searchKeyword={searchKeyword}

--- a/frontend/src/pages/signup.jsx
+++ b/frontend/src/pages/signup.jsx
@@ -79,7 +79,7 @@ function App() {
               onChange={(e) => setPassword(e.target.value)}
               placeholder="비밀번호를 입력해주세요"
               required
-              minLength="12"
+              minLength="4" //수정
             />
           </div>
 


### PR DESCRIPTION
## 🛰️ Issue Number
#102 

## 🪐 작업 내용
![image](https://github.com/user-attachments/assets/9bb480ba-0973-42e0-b9ad-b207fabcf651)
chatRoom에 쓰이는 컴포넌트들을 components/chatroom 디렉토리에 모아놓았습니다.


1. **RoomHeader**
![image](https://github.com/user-attachments/assets/16f6a802-94d0-4249-9f24-784ccd4eea12)
채팅방 상단 헤더
채팅방 이름, 초대 코드 복사 버튼, 나가기 버튼, 메세지 검색 창

2. **MessageList**
![image](https://github.com/user-attachments/assets/2d26ee55-78f4-4701-ac1e-795b5e2e407a)
메세지 목록
각 메세지 타입에 대한 조건부 렌더링 로직이 존재

3. **MessageInput**
![image](https://github.com/user-attachments/assets/4d990f76-a30a-453e-be5d-679ad33c24b2)
메세지 입력란
메세지 입력 모드(코드인지, 사진인지)에 따른 로직이 있다고 보면 됨

4. **useWebSocket**
components/common에 웹소켓에 연결하는 로직을 따로 빼놈
웹소켓 연결을 공통 함수로 처리하면 좋을듯

## 📚 참고사항
비밀번호 길이를 12자에서 4자로 줄여놨습니다.
12자 너무 힘듭니다ㅜㅜ 개발 브랜치에선 4자로 하는게 어떤가요ㅎㅎ

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?
