### PR TITLE
Fix: 채팅방 나가기 소프트 딜리트

### DIFF
--- a/backend/src/main/java/project/backend/domain/chat/chatmessage/dao/ChatMessageRepository.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatmessage/dao/ChatMessageRepository.java
@@ -10,18 +10,6 @@ import org.springframework.data.repository.query.Param;
 import project.backend.domain.chat.chatmessage.entity.ChatMessage;
 
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
-
-//	@Query(value = """
-//		select m.room_id
-//		from chat_message m
-//		join chat_participant cp on cp.room_id = m.room_id
-//		join member mb on cp.member_id = mb.member_id
-//		where mb.email = :email
-//		order by m.send_at desc
-//		limit 1
-//		""", nativeQuery = true)
-//	Optional<Long> findMostRecentRoomIdByMemberEmail(@Param("email") String email);
-
 	@Query("""
         SELECT cm.chatRoom.id 
         FROM ChatMessage cm

--- a/backend/src/main/java/project/backend/domain/chat/chatmessage/dao/ChatMessageRepository.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatmessage/dao/ChatMessageRepository.java
@@ -11,16 +11,26 @@ import project.backend.domain.chat.chatmessage.entity.ChatMessage;
 
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
 
-	@Query(value = """
-		select m.room_id 
-		from chat_message m 
-		join chat_participant cp on cp.room_id = m.room_id 
-		join member mb on cp.member_id = mb.member_id 
-		where mb.email = :email 
-		order by m.send_at desc 
-		limit 1
-		""", nativeQuery = true)
-	Optional<Long> findMostRecentRoomIdByMemberEmail(@Param("email") String email);
+//	@Query(value = """
+//		select m.room_id
+//		from chat_message m
+//		join chat_participant cp on cp.room_id = m.room_id
+//		join member mb on cp.member_id = mb.member_id
+//		where mb.email = :email
+//		order by m.send_at desc
+//		limit 1
+//		""", nativeQuery = true)
+//	Optional<Long> findMostRecentRoomIdByMemberEmail(@Param("email") String email);
+
+	@Query("""
+        SELECT cm.chatRoom.id 
+        FROM ChatMessage cm
+        JOIN ChatParticipant cp ON cp.chatRoom.id = cm.chatRoom.id AND cp.participant.email = :email
+        WHERE cp.isActive = true
+        ORDER BY cm.sendAt DESC
+        LIMIT 1
+        """)
+	Optional<Long> findMostRecentRoomIdByMemberEmailAndIsActiveTrue(@Param("email") String email);
 
 	@Query(value = """
 		SELECT * 
@@ -33,4 +43,5 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
 	List<ChatMessage> findByChatRoom_IdOrderBySendAtAsc(Long roomId);
 
 	List<ChatMessage> findByIdIn(List<Long> ids);
+
 }

--- a/backend/src/main/java/project/backend/domain/chat/chatmessage/mapper/ChatMessageMapper.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatmessage/mapper/ChatMessageMapper.java
@@ -11,6 +11,7 @@ import project.backend.domain.chat.chatmessage.entity.ChatMessage;
 import project.backend.domain.chat.chatmessage.entity.ChatMessageSearch;
 import project.backend.domain.chat.chatmessage.entity.MessageType;
 import project.backend.domain.chat.chatroom.dto.event.JoinChatRoomEvent;
+import project.backend.domain.chat.chatroom.dto.event.LeaveChatRoomEvent;
 import project.backend.domain.chat.chatroom.entity.ChatParticipant;
 import project.backend.domain.chat.chatroom.entity.ChatRoom;
 import project.backend.domain.chat.github.dto.GitMessageDto;
@@ -71,6 +72,17 @@ public class ChatMessageMapper {
 			.content(joinEvent.nickname() + "님이 입장했습니다.")
 			.type(MessageType.EVENT)
 			.sendAt(joinEvent.joinAt())
+			.build();
+	}
+
+	public ChatMessage toEntityWithEventLeave(ChatRoom room, ChatParticipant participant,
+		LeaveChatRoomEvent leaveEvent) {
+		return ChatMessage.builder()
+			.chatRoom(room)
+			.sender(participant)
+			.content(leaveEvent.nickname() + "님이 나갔습니다.")
+			.type(MessageType.EVENT)
+			.sendAt(LocalDateTime.now())
 			.build();
 	}
 

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomService.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomService.java
@@ -22,6 +22,7 @@ import project.backend.domain.chat.chatroom.dto.InviteJoinResponse;
 import project.backend.domain.chat.chatroom.dto.MyChatRoomResponse;
 import project.backend.domain.chat.chatroom.dto.ParticipantResponse;
 import project.backend.domain.chat.chatroom.dto.event.JoinChatRoomEvent;
+import project.backend.domain.chat.chatroom.dto.event.LeaveChatRoomEvent;
 import project.backend.domain.chat.chatroom.entity.ChatParticipant;
 import project.backend.domain.chat.chatroom.entity.ChatRoom;
 import project.backend.domain.chat.github.app.GitMessageService;
@@ -100,7 +101,6 @@ public class ChatRoomService {
 	@Transactional
 	public InviteJoinResponse joinChatRoom(String inviteCode, Long memberId) {
 		ChatRoom room = findByInviteCode(inviteCode);
-
 		Member member = memberService.getMemberById(memberId);
 
 		boolean isAlreadyParticipant = chatParticipantRepository
@@ -125,15 +125,16 @@ public class ChatRoomService {
 
 	public Long getMostRecentRoomId(String email) {
 
-		// 1순위: 가장 최근 메시지가 도착한 채팅방
-		Optional<Long> recentRoomId = chatMessageRepository.findMostRecentRoomIdByMemberEmail(
-			email);
+		// 1순위: 가장 최근 메시지가 도착한 활성 참가자인 채팅방
+		Optional<Long> recentRoomId = chatMessageRepository
+			.findMostRecentRoomIdByMemberEmailAndIsActiveTrue(email);
 		if (recentRoomId.isPresent()) {
 			return recentRoomId.get();
 		}
 
-		// 2순위: 채팅방에 메세지가 없을 때 참여중인 채팅방 중 roomId가 가장 큰 채팅방
-		Optional<Long> fallbackRoomId = chatParticipantRepository.findMostLargeRoomIdByEmail(email);
+		// 2순위: 활성 참가자인 채팅방 중 roomId가 가장 큰 채팅방
+		Optional<Long> fallbackRoomId = chatParticipantRepository
+			.findMostLargeRoomIdByEmailAndIsActiveTrue(email);
 		if (fallbackRoomId.isPresent()) {
 			return fallbackRoomId.get();
 		}
@@ -144,7 +145,7 @@ public class ChatRoomService {
 	}
 
 	public Page<MyChatRoomResponse> findAllRoomsByOwnerId(Long memberId, Pageable pageable) {
-		Page<ChatRoom> allRoomsByOwnerId = chatRoomRepository.findAllRoomsByOwnerId(memberId,
+		Page<ChatRoom> allRoomsByOwnerId = chatRoomRepository.findActiveChatRoomsByParticipantId(memberId,
 			pageable);
 
 		return allRoomsByOwnerId.map(ChatRoomMapper::toProfileResponse);
@@ -154,7 +155,7 @@ public class ChatRoomService {
 	@Transactional(readOnly = true)
 	public Page<ChatRoomNameResponse> findChatRoomsByMemberId(Long memberId, Pageable pageable) {
 
-		Page<ChatRoom> chatRooms = chatRoomRepository.findChatRoomsByParticipantId(
+		Page<ChatRoom> chatRooms = chatRoomRepository.findActiveChatRoomsByParticipantId(
 			memberId, pageable);
 
 		if (chatRooms.isEmpty()) {
@@ -170,9 +171,7 @@ public class ChatRoomService {
 		ChatRoom chatRoom = chatRoomRepository.findById(roomId)
 			.orElseThrow(() -> new ChatRoomException(ChatRoomErrorCode.CHATROOM_NOT_FOUND));
 
-		List<ChatParticipant> participants = chatParticipantRepository.findByChatRoom(chatRoom);
-
-		Member owner = chatRoom.getOwner();
+		List<ChatParticipant> participants = chatParticipantRepository.findByChatRoomAndIsActiveTrue(chatRoom);
 
 		return participants.stream()
 			.map(ChatRoomMapper::toParticipantResponse).collect(Collectors.toList());
@@ -187,11 +186,16 @@ public class ChatRoomService {
 			throw new ChatRoomException(ChatRoomErrorCode.OWNER_CANNOT_LEAVE);
 		}
 
-		ChatParticipant participant = chatParticipantRepository.findByChatRoomIdAndParticipantId(
-				roomId, memberId)
+		ChatParticipant participant = chatParticipantRepository
+			.findByChatRoomIdAndParticipantIdAndIsActiveTrue(roomId, memberId)
 			.orElseThrow(() -> new ChatRoomException(ChatRoomErrorCode.NOT_PARTICIPANT));
 
-		room.getParticipants().remove(participant);
+		participant.leave();
+
+		eventPublisher.publishEvent(
+			new LeaveChatRoomEvent(roomId, memberId,
+				participant.getParticipant().getNickname())
+		);
 	}
 
 	private ChatRoom findByInviteCode(String inviteCode) {

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomService.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomService.java
@@ -145,7 +145,7 @@ public class ChatRoomService {
 	}
 
 	public Page<MyChatRoomResponse> findAllRoomsByOwnerId(Long memberId, Pageable pageable) {
-		Page<ChatRoom> allRoomsByOwnerId = chatRoomRepository.findActiveChatRoomsByParticipantId(memberId,
+		Page<ChatRoom> allRoomsByOwnerId = chatRoomRepository.findAllRoomsByOwnerId(memberId,
 			pageable);
 
 		return allRoomsByOwnerId.map(ChatRoomMapper::toProfileResponse);

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/dao/ChatParticipantRepository.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/dao/ChatParticipantRepository.java
@@ -16,22 +16,36 @@ public interface ChatParticipantRepository extends JpaRepository<ChatParticipant
 
 	//fixme chat_participant에 join_at 추가해서 가장 마지막에 참여한 채팅방을 반환하도록 변경
 	@Query("""
-		select cp.chatRoom.id 
-		from ChatParticipant cp 
-		where cp.participant.email = :email 
-		order by cp.chatRoom.id desc 
-		limit 1
-		""")
-	Optional<Long> findMostLargeRoomIdByEmail(@Param("email") String email);
+        SELECT cp.chatRoom.id 
+        FROM ChatParticipant cp 
+        WHERE cp.participant.email = :email 
+        AND cp.isActive = true
+        ORDER BY cp.chatRoom.id DESC
+        LIMIT 1
+        """)
+	Optional<Long> findMostLargeRoomIdByEmailAndIsActiveTrue(@Param("email") String email);
 
 	boolean existsByParticipantIdAndChatRoomId(Long participantId, Long chatRoomId);
 
 	@EntityGraph(attributePaths = {"participant"})
-	List<ChatParticipant> findByChatRoom(ChatRoom chatRoom);
+	@Query("SELECT cp FROM ChatParticipant cp WHERE cp.chatRoom = :chatRoom AND cp.isActive = true")
+	List<ChatParticipant> findByChatRoomAndIsActiveTrue(@Param("chatRoom") ChatRoom chatRoom);
 
 	Optional<ChatParticipant> findByChatRoomIdAndParticipantId(Long chatRoomId, Long participantId);
 
 	Optional<ChatParticipant> findByChatRoom_IdAndParticipant_Id(Long ChatRoomId,
 		Long participantId);
+
+	@Query("""
+		SELECT cp FROM ChatParticipant cp 
+		WHERE cp.chatRoom.id = :roomId 
+		AND cp.participant.id = :participantId 
+		AND cp.isActive = true
+		""")
+	Optional<ChatParticipant> findByChatRoomIdAndParticipantIdAndIsActiveTrue(
+		@Param("roomId") Long roomId,
+		@Param("participantId") Long participantId
+	);
+
 }
 

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/dao/ChatRoomRepository.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/dao/ChatRoomRepository.java
@@ -14,17 +14,20 @@ import project.backend.domain.chat.chatroom.entity.ChatRoom;
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
 	@Query("""
-		SELECT DISTINCT cr
-		FROM ChatRoom cr
-		JOIN cr.participants cp
-		WHERE cp.participant.id = :memberId
-		""")
-	Page<ChatRoom> findChatRoomsByParticipantId(@Param("memberId") Long memberId,
-		Pageable pageable);
+        SELECT DISTINCT cr 
+        FROM ChatRoom cr
+        JOIN cr.participants cp
+        WHERE cp.participant.id = :memberId
+        AND cp.isActive = true
+        ORDER BY cr.createdAt DESC
+        """)
+	Page<ChatRoom> findActiveChatRoomsByParticipantId(
+		@Param("memberId") Long memberId,
+		Pageable pageable
+	);
 
 	Optional<ChatRoom> findByInviteCode(String inviteCode);
 	
 	Page<ChatRoom> findAllRoomsByOwnerId(Long ownerId, Pageable pageable);
-
 }
 

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/dto/event/LeaveChatRoomEvent.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/dto/event/LeaveChatRoomEvent.java
@@ -1,0 +1,5 @@
+package project.backend.domain.chat.chatroom.dto.event;
+
+public record LeaveChatRoomEvent(Long roomId, Long memberId, String nickname) {
+
+}

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/entity/ChatParticipant.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/entity/ChatParticipant.java
@@ -33,6 +33,9 @@ public class ChatParticipant {
 	@JoinColumn(name = "room_id")
 	private ChatRoom chatRoom;
 
+	@Column(name = "is_active", nullable = false)
+	private Boolean isActive = true;
+
 	@Builder
 	public ChatParticipant(Long id, Member participant, ChatRoom chatRoom) {
 		this.id = id;
@@ -47,5 +50,8 @@ public class ChatParticipant {
 			.build();
 	}
 
+	public void leave() {
+		this.isActive = false;
+	}
 }
 

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/listener/ChatRoomEventListener.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/listener/ChatRoomEventListener.java
@@ -15,6 +15,7 @@ import project.backend.domain.chat.chatroom.app.ChatRoomService;
 import project.backend.domain.chat.chatroom.dao.ChatParticipantRepository;
 import project.backend.domain.chat.chatroom.dao.ChatRoomRepository;
 import project.backend.domain.chat.chatroom.dto.event.EventMessageResponse;
+import project.backend.domain.chat.chatroom.dto.event.LeaveChatRoomEvent;
 import project.backend.domain.chat.chatroom.entity.ChatParticipant;
 import project.backend.domain.chat.chatroom.entity.ChatRoom;
 import project.backend.domain.chat.chatroom.dto.event.JoinChatRoomEvent;
@@ -52,6 +53,30 @@ public class ChatRoomEventListener {
 		// 채팅방 인원 갱신 트리거 전송
 		simpMessagingTemplate.convertAndSend("/topic/chat/" + joinEvent.roomId() + "/refresh",
 			joinEvent.roomId());
+	}
+
+	@Async
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void handleMemberLeave(LeaveChatRoomEvent leaveEvent) {
+		ChatRoom chatRoom = chatRoomService.getRoomById(leaveEvent.roomId());
+
+		ChatParticipant participant = chatParticipantRepository
+			.findByChatRoomIdAndParticipantId(leaveEvent.roomId(), leaveEvent.memberId())
+			.orElseThrow(() -> new ChatRoomException(ChatRoomErrorCode.CHATROOM_NOT_FOUND));
+
+		ChatMessage message = chatMessageMapper.toEntityWithEventLeave(chatRoom, participant,
+			leaveEvent);
+		chatMessageRepository.save(message);
+
+		EventMessageResponse eventMessageResponse = ChatRoomMapper.toLeaveEventMessageResponse(
+			leaveEvent);
+
+		simpMessagingTemplate.convertAndSend("/topic/chat/" + leaveEvent.roomId(),
+			eventMessageResponse);
+
+		simpMessagingTemplate.convertAndSend("/topic/chat/" + leaveEvent.roomId() + "/refresh",
+			leaveEvent.roomId());
+
 	}
 
 	private ChatParticipant getParticipantByRoomAndMember(Long roomId, Long memberId) {

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/mapper/ChatRoomMapper.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/mapper/ChatRoomMapper.java
@@ -74,7 +74,9 @@ public class ChatRoomMapper {
 		return MyChatRoomResponse.builder()
 			.roomId(chatRoom.getId())
 			.roomName(chatRoom.getName())
-			.participantCount(chatRoom.getParticipants().size())
+			.participantCount((int) chatRoom.getParticipants().stream()
+				.filter(ChatParticipant::getIsActive)
+				.count())	//참여중인(isActive==true) 참가자의 수만 세도록
 			.inviteCode(chatRoom.getInviteCode())
 			.build();
 	}

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/mapper/ChatRoomMapper.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/mapper/ChatRoomMapper.java
@@ -13,6 +13,7 @@ import project.backend.domain.chat.chatroom.dto.InviteJoinResponse;
 import project.backend.domain.chat.chatroom.dto.MyChatRoomResponse;
 import project.backend.domain.chat.chatroom.dto.event.EventMessageResponse;
 import project.backend.domain.chat.chatroom.dto.event.JoinChatRoomEvent;
+import project.backend.domain.chat.chatroom.dto.event.LeaveChatRoomEvent;
 import project.backend.domain.chat.chatroom.entity.ChatParticipant;
 import project.backend.domain.chat.chatroom.entity.ChatRoom;
 import project.backend.domain.imagefile.ImageFile;
@@ -97,6 +98,16 @@ public class ChatRoomMapper {
 			.sender(joinEvent.nickname())
 			.content(joinEvent.nickname() + "님이 입장했습니다.")
 			.sendAt(joinEvent.joinAt())
+			.build();
+	}
+
+	public static EventMessageResponse toLeaveEventMessageResponse(LeaveChatRoomEvent leaveEvent) {
+		return EventMessageResponse.builder()
+			.type(MessageType.EVENT)
+			.roomId(leaveEvent.roomId())
+			.sender(leaveEvent.nickname())
+			.content(leaveEvent.nickname() + "님이 나갔습니다.")
+			.sendAt(LocalDateTime.now())
 			.build();
 	}
 }

--- a/frontend/src/components/chatroom/RoomHeader.jsx
+++ b/frontend/src/components/chatroom/RoomHeader.jsx
@@ -20,7 +20,6 @@ const RoomHeader= ({roomName, inviteCode, onSearch, onLeaveRoom}) => {
             setTimeout(() => {
                 setShowLeaveSuccess(false);
                 navigate('/'); 
-       
             }, 500);
         } else {
             alert(result.error);

--- a/frontend/src/components/chatroom/RoomHeader.jsx
+++ b/frontend/src/components/chatroom/RoomHeader.jsx
@@ -19,7 +19,8 @@ const RoomHeader= ({roomName, inviteCode, onSearch, onLeaveRoom}) => {
             setShowLeaveSuccess(true);
             setTimeout(() => {
                 setShowLeaveSuccess(false);
-                navigate('/');
+                navigate('/'); 
+       
             }, 500);
         } else {
             alert(result.error);


### PR DESCRIPTION
## 🛰️ Issue Number
#125 

## 🪐 작업 내용
<img width="419" alt="image" src="https://github.com/user-attachments/assets/307f8be9-567f-4ae3-b83a-287049f4d0d5" /><br>
ChatParticipant엔티티에 isActive라는 채팅방에 참여중 or 미참여중 필드 추가
그에 따라 바뀌는 코드들 최대한 수정했는데 파일 한번 봐주세용

<img width="1239" alt="image" src="https://github.com/user-attachments/assets/67005c85-0846-4d58-8810-6a5bf0789a95" />
채팅방 나갈시 채팅 메세지뜸.

채팅방 나간 당사자는 사이드바에서 채팅방이 사라지며, 최근 채팅방으로 이동. 

<img width="1235" alt="image" src="https://github.com/user-attachments/assets/9b2cf008-588e-4d97-897d-c58eaf31e9a3" />
나가더라도 메시지 모두 남아있음.

<h3> 추가할 사항<br>
1. 재입장 로직<br>
2. A님이 입장했습니다 라는 알림 메시지가 나가게 되면 사라지는 버그가 있음. 새로고침 하면 다시 생김.

## 📚 Reference


## ✅ Check List
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?