### PR TITLE
Feat: 이미지 관리를 위한 S3파일시스템 구축과 적용 및 서버 상시 개방 시도

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -53,6 +53,9 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
 
+    implementation 'io.awspring.cloud:spring-cloud-aws-starter:3.1.1'
+    implementation 'com.amazonaws:aws-java-sdk-s3:1.12.767'
+
     testCompileOnly 'org.projectlombok:lombok'
     testAnnotationProcessor 'org.projectlombok:lombok'
 }

--- a/backend/src/main/java/project/backend/domain/imagefile/ImageFile.java
+++ b/backend/src/main/java/project/backend/domain/imagefile/ImageFile.java
@@ -34,19 +34,12 @@ public class ImageFile {
     @Enumerated(EnumType.STRING)
     private ImageType imageType;
 
-    public static ImageFile ofProfile(String storeFileName, String uploadFileName) {
+    public static ImageFile of(String storeFileName, String uploadFileName, ImageType imageType) {
         return ImageFile.builder()
                 .storeFileName(storeFileName)
                 .uploadFileName(uploadFileName)
-                .imageType(ImageType.PROFILE_IMAGE)
+                .imageType(imageType)
                 .build();
     }
 
-    public static ImageFile ofChat(String storeFileName, String uploadFileName) {
-        return ImageFile.builder()
-                .storeFileName(storeFileName)
-                .uploadFileName(uploadFileName)
-                .imageType(ImageType.CHAT_IMAGE)
-                .build();
-    }
 }

--- a/backend/src/main/java/project/backend/domain/imagefile/ImageFileService.java
+++ b/backend/src/main/java/project/backend/domain/imagefile/ImageFileService.java
@@ -1,6 +1,7 @@
 package project.backend.domain.imagefile;
 
 
+import com.amazonaws.AmazonServiceException;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.ObjectMetadata;
@@ -17,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 import project.backend.global.exception.ex.ImageFileException;
 import project.backend.global.exception.errorcode.ImageFileErrorCode;
+import software.amazon.awssdk.core.exception.SdkClientException;
 
 @Slf4j
 @Service
@@ -53,8 +55,7 @@ public class ImageFileService {
 			metadata.setContentLength(file.getSize());
 
 			// 업로드 실행
-			amazonS3.putObject(new PutObjectRequest(bucket, s3Key, file.getInputStream(), metadata)
-				.withCannedAcl(CannedAccessControlList.PublicRead));
+			amazonS3.putObject(new PutObjectRequest(bucket, s3Key, file.getInputStream(), metadata));
 
 			ImageFile imageFile = ImageFile.of(storeFileName, uploadFileName, type);
 			imageFileRepository.save(imageFile);
@@ -62,7 +63,7 @@ public class ImageFileService {
 			return imageFile;
 
 			// db에 메타데이터 저장
-		} catch (IOException e) {
+		} catch (IOException | SdkClientException | AmazonServiceException e) {
 			log.error("파일 업로드 실패",e);
 			throw new ImageFileException(ImageFileErrorCode.FILE_SAVE_FAILURE);
 		}
@@ -71,8 +72,8 @@ public class ImageFileService {
 
 	private String getS3Key(ImageType type, String storeFileName) {
 		return switch (type) {
-			case PROFILE_IMAGE -> "profile" + "/" + storeFileName;
-			case CHAT_IMAGE -> "chat" + "/" + storeFileName;
+			case PROFILE_IMAGE -> "images/profile/" + storeFileName;
+			case CHAT_IMAGE -> "images/chat/" + storeFileName;
 			default -> throw new ImageFileException(ImageFileErrorCode.INVALID_ROUTE);
 		};
 	}

--- a/backend/src/main/java/project/backend/domain/imagefile/ImageFileService.java
+++ b/backend/src/main/java/project/backend/domain/imagefile/ImageFileService.java
@@ -2,9 +2,10 @@ package project.backend.domain.imagefile;
 
 
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
 import java.io.IOException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
 import java.util.UUID;
 
@@ -29,14 +30,13 @@ public class ImageFileService {
 	@Value("${cloud.aws.s3.bucket}")
 	private String bucket;
 
-
 	@Transactional
 	public ImageFile saveImageFile(MultipartFile file, ImageType type) {
 
-		log.info("Saving profile image file");
+		log.info("Saving image file");
 		String uploadFileName = file.getOriginalFilename();
 
-		checkExtension(uploadFileName);
+		checkFileValidation(uploadFileName);
 		checkFileTypeIsImage(file.getContentType());
 
 		String extension = uploadFileName.substring(uploadFileName.lastIndexOf(".")).toLowerCase();
@@ -44,32 +44,38 @@ public class ImageFileService {
 		checkFileExtensionIsImage(extension);
 
 		String storeFileName = UUID.randomUUID() + extension;
-
-		Path savePath;
-		if (type.equals(ImageType.PROFILE_IMAGE)) {
-			savePath = Paths.get(profilePath, storeFileName);
-		} else if (type.equals(ImageType.CHAT_IMAGE)) {
-			savePath = Paths.get(chatImagePath, storeFileName);
-		} else {
-			throw new ImageFileException(ImageFileErrorCode.INVALID_ROUTE);
-		}
-
-		ImageFile imageFile = ImageFile.ofProfile(storeFileName, uploadFileName);
-		imageFileRepository.saveAndFlush(imageFile);
-		log.info("Saved Metadata of profile image file");
+		String s3Key = getS3Key(type, storeFileName);
 
 		try {
-			log.info("📁 저장 경로: {}", savePath.toAbsolutePath());
-			file.transferTo(savePath);
+			// 메타데이터 설정
+			ObjectMetadata metadata = new ObjectMetadata();
+			metadata.setContentType(file.getContentType());
+			metadata.setContentLength(file.getSize());
+
+			// 업로드 실행
+			amazonS3.putObject(new PutObjectRequest(bucket, s3Key, file.getInputStream(), metadata)
+				.withCannedAcl(CannedAccessControlList.PublicRead));
+
+			ImageFile imageFile = ImageFile.of(storeFileName, uploadFileName, type);
+			imageFileRepository.save(imageFile);
+
 			return imageFile;
 
+			// db에 메타데이터 저장
 		} catch (IOException e) {
-			imageFileRepository.delete(imageFile);
-			log.error("파일 저장 중 IOException 발생", e);
+			log.error("파일 업로드 실패",e);
 			throw new ImageFileException(ImageFileErrorCode.FILE_SAVE_FAILURE);
 		}
+
 	}
 
+	private String getS3Key(ImageType type, String storeFileName) {
+		return switch (type) {
+			case PROFILE_IMAGE -> "profile" + "/" + storeFileName;
+			case CHAT_IMAGE -> "chat" + "/" + storeFileName;
+			default -> throw new ImageFileException(ImageFileErrorCode.INVALID_ROUTE);
+		};
+	}
 
 	private void checkFileExtensionIsImage(String extension) {
 		List<String> imageExtensions = List.of(".jpg", ".jpeg", ".png", ".gif", ".bmp", ".webp");
@@ -84,7 +90,7 @@ public class ImageFileService {
 		}
 	}
 
-	private void checkExtension(String fileName) {
+	private void checkFileValidation(String fileName) {
 		if (fileName == null || !fileName.contains(".")) {
 			throw new ImageFileException(ImageFileErrorCode.INVALID_IMAGE_TYPE);
 		}

--- a/backend/src/main/java/project/backend/domain/imagefile/ImageFileService.java
+++ b/backend/src/main/java/project/backend/domain/imagefile/ImageFileService.java
@@ -1,6 +1,7 @@
 package project.backend.domain.imagefile;
 
 
+import com.amazonaws.services.s3.AmazonS3;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -23,11 +24,11 @@ public class ImageFileService {
 
 	private final ImageFileRepository imageFileRepository;
 
-	@Value("${file.images.profile.path}")
-	private String profilePath;
+	private final AmazonS3 amazonS3;
 
-	@Value("${file.images.chat.path}")
-	private String chatImagePath;
+	@Value("${cloud.aws.s3.bucket}")
+	private String bucket;
+
 
 	@Transactional
 	public ImageFile saveImageFile(MultipartFile file, ImageType type) {

--- a/backend/src/main/java/project/backend/global/config/aws/S3Config.java
+++ b/backend/src/main/java/project/backend/global/config/aws/S3Config.java
@@ -1,0 +1,32 @@
+package project.backend.global.config.aws;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+
+	@Value("${cloud.aws.credentials.access-key}")
+	private String accessKey;
+
+	@Value("${cloud.aws.credentials.secret-key}")
+	private String secretKey;
+
+	@Value("${cloud.aws.region.static}")
+	private String region;
+
+	@Bean
+	public AmazonS3 amazonS3() {
+		BasicAWSCredentials awsCreds = new BasicAWSCredentials(accessKey, secretKey);
+		return AmazonS3ClientBuilder.standard()
+			.withRegion(region)
+			.withCredentials(new AWSStaticCredentialsProvider(awsCreds))
+			.build();
+	}
+
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -70,6 +70,17 @@ jwt:
     issuer: "대한민국26세 달성 배씨 배문성의 허가가 있는 토큰이올시다."
     secret: 36b2294c1079470409d860ac57402fc152524d134a75b7cb223d92644b63adba980d90dcefd0d53c02a5cbb43c2678d49128dae2299f652f5f71033fee640686
 
+
+cloud:
+  aws:
+    credentials:
+      access-key: ${AWS_ACCESS_KEY}
+      secret-key: ${AWS_SECRET_KEY}
+    region:
+      static: ap-northeast-2
+    s3:
+      bucket: devchat-images
+
 #logging:
 #  level:
 #    root: DEBUG

--- a/frontend/src/components/SearchSideBar.jsx
+++ b/frontend/src/components/SearchSideBar.jsx
@@ -127,7 +127,7 @@ const SearchSidebar = ({
               
               <div style={{ display: 'flex' }}>
                 <img
-                  src={`https://52.78.93.133/images/profile/${msg.profileImageUrl}`}
+                  src={`https://d31jo47k92du0.cloudfront.net/images/profile/${msg.profileImageUrl}`}
                   alt="profile"
                   style={{
                     width: '40px',

--- a/frontend/src/components/chatroom/MessageList.jsx
+++ b/frontend/src/components/chatroom/MessageList.jsx
@@ -344,7 +344,7 @@ const MessageContent = ({msg, editMessageId, editContent, setEditContent, handle
         boxShadow: '0 1px 4px rgba(0, 0, 0, 0.05)'
       }}>
         <img
-          src={`https://52.78.93.133/images/chat/${msg.chatImageUrl}`}
+          src={`https://d31jo47k92du0.cloudfront.net/images/chat/${msg.chatImageUrl}`}
           alt="업로드된 이미지"
           style={{
             width: '100%',

--- a/frontend/src/components/header.jsx
+++ b/frontend/src/components/header.jsx
@@ -63,7 +63,7 @@ export function Header() {
           ) : (
             <a href= {"/myprofile"}>
             <img 
-              src={`https://52.78.93.133/images/profile/${profileImage}`}
+              src={`https://d31jo47k92du0.cloudfront.net/images/profile/${profileImage}`}
               alt="User profile"
               className="profile-image"
             />

--- a/frontend/src/components/modals/RoomInfoModal.jsx
+++ b/frontend/src/components/modals/RoomInfoModal.jsx
@@ -85,7 +85,7 @@ const RoomInfoModal = ({ room, sidebarRef, onClose, showToast }) => {
         }}>
           {participant.profileImageUrl && !imageError ? (
             <img
-              src={`https://52.78.93.133/images/profile/${participant.profileImageUrl}`}
+              src={`https://d31jo47k92du0.cloudfront.net/images/profile/${participant.profileImageUrl}`}
               alt={participant.nickname}
               style={{
                 width: '100%',

--- a/frontend/src/pages/editprofile.jsx
+++ b/frontend/src/pages/editprofile.jsx
@@ -92,7 +92,7 @@ const EditProfilePage = () => {
             <div className={styles["profile-picture-section"]}>
               <div className={styles["profile-picture"]}>
                 <img
-                  src={selectedImage || `https://52.78.93.133/images/profile/${userDetails.profileImg}`}
+                  src={selectedImage || `https://d31jo47k92du0.cloudfront.net/images/profile/${userDetails.profileImg}`}
                   alt="Profile"
                   className={styles["profile-image"]}
                   onError={(e) => {

--- a/frontend/src/pages/profile.jsx
+++ b/frontend/src/pages/profile.jsx
@@ -80,7 +80,7 @@ const ProfilePage = () => {
                   <div className={styles["profile-image-in-page"]}>
                     <img
                       className={styles["profile-image"]}
-                      src={`https://52.78.93.133/images/profile/${userDetails.profileImg}`}
+                      src={`https://d31jo47k92du0.cloudfront.net/images/profile/${userDetails.profileImg}`}
                       alt="Profile"
                       onError={(e) => {
                         e.target.onerror = null;


### PR DESCRIPTION
## 🛰️ Issue Number
#120 

## 🪐 작업 내용
이미지 파일은 S3에 저장하고, CloudFront를 통해 정적 리소스 CDN으로 배포하고 있습니다. CloudFront를 프록시처럼 사용해 직접 S3를 노출하지 않고, 빠르고 안정적인 이미지 전송이 가능하도록 구성했습니다.
그러므로 현재 배포되고있는 서비스 url로 이미지접근이 가능하도록 했습니다.
https://d31jo47k92du0.cloudfront.net/images/profile/github-profile.png
![스크린샷 2025-05-31 023533](https://github.com/user-attachments/assets/de02637c-d172-4a9b-8201-afd70af05af1)
![스크린샷 2025-05-31 023515](https://github.com/user-attachments/assets/86c86e34-e8fd-43b6-a9ce-8c6c5558fa1c)

자바에서 S3에 이미지 업로드를 위해 
- Spring Cloud AWS Starter
- AWS Java SDK For Amazon S3
을 사용하여 이미지 업로드 관련 메소드를 수정했습니다.

추가로 현재 nohup로 백그라운드에서 계속 서버가 실행되도록 해봤습니다..
안정적으로 계속 서버가 열려있을지 모르겠지만말이죠 ㅎㅎ
https://d31jo47k92du0.cloudfront.net/

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?