### PR TITLE
Fix: ws/info 401예외발생 개선

### DIFF
--- a/backend/src/main/java/project/backend/domain/chat/chatroom/api/ChatRoomController.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/api/ChatRoomController.java
@@ -124,10 +124,4 @@ public class ChatRoomController {
 		return chatRoomService.getChatRoomByInviteCode(inviteCode);
 	}
 
-	//배문성 배포버젼 v1
-	@GetMapping("/{roomId}/check/exists")
-	public boolean existsMember(@AuthenticationPrincipal MemberDetails memberDetails,
-		@PathVariable Long roomId) {
-		return chatRoomService.checkMemberExistsInChatRoom(memberDetails, roomId);
-	}
 }

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomService.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomService.java
@@ -157,10 +157,6 @@ public class ChatRoomService {
 		Page<ChatRoom> chatRooms = chatRoomRepository.findChatRoomsByParticipantId(
 			memberId, pageable);
 
-		if (chatRooms.isEmpty()) {
-			throw new ChatRoomException(ChatRoomErrorCode.CHATROOM_NOT_FOUND);
-		}
-
 		return chatRooms.map(ChatRoomMapper::toListResponse);
 	}
 

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/dao/ChatRoomRepository.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/dao/ChatRoomRepository.java
@@ -26,17 +26,5 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
 	Page<ChatRoom> findAllRoomsByOwnerId(Long ownerId, Pageable pageable);
 
-
-	@Query("""
-		SELECT CASE WHEN COUNT(cr) > 0 THEN true ELSE false END
-		FROM ChatRoom cr
-		JOIN cr.participants cp
-		WHERE cr.id = :roomId
-		AND cp.participant.id = :memberId
-		""")
-	boolean existsByRoomIdAndParticipantId(
-		@Param("roomId") Long roomId,
-		@Param("memberId") Long memberId
-	);
 }
 

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/entity/ChatParticipant.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/entity/ChatParticipant.java
@@ -2,6 +2,7 @@ package project.backend.domain.chat.chatroom.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -25,11 +26,11 @@ public class ChatParticipant {
 	@Column(name = "chat_participant_id")
 	private Long id;
 
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "member_id")
 	private Member participant;
 
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "room_id")
 	private ChatRoom chatRoom;
 

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/entity/ChatRoom.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/entity/ChatRoom.java
@@ -34,7 +34,7 @@ public class ChatRoom {
 
 	private String inviteCode;
 
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "owner_id")
 	private Member owner;
 
@@ -45,7 +45,8 @@ public class ChatRoom {
 	private List<ChatParticipant> participants = new ArrayList<>();
 
 	@Builder
-	public ChatRoom(String name, LocalDateTime createdAt, String repositoryUrl,String inviteCode, Member owner,
+	public ChatRoom(String name, LocalDateTime createdAt, String repositoryUrl, String inviteCode,
+		Member owner,
 		List<ChatMessage> messages, List<ChatParticipant> participants) {
 		this.name = name;
 		this.createdAt = createdAt != null ? createdAt : LocalDateTime.now();

--- a/backend/src/main/java/project/backend/global/config/security/SecurityConfig.java
+++ b/backend/src/main/java/project/backend/global/config/security/SecurityConfig.java
@@ -65,7 +65,7 @@ public class SecurityConfig {
 						"/github/**")
 					.anonymous()
 
-					.requestMatchers("/auth", "/oauth/**", "/webhook", "/github/**")
+					.requestMatchers("/auth", "/oauth/**", "/webhook", "/github/**","/ws/**")
 					.permitAll()
 
 					.anyRequest()

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -69,3 +69,7 @@ jwt:
   info:
     issuer: "대한민국26세 달성 배씨 배문성의 허가가 있는 토큰이올시다."
     secret: 36b2294c1079470409d860ac57402fc152524d134a75b7cb223d92644b63adba980d90dcefd0d53c02a5cbb43c2678d49128dae2299f652f5f71033fee640686
+
+#logging:
+#  level:
+#    root: DEBUG

--- a/frontend/src/components/SideBar.jsx
+++ b/frontend/src/components/SideBar.jsx
@@ -50,7 +50,10 @@ const Sidebar = () => {
     if (chatRooms.length === 0) return;
 
     const client = new Client({
-      webSocketFactory: () => new SockJS('https://52.78.93.133/ws'),
+      webSocketFactory: () => new SockJS('https://52.78.93.133/ws', null, {
+        transports: ['websocket'],
+        withCredentials: true
+      }),
       reconnectDelay: 1000,
       heartbeatIncoming: 15000,
       heartbeatOutgoing: 10000,

--- a/frontend/src/components/common/useWebSocket.jsx
+++ b/frontend/src/components/common/useWebSocket.jsx
@@ -16,7 +16,10 @@ const useWebSocket = ({
 
     useEffect(() => {
         const client = new Client({
-            webSocketFactory: () => new SockJS('https://52.78.93.133/ws'),
+            webSocketFactory: () => new SockJS('https://52.78.93.133/ws', null, {
+                transports: ['websocket'],
+                withCredentials: true
+            }),
             reconnectDelay: 1000,
             heartbeatIncoming: 15000,
             heartbeatOutgoing: 10000,

--- a/frontend/src/components/modals/RoomInfoModal.jsx
+++ b/frontend/src/components/modals/RoomInfoModal.jsx
@@ -9,6 +9,7 @@ import {
 import SockJS from 'sockjs-client';
 import { Client } from '@stomp/stompjs';
 import axiosInstance from "../api/axiosInstance"
+import transportList from 'sockjs-client/lib/transport-list';
 
 const RoomInfoModal = ({ room, sidebarRef, onClose, showToast }) => {
   const [participants, setParticipants] = useState([]);
@@ -37,7 +38,10 @@ const RoomInfoModal = ({ room, sidebarRef, onClose, showToast }) => {
 
     if (!room?.roomId) return;
 
-    const socket = new SockJS('https://52.78.93.133/ws');
+    const socket = new SockJS('https://52.78.93.133/ws', null, {
+        transports: ['websocket'],
+        withCredentials: true
+    });
     const stomp = new Client({
       webSocketFactory: () => socket,
       reconnectDelay: 5000,


### PR DESCRIPTION
## 🛰️ Issue Number
#124 

## 🪐 작업 내용
해당 예외발생시 쿠키가 담겨있지 않았기에
```javascript
      webSocketFactory: () => new SockJS('https://52.78.93.133/ws', null, {
        transports: ['websocket'],
        withCredentials: true
      }),
```
위와 같이 수정하고 서버에서도 일단 /ws/**를 permitAll로 설정해놨습니다.

서버를 가동시킨 결과 해당 예외는 더이상 뜨지 않은것 같으나 확실하진 않습니다. 인증 부분에 문제가 있어 간혈적으로 튕기긴하는 것 같은데 해당 문제는 원인을 파악중입니다.

## 📚 Reference


## ✅ Check List
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?