### PR TITLE
Refactor: 조인 성능 개선

### DIFF
--- a/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomService.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomService.java
@@ -157,10 +157,6 @@ public class ChatRoomService {
 		Page<ChatRoom> chatRooms = chatRoomRepository.findChatRoomsByParticipantId(
 			memberId, pageable);
 
-		if (chatRooms.isEmpty()) {
-			throw new ChatRoomException(ChatRoomErrorCode.CHATROOM_NOT_FOUND);
-		}
-
 		return chatRooms.map(ChatRoomMapper::toListResponse);
 	}
 

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/entity/ChatParticipant.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/entity/ChatParticipant.java
@@ -2,6 +2,7 @@ package project.backend.domain.chat.chatroom.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -25,11 +26,11 @@ public class ChatParticipant {
 	@Column(name = "chat_participant_id")
 	private Long id;
 
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "member_id")
 	private Member participant;
 
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "room_id")
 	private ChatRoom chatRoom;
 

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/entity/ChatRoom.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/entity/ChatRoom.java
@@ -34,7 +34,7 @@ public class ChatRoom {
 
 	private String inviteCode;
 
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "owner_id")
 	private Member owner;
 
@@ -45,7 +45,8 @@ public class ChatRoom {
 	private List<ChatParticipant> participants = new ArrayList<>();
 
 	@Builder
-	public ChatRoom(String name, LocalDateTime createdAt, String repositoryUrl,String inviteCode, Member owner,
+	public ChatRoom(String name, LocalDateTime createdAt, String repositoryUrl, String inviteCode,
+		Member owner,
 		List<ChatMessage> messages, List<ChatParticipant> participants) {
 		this.name = name;
 		this.createdAt = createdAt != null ? createdAt : LocalDateTime.now();


### PR DESCRIPTION
## 🛰️ Issue Number
#122 

## 🪐 작업 내용
- ManyToOne 관계 fetch 전략을 LAZY로 변경하여 불필요한 member 조인 제거
- 빈페이지인경우 404를 뿌리는 예외 제거

[쿼리 수정 전후 비교 결과]
> --------- **수정 전**
select
        cp1_0.chat_participant_id,
        cr1_0.room_id,
        cr1_0.created_at,
        cr1_0.invite_code,
        cr1_0.name,
        o1_0.member_id,
        o1_0.email,
        o1_0.github_username,
        o1_0.join_at,
        o1_0.nickname,
        o1_0.password,
        o1_0.profile_image_id,
        o1_0.provider,
        cr1_0.repository_url,
        p1_0.member_id,
        p1_0.email,
        p1_0.github_username,
        p1_0.join_at,
        p1_0.nickname,
        p1_0.password,
        p1_0.profile_image_id,
        p1_0.provider
    from
        chat_participant cp1_0
    left join
        chat_room cr1_0
            on cr1_0.room_id=cp1_0.room_id
    left join
        member o1_0
            on o1_0.member_id=cr1_0.owner_id
    left join
        member p1_0
            on p1_0.member_id=cp1_0.member_id
    where
        cp1_0.chat_participant_id=?
---------------------- **LAZY로 수정 후**
select
        cp1_0.chat_participant_id,
        cp1_0.room_id,
        cp1_0.member_id 
    from
        chat_participant cp1_0 
    where
        cp1_0.chat_participant_id=?

## 📚 Reference


## ✅ Check List
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?