### PR TITLE
Refactor: url에서 roomId제거, ChatRoom조회 메서드 수정, 메세지 조회 검증 로직 추가

### DIFF
--- a/backend/src/main/java/project/backend/domain/chat/chatmessage/api/ChatMessageController.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatmessage/api/ChatMessageController.java
@@ -8,6 +8,7 @@ import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -23,6 +24,7 @@ import project.backend.domain.chat.chatmessage.dto.ChatMessageSearchResponse;
 import project.backend.domain.imagefile.ImageFile;
 import project.backend.domain.imagefile.ImageFileService;
 import project.backend.domain.imagefile.ImageType;
+import project.backend.global.config.security.dto.MemberDetails;
 
 @RestController
 @RequiredArgsConstructor
@@ -67,8 +69,9 @@ public class ChatMessageController {
 	}
 
 	@GetMapping("/{roomId}/messages")
-	public List<ChatMessageResponse> getMessages(@PathVariable Long roomId) {
-		return chatMessageService.getMessagesByRoomId(roomId);
+	public List<ChatMessageResponse> getMessages(@PathVariable Long roomId,
+		@AuthenticationPrincipal MemberDetails memberDetails) {
+		return chatMessageService.getMessagesByRoomId(roomId, memberDetails.getId());
 	}
 
 	@MessageMapping("/delete-message/{roomId}")

--- a/backend/src/main/java/project/backend/domain/chat/chatmessage/api/ChatMessageController.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatmessage/api/ChatMessageController.java
@@ -25,6 +25,8 @@ import project.backend.domain.imagefile.ImageFile;
 import project.backend.domain.imagefile.ImageFileService;
 import project.backend.domain.imagefile.ImageType;
 import project.backend.global.config.security.dto.MemberDetails;
+import project.backend.global.exception.errorcode.AuthErrorCode;
+import project.backend.global.exception.ex.AuthException;
 
 @RestController
 @RequiredArgsConstructor
@@ -71,6 +73,11 @@ public class ChatMessageController {
 	@GetMapping("/{roomId}/messages")
 	public List<ChatMessageResponse> getMessages(@PathVariable Long roomId,
 		@AuthenticationPrincipal MemberDetails memberDetails) {
+
+		if (memberDetails == null) {
+			throw new AuthException(AuthErrorCode.UNAUTHORIZED_USER);
+		}
+
 		return chatMessageService.getMessagesByRoomId(roomId, memberDetails.getId());
 	}
 

--- a/backend/src/main/java/project/backend/domain/chat/chatmessage/app/ChatMessageService.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatmessage/app/ChatMessageService.java
@@ -193,9 +193,14 @@ public class ChatMessageService {
 
 	// 예외 처리
 	@Transactional(readOnly = true)
-	public List<ChatMessageResponse> getMessagesByRoomId(Long roomId) {
+	public List<ChatMessageResponse> getMessagesByRoomId(Long roomId, Long memberId) {
 		chatRoomRepository.findById(roomId)
 			.orElseThrow(() -> new ChatRoomException(ChatRoomErrorCode.CHATROOM_NOT_FOUND));
+
+		if (!chatParticipantRepository.
+			existsByParticipantIdAndChatRoomId(memberId, roomId)) {
+			throw new ChatRoomException(ChatRoomErrorCode.NOT_PARTICIPANT);
+		}
 
 		List<ChatMessage> messages = chatMessageRepository.findByChatRoom_IdOrderBySendAtAsc(
 			roomId);

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/api/ChatRoomController.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/api/ChatRoomController.java
@@ -117,8 +117,9 @@ public class ChatRoomController {
 	}
 	//임창인 끝
 
-	@GetMapping("/check")
-	public ChatRoomNameResponse getChatRoomName(@RequestParam String inviteCode) {
-		return chatRoomService.getChatRoomByInviteCode(inviteCode);
+	@GetMapping("/{inviteCode}")
+	public ChatRoomNameResponse getChatRoomDetails(@PathVariable String inviteCode,
+		@AuthenticationPrincipal MemberDetails memberDetails) {
+		return chatRoomService.getChatRoomDetails(inviteCode,memberDetails.getId());
 	}
 }

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomService.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomService.java
@@ -202,8 +202,14 @@ public class ChatRoomService {
 	}
 
 	@Transactional(readOnly = true)
-	public ChatRoomNameResponse getChatRoomByInviteCode(String inviteCode) {
+	public ChatRoomNameResponse getChatRoomDetails(String inviteCode,Long memberId) {
 		ChatRoom room = findByInviteCode(inviteCode);
+
+		if (!chatParticipantRepository.
+			existsByParticipantIdAndChatRoomId(memberId, room.getId())) {
+			throw new ChatRoomException(ChatRoomErrorCode.NOT_PARTICIPANT);
+		}
+
 		return ChatRoomMapper.toListResponse(room);
 	}
 }

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomService.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomService.java
@@ -103,12 +103,7 @@ public class ChatRoomService {
 
 		Member member = memberService.getMemberById(memberId);
 
-		boolean isAlreadyParticipant = chatParticipantRepository
-			.existsByParticipantIdAndChatRoomId(memberId, room.getId());
-
-		if (isAlreadyParticipant) {
-			throw new ChatRoomException(ChatRoomErrorCode.ALREADY_PARTICIPANT);
-		}
+		validateNotParticipant(memberId,room.getId());
 
 		ChatParticipant chatParticipant = ChatParticipant.of(member, room);
 
@@ -205,12 +200,16 @@ public class ChatRoomService {
 	public ChatRoomNameResponse getChatRoomDetails(String inviteCode,Long memberId) {
 		ChatRoom room = findByInviteCode(inviteCode);
 
-		if (!chatParticipantRepository.
-			existsByParticipantIdAndChatRoomId(memberId, room.getId())) {
-			throw new ChatRoomException(ChatRoomErrorCode.NOT_PARTICIPANT);
-		}
+		validateNotParticipant(memberId,room.getId());
 
 		return ChatRoomMapper.toListResponse(room);
+	}
+
+	private void validateNotParticipant(Long memberId, Long roomId) {
+		if (!chatParticipantRepository.
+			existsByParticipantIdAndChatRoomId(memberId, roomId)) {
+			throw new ChatRoomException(ChatRoomErrorCode.NOT_PARTICIPANT);
+		}
 	}
 }
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,9 +6,10 @@ import Login from "./pages/login-form"
 import Signup from "./pages/signup"
 import MyPage from "./pages/profile"
 import EditProfilePage from "./pages/editprofile"
-
+import ErrorPage from './pages/ErrorPage';
 
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
+
 
 
 
@@ -17,12 +18,13 @@ function App() {
     <BrowserRouter>
       <Routes>
         <Route path="/" element={<Home />}/>
-        <Route path="/chat/:roomId/:inviteCode" element={<ChatRoom />} />
+        <Route path="/chat/:inviteCode" element={<ChatRoom />} />
         <Route path="/blank" element={<BlankRoom />} />
         <Route path="/login" element={<Login />} />
         <Route path="/signup" element={<Signup />} />
         <Route path="/myprofile" element={<MyPage />} />
         <Route path="/myprofile/edit" element={<EditProfilePage />} />
+        <Route path="/error" element={<ErrorPage />} />
  
 
       </Routes>

--- a/frontend/src/components/SideBar.jsx
+++ b/frontend/src/components/SideBar.jsx
@@ -12,13 +12,13 @@ import axiosInstance from "./api/axiosInstance"
 
 const Sidebar = () => {
   const navigate = useNavigate();
-  const { roomId } = useParams();
+  const { inviteCode } = useParams();
   const sidebarRef = useRef(null);
   const stompClientRef = useRef(null);
-  
+
   const [chatRooms, setChatRooms] = useState([]);
   const [loading, setLoading] = useState(true);
-  
+
   // 페이지네이션 상태
   const [currentPage, setCurrentPage] = useState(0);
   const [totalPages, setTotalPages] = useState(0);
@@ -29,16 +29,17 @@ const Sidebar = () => {
   const [showJoinModal, setShowJoinModal] = useState(false);
   const [showMembersModal, setShowMembersModal] = useState(false);
   const [selectedRoom, setSelectedRoom] = useState(null);
-  
+
   // 토스트 알림 상태
   const [showToast, setShowToast] = useState(false);
   const [toastMessage, setToastMessage] = useState('');
-  
+
   // 현재 사용자 정보 
   const [currentUser, setCurrentUser] = useState(null);
 
   // 읽지 않은 메시지 상태 (roomId: boolean)
   const [unreadMessages, setUnreadMessages] = useState({});
+  const [roomId, setRoomId] = useState(null);
 
   useEffect(() => {
     fetchChatRooms(currentPage);
@@ -57,13 +58,13 @@ const Sidebar = () => {
       debug: (str) => console.log(`[SIDEBAR STOMP] ${str}`),
       onConnect: () => {
         console.log('✅ Sidebar connected to WebSocket');
-        
+
         // 모든 채팅방에 대해 구독
         chatRooms.forEach(room => {
           const subscription = client.subscribe(`/topic/chat/${room.uniqueId}`, (message) => {
             try {
               const received = JSON.parse(message.body);
-              
+
               // 현재 있는 채팅방이 아닌 경우에만 알림 표시
               if (Number(roomId) !== Number(room.uniqueId)) {
                 setUnreadMessages(prev => ({
@@ -107,6 +108,15 @@ const Sidebar = () => {
     }
   }, [roomId]);
 
+  useEffect(() => {
+    if (inviteCode && chatRooms.length > 0) {
+      const currentRoom = chatRooms.find(room => room.inviteCode === inviteCode);
+      if (currentRoom) {
+        setRoomId(currentRoom.uniqueId);
+      }
+    }
+  }, [inviteCode, chatRooms]);
+
   const fetchCurrentUser = async () => {
     try {
       const res = await axiosInstance.get('/user/details');
@@ -145,7 +155,7 @@ const Sidebar = () => {
         delete updated[id];
         return updated;
       });
-      navigate(`/chat/${id}/${inviteCode}`);
+      navigate(`/chat/${inviteCode}`);
     }
   };
 
@@ -162,9 +172,9 @@ const Sidebar = () => {
       // 방 상세 정보를 가져오는 API가 있다면 사용
       // 현재 예시에서는 이런 API가 명시되어 있지 않으므로 기존 목록에서 찾아서 사용
       const existingRoom = chatRooms.find(room => Number(room.uniqueId) === Number(roomId));
-      
+
       if (!existingRoom) return null;
-      
+
       // 방장 정보가 없는 경우에만 추가
       if (!existingRoom.participants || !existingRoom.participants.some(p => p.owner)) {
         return {
@@ -179,7 +189,7 @@ const Sidebar = () => {
           ] : existingRoom.participants || []
         };
       }
-      
+
       return existingRoom;
     } catch (err) {
       console.error('방 상세 정보 가져오기 오류:', err);
@@ -191,18 +201,18 @@ const Sidebar = () => {
   const showMembersInfo = async (room) => {
     // 방 상세 정보 가져오기
     const detailedRoom = await fetchRoomDetails(room.uniqueId);
-    
+
     // 방 정보에 방장 추가
     const enhancedRoom = detailedRoom || room;
-    
+
     // 방장 정보 처리
-    if (currentUser && enhancedRoom.ownerId === currentUser.id && 
-        (!enhancedRoom.participants || !enhancedRoom.participants.some(p => p.owner))) {
+    if (currentUser && enhancedRoom.ownerId === currentUser.id &&
+      (!enhancedRoom.participants || !enhancedRoom.participants.some(p => p.owner))) {
       enhancedRoom.participants = enhancedRoom.participants || [];
-      
+
       // 이미 해당 사용자가 목록에 있는지 확인
       const existingUserIndex = enhancedRoom.participants.findIndex(p => p.id === currentUser.id);
-      
+
       if (existingUserIndex >= 0) {
         // 기존 사용자 정보를 방장으로 업데이트
         enhancedRoom.participants[existingUserIndex] = {
@@ -218,12 +228,12 @@ const Sidebar = () => {
         });
       }
     }
-    
+
     setSelectedRoom(enhancedRoom);
     setShowMembersModal(true);
-    
+
     // 상태 업데이트 - 방 목록에 반영
-    setChatRooms(prev => prev.map(r => 
+    setChatRooms(prev => prev.map(r =>
       Number(r.uniqueId) === Number(enhancedRoom.uniqueId) ? enhancedRoom : r
     ));
   };
@@ -242,11 +252,11 @@ const Sidebar = () => {
         name: roomName,
         repositoryUrl: repoUrl
       });
-      
+
       const created = res.data;
       setShowCreateModal(false);
       fetchChatRooms(0);
-      
+
       // 응답에서 얻은 데이터로 채팅방 목록 직접 업데이트
       if (created) {
         // 생성자를 방장으로 추가
@@ -262,7 +272,7 @@ const Sidebar = () => {
             }
           ]
         };
-        
+
         // 현재 페이지가 첫 페이지인 경우만 직접 목록에 추가
         if (currentPage === 0) {
           setChatRooms(prev => [newRoom, ...prev.slice(0, 9)]); // 최대 10개 유지
@@ -274,15 +284,15 @@ const Sidebar = () => {
           fetchChatRooms(0);
         }
       }
-      
+
       if (created?.id) {
-        navigate(`/chat/${created.id}/${created.inviteCode}`);
+        navigate(`/chat/${created.inviteCode}`);
       }
     } catch (err) {
       alert(err.response?.data?.message || // 백엔드에서 내려준 에러 메시지
         err.message ||                // 일반 JS 에러 메시지
         '방 생성에 실패했습니다.. ㅋㅋ루삥뽕뽕'); // 기본 메시지);
-      
+
       throw err;
     }
   };
@@ -301,20 +311,20 @@ const Sidebar = () => {
 
       if (joined) {
         const newRoom = {
-        ...joined,
-        uniqueId: joined.id || joined.roomId,
-        participants: [
-          ...(joined.participants || []),
-          ...(joined.ownerId === currentUser?.id && currentUser
-            ? [{
+          ...joined,
+          uniqueId: joined.id || joined.roomId,
+          participants: [
+            ...(joined.participants || []),
+            ...(joined.ownerId === currentUser?.id && currentUser
+              ? [{
                 ...currentUser,
                 owner: true,
                 nickname: currentUser.nickname || currentUser.username || '나'
               }]
-            : []
-          )
-        ]
-      };
+              : []
+            )
+          ]
+        };
 
         if (currentPage === 0) {
           setChatRooms(prev => {
@@ -332,7 +342,7 @@ const Sidebar = () => {
       }
 
       if (joined?.id) {
-        navigate(`/chat/${joined.id}/${joined.inviteCode}`);
+        navigate(`/chat/${joined.inviteCode}`);
       }
     } catch (err) {
       alert(err.response?.data?.message || err.message || "채팅방 참여에 실패했습니다.");
@@ -346,15 +356,15 @@ const Sidebar = () => {
 
   return (
     <>
-      <div 
+      <div
         ref={sidebarRef}
-        className="sidebar-container" 
-        style={{ 
-          width: '260px', 
-          height: '100%', 
-          backgroundColor: '#2588F1', 
-          color: 'white', 
-          display: 'flex', 
+        className="sidebar-container"
+        style={{
+          width: '260px',
+          height: '100%',
+          backgroundColor: '#2588F1',
+          color: 'white',
+          display: 'flex',
           flexDirection: 'column',
           position: 'relative',
           overflow: 'hidden'
@@ -367,13 +377,13 @@ const Sidebar = () => {
           background: 'linear-gradient(to bottom, rgba(0,0,0,0.1), transparent)'
         }}>
           <h3 style={{ margin: '0', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-            <span style={{ fontSize: '18px', fontWeight: '600' }}>Code Chat <br/> Rooms</span>
+            <span style={{ fontSize: '18px', fontWeight: '600' }}>Code Chat <br /> Rooms</span>
             {totalElements > 0 && (
-              <span style={{ 
-                fontSize: '14px', 
-                color: 'rgba(255,255,255,0.8)', 
-                padding: '2px 8px', 
-                backgroundColor: 'rgba(0,0,0,0.1)', 
+              <span style={{
+                fontSize: '14px',
+                color: 'rgba(255,255,255,0.8)',
+                padding: '2px 8px',
+                backgroundColor: 'rgba(0,0,0,0.1)',
                 borderRadius: '12px',
                 whiteSpace: 'nowrap'
               }}>
@@ -384,8 +394,8 @@ const Sidebar = () => {
         </div>
 
         {/* 채팅방 목록 */}
-        <div className="rooms-container" style={{ 
-          overflowY: 'auto', 
+        <div className="rooms-container" style={{
+          overflowY: 'auto',
           flex: 1,
           padding: '5px 0'
         }}>
@@ -404,7 +414,7 @@ const Sidebar = () => {
               const isSelectedForModal = selectedRoom && Number(selectedRoom.uniqueId) === Number(roomUniqueId) && showMembersModal;
               const roomInviteCode = room.inviteCode;
               const hasUnreadMessage = unreadMessages[roomUniqueId] && !isCurrentRoom;
-              
+
               return (
                 <div key={`room-${roomUniqueId}`} style={{ padding: '5px 10px' }}>
                   <div
@@ -432,10 +442,10 @@ const Sidebar = () => {
                     }}
                   >
                     <div
-                      onClick={() => navigateToRoom(roomUniqueId,roomInviteCode)}
-                      style={{ 
-                        display: 'flex', 
-                        alignItems: 'center', 
+                      onClick={() => navigateToRoom(roomUniqueId, roomInviteCode)}
+                      style={{
+                        display: 'flex',
+                        alignItems: 'center',
                         flex: 1,
                         overflow: 'hidden'
                       }}
@@ -469,7 +479,7 @@ const Sidebar = () => {
                           }} />
                         )}
                       </div>
-                      <span style={{ 
+                      <span style={{
                         fontWeight: isCurrentRoom ? 'bold' : (hasUnreadMessage ? '600' : 'normal'),
                         whiteSpace: 'nowrap',
                         overflow: 'hidden',
@@ -480,9 +490,9 @@ const Sidebar = () => {
                       </span>
                     </div>
 
-                    <div 
+                    <div
                       onClick={() => showMembersInfo(room)}
-                      style={{ 
+                      style={{
                         cursor: 'pointer',
                         width: '28px',
                         height: '28px',
@@ -523,17 +533,17 @@ const Sidebar = () => {
         </div>
 
         {/* 페이지네이션 컨트롤 */}
-        <div style={{ 
-          display: 'flex', 
-          justifyContent: 'center', 
-          alignItems: 'center', 
+        <div style={{
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
           padding: '12px 0',
           borderTop: '1px solid rgba(255,255,255,0.15)',
           borderBottom: '1px solid rgba(255,255,255,0.15)',
           backgroundColor: 'rgba(0,0,0,0.05)'
         }}>
-          <button 
-            onClick={() => paginate(currentPage - 1)} 
+          <button
+            onClick={() => paginate(currentPage - 1)}
             disabled={currentPage === 0}
             style={{
               background: 'none',
@@ -546,13 +556,13 @@ const Sidebar = () => {
           >
             <FaAngleLeft />
           </button>
-          
+
           <div style={{ margin: '0 10px', fontSize: '14px', fontWeight: '500' }}>
             {currentPage + 1} / {totalPages || 1}
           </div>
-          
-          <button 
-            onClick={() => paginate(currentPage + 1)} 
+
+          <button
+            onClick={() => paginate(currentPage + 1)}
             disabled={currentPage === totalPages - 1 || totalPages === 0}
             style={{
               background: 'none',
@@ -568,7 +578,7 @@ const Sidebar = () => {
         </div>
 
         {/* 하단 버튼 */}
-        <div style={{ 
+        <div style={{
           padding: '16px',
           borderTop: '1px solid rgba(255,255,255,0.15)',
           backgroundColor: 'rgba(0,0,0,0.05)'
@@ -629,7 +639,7 @@ const Sidebar = () => {
 
       {/* 모달 컴포넌트들 */}
       {showMembersModal && selectedRoom && (
-        <RoomInfoModal 
+        <RoomInfoModal
           room={selectedRoom}
           onClose={() => setShowMembersModal(false)}
           sidebarRef={sidebarRef}
@@ -638,14 +648,14 @@ const Sidebar = () => {
       )}
 
       {showCreateModal && (
-        <CreateRoomModal 
+        <CreateRoomModal
           onClose={() => setShowCreateModal(false)}
           onSubmit={handleCreateRoom}
         />
       )}
 
       {showJoinModal && (
-        <JoinRoomModal 
+        <JoinRoomModal
           onClose={() => setShowJoinModal(false)}
           onSubmit={handleJoinRoom}
         />

--- a/frontend/src/components/common/useWebSocket.jsx
+++ b/frontend/src/components/common/useWebSocket.jsx
@@ -15,6 +15,12 @@ const useWebSocket = ({
     const navigate = useNavigate(); 
 
     useEffect(() => {
+        
+        if (!roomId) {
+            console.log('⏳ roomId가 없어서 웹소켓 연결을 대기합니다.');
+            return;
+        }
+
         const client = new Client({
             webSocketFactory: () => new SockJS('http://localhost:8080/ws'),
             reconnectDelay: 1000,

--- a/frontend/src/components/modals/JoinRoomModal.jsx
+++ b/frontend/src/components/modals/JoinRoomModal.jsx
@@ -27,7 +27,7 @@ const JoinRoomModal = ({ onClose, onSubmit }) => {
     setError(null);
     
     try {
-      const res = await axiosInstance.get(`/chat-rooms/check?inviteCode=${inviteCode.trim()}`);
+      const res = await axiosInstance.get(`/chat-rooms/${inviteCode}`);
       setRoomInfo(res.data);
     } catch (err) {
       console.error('초대 코드 확인 오류:', err);

--- a/frontend/src/pages/BlankRoom.jsx
+++ b/frontend/src/pages/BlankRoom.jsx
@@ -24,7 +24,7 @@ const BlankRoom = () => {
       setShowCreateModal(false);
 
       if (created?.id) {
-        navigate(`/chat/${created.id}/${created.inviteCode}`);
+        navigate(`/chat/${created.inviteCode}`);
       }
     } catch (err) {
       const backendMessage = err.response?.data?.message;
@@ -50,7 +50,7 @@ const BlankRoom = () => {
       const data = res.data;
       setShowJoinModal(false);
       
-      navigate(`/chat/${data.id}/${data.inviteCode}`);
+      navigate(`/chat/${data.inviteCode}`);
     } catch (err) {
       alert(err.response?.data?.message || err.message || "방 입장에 실패했습니다.");
       throw err;

--- a/frontend/src/pages/ChatRoom.jsx
+++ b/frontend/src/pages/ChatRoom.jsx
@@ -11,7 +11,7 @@ import RoomHeader from '../components/chatroom/RoomHeader';
 
 const ChatRoom = () => {
 
-  const { roomId, inviteCode } = useParams();
+  const { inviteCode } = useParams();
   const [messages, setMessages] = useState([]);
   const [content, setContent] = useState("");
   const [inputMode, setInputMode] = useState("TEXT");
@@ -25,28 +25,31 @@ const ChatRoom = () => {
 
   const messagesEndRef = useRef(null);
   const navigate = useNavigate();           // ← 네비게이트 훅
-  const location = useLocation();           // ← 현재 URL 가져오기
 
   const [roomName, setRoomName] = useState("로딩 중...");
+  const [roomId, setRoomId] = useState(null);
 
-  // 1. 방 이름 불러오기
+  // 1. 방 정보(현재는 방 이름만) 불러오기
   const fetchRoomInfo = async () => {
     try {
-      const res = await axiosInstance.get(`/chat-rooms/check?inviteCode=${inviteCode}`, {
+      const res = await axiosInstance.get(`/chat-rooms/${inviteCode}`, {
       });
 
       const roomData = res.data;
+
+      setRoomId(roomData.roomId);
       setRoomName(roomData.roomName);
+      return roomData.roomId;
     } catch (error) {
-      console.error('방 정보 요청 실패:', error);
-      setRoomName(`채팅방 #${roomId}`); // 오류 시 기본값으로 표시
+        navigate(`/error`);
+      return null;
     }
   };
 
   // 2. 메시지 목록 불러오기
-  const fetchMessages = async () => {
+  const fetchMessages = async (roomId) => { // 수정: 파라미터 추가
     try {
-      const res = await axiosInstance.get(`/${roomId}/messages`);
+      const res = await axiosInstance.get(`/${roomId}/messages`); 
       const data = res.data;
 
       // 날짜 유효성 검사
@@ -92,13 +95,13 @@ const ChatRoom = () => {
     }
   };
 
-  //웹소켓 연결 (현재 채팅방 구독)
+  // 웹소켓 연결 (roomId가 있을 때만 연결)
   const stompClientRef = useWebSocket({
-    roomId,
-    onMessageReceived: (received)=> {
+    roomId, // roomId가 null이면 useWebSocket 내부에서 연결하지 않도록 처리해야 함
+    onMessageReceived: (received) => {
       //메세지 상태 업데이트
       setMessages(prev => {
-        const updated=prev.some(m => m.messageId === received.messageId)
+        const updated = prev.some(m => m.messageId === received.messageId)
         ? prev.map(m => m.messageId === received.messageId ? received : m)
         : [...prev, received];
 
@@ -108,21 +111,28 @@ const ChatRoom = () => {
     }
   });
 
-  //roomId가 변할 때 초기 데이터 불러오기
   useEffect(() => {
-    if (!roomId) {
-      console.error("No roomId available");
-      navigate("/");
+    if (!inviteCode) {
+      console.error("No inviteCode available");
+      navigate("/error");
       return;
     }
 
-    setMessages([]); // 이전 채팅방 메세지 제거
+    const initializeRoom = async () => {
+      setMessages([]); // 이전 채팅방 메시지 제거
+      
+      // 1. 먼저 방 정보 가져오기 (roomId 포함)
+      const fetchedRoomId = await fetchRoomInfo();
+      
+      if (fetchedRoomId) {
+        // 2. roomId를 얻은 후 나머지 초기화
+        fetchCurrentUser();
+        fetchMessages(fetchedRoomId); // roomId를 파라미터로 전달
+      }
+    };
 
-    fetchCurrentUser();
-    fetchRoomInfo(); // 방 정보 가져오기 함수 호출 추가
-    fetchMessages();
-
-  },[roomId]);
+    initializeRoom();
+  }, [inviteCode]);
 
   const handleLeaveRoom = async () => {
     try {
@@ -260,10 +270,16 @@ const ChatRoom = () => {
   // 메시지 전송 (텍스트/코드/이미지 모두 처리)
   const sendMessage = (overrideMessage = null) => {
     const client = stompClientRef.current;
-    // 연결이 끊긴 경우 재연결 시도
-    if (!client.connected) {
-      client.activate();
+    
+    // roomId가 없거나 연결이 끊긴 경우 처리
+    if (!roomId) {
+      alert('채팅방 정보를 로딩 중입니다. 잠시 후 다시 시도해주세요.');
+      return;
+    }
+    
+    if (!client || !client.connected) {
       alert('⚠️ 서버와 연결이 끊어졌습니다. 재연결을 시도합니다.');
+      // 재연결 로직이 있다면 여기서 처리
       return;
     }
 

--- a/frontend/src/pages/ChatRoom.jsx
+++ b/frontend/src/pages/ChatRoom.jsx
@@ -10,7 +10,6 @@ import useWebSocket from '../components/common/useWebSocket';
 import RoomHeader from '../components/chatroom/RoomHeader';
 
 const ChatRoom = () => {
-
   const { inviteCode } = useParams();
   const [messages, setMessages] = useState([]);
   const [content, setContent] = useState("");
@@ -20,34 +19,37 @@ const ChatRoom = () => {
   const [currentUser, setCurrentUser] = useState(null);
   const [contextMenuId, setContextMenuId] = useState(null);
 
-  const [editMessageId, setEditMessageId] = useState(null); // 현재 수정 중인 메시지 ID
-  const [editContent, setEditContent] = useState(""); // 수정 중인 내용
+  const [editMessageId, setEditMessageId] = useState(null);
+  const [editContent, setEditContent] = useState("");
 
   const messagesEndRef = useRef(null);
-  const navigate = useNavigate();           // ← 네비게이트 훅
+  const navigate = useNavigate();
 
   const [roomName, setRoomName] = useState("로딩 중...");
   const [roomId, setRoomId] = useState(null);
+  
+  // 초기화 상태 관리
+  const [isRoomValidated, setIsRoomValidated] = useState(false);
+  const [isInitializing, setIsInitializing] = useState(true);
 
   // 1. 방 정보(현재는 방 이름만) 불러오기
   const fetchRoomInfo = async () => {
     try {
-      const res = await axiosInstance.get(`/chat-rooms/${inviteCode}`, {
-      });
-
+      const res = await axiosInstance.get(`/chat-rooms/${inviteCode}`);
       const roomData = res.data;
 
       setRoomId(roomData.roomId);
       setRoomName(roomData.roomName);
       return roomData.roomId;
     } catch (error) {
-        navigate(`/error`);
+      console.error('방 정보 조회 실패:', error);
+      navigate(`/error`);
       return null;
     }
   };
 
   // 2. 메시지 목록 불러오기
-  const fetchMessages = async (roomId) => { // 수정: 파라미터 추가
+  const fetchMessages = async (roomId) => {
     try {
       const res = await axiosInstance.get(`/${roomId}/messages`); 
       const data = res.data;
@@ -55,7 +57,7 @@ const ChatRoom = () => {
       // 날짜 유효성 검사
       const validatedData = data.map(msg => {
         const sendAt = new Date(msg.sendAt);
-        const isInvalidDate = isNaN(sendAt.getTime()); // getTime이 NaN이면 잘못된 날짜
+        const isInvalidDate = isNaN(sendAt.getTime());
 
         if (!msg.sendAt || isInvalidDate) {
           return { ...msg, sendAt: new Date().toISOString() };
@@ -64,7 +66,7 @@ const ChatRoom = () => {
         return msg;
       });
 
-      //sendAt 기준으로 메시지 정렬
+      // sendAt 기준으로 메시지 정렬
       const sortedData = validatedData.sort(
           (a, b) => new Date(a.sendAt).getTime() - new Date(b.sendAt).getTime()
       );
@@ -88,18 +90,17 @@ const ChatRoom = () => {
         throw new Error('로그인 정보를 가져오지 못했습니다.');
       }
 
-      const user = await res.json(); // { id, email, nickname, profileImg }
+      const user = await res.json();
       setCurrentUser(user);
     } catch (error) {
       console.error('사용자 정보 요청 실패:', error);
     }
   };
 
-  // 웹소켓 연결 (roomId가 있을 때만 연결)
+  // 웹소켓 연결 (roomId가 검증된 후에만 연결)
   const stompClientRef = useWebSocket({
-    roomId, // roomId가 null이면 useWebSocket 내부에서 연결하지 않도록 처리해야 함
+    roomId: isRoomValidated ? roomId : null, // 방이 검증된 후에만 roomId 전달
     onMessageReceived: (received) => {
-      //메세지 상태 업데이트
       setMessages(prev => {
         const updated = prev.some(m => m.messageId === received.messageId)
         ? prev.map(m => m.messageId === received.messageId ? received : m)
@@ -111,6 +112,7 @@ const ChatRoom = () => {
     }
   });
 
+  // 초기화 로직 
   useEffect(() => {
     if (!inviteCode) {
       console.error("No inviteCode available");
@@ -119,15 +121,33 @@ const ChatRoom = () => {
     }
 
     const initializeRoom = async () => {
+      setIsInitializing(true);
+      setIsRoomValidated(false);
       setMessages([]); // 이전 채팅방 메시지 제거
       
-      // 1. 먼저 방 정보 가져오기 (roomId 포함)
-      const fetchedRoomId = await fetchRoomInfo();
-      
-      if (fetchedRoomId) {
-        // 2. roomId를 얻은 후 나머지 초기화
-        fetchCurrentUser();
-        fetchMessages(fetchedRoomId); // roomId를 파라미터로 전달
+      try {
+        // 1단계: 방 정보 검증 및 로딩
+        const fetchedRoomId = await fetchRoomInfo();
+        
+        if (!fetchedRoomId) {
+          // 방 정보 로딩 실패 시 여기서 종료 (navigate는 fetchRoomInfo에서 처리)
+          return;
+        }
+
+        // 2단계: 방 검증 완료 표시 (이제 웹소켓 연결 가능)
+        setIsRoomValidated(true);
+        
+        // 3단계: 병렬로 사용자 정보와 메시지 로딩
+        await Promise.all([
+          fetchCurrentUser(),
+          fetchMessages(fetchedRoomId)
+        ]);
+
+      } catch (error) {
+        console.error('방 초기화 중 오류:', error);
+        navigate("/error");
+      } finally {
+        setIsInitializing(false);
       }
     };
 
@@ -137,8 +157,6 @@ const ChatRoom = () => {
   const handleLeaveRoom = async () => {
     try {
       await axiosInstance.delete(`/chat-rooms/${roomId}/leave`);
-
-      // ChatRoom 컴포넌트의 상태 업데이트는 RoomHeader가 처리하도록 처리
       return { success: true };
     } catch (err) {
       const errorMsg =
@@ -150,7 +168,7 @@ const ChatRoom = () => {
     }
   };
 
-  //메세지 검색
+  // 메시지 검색 관련 상태
   const [showSearchSidebar, setShowSearchSidebar] = useState(false);
   const [searchKeyword, setSearchKeyword] = useState('');
   const [searchResults, setSearchResults] = useState([]);
@@ -161,15 +179,16 @@ const ChatRoom = () => {
   const [errorMessage, setErrorMessage] = useState(null);
 
   const handleSearch = async (keyword, page = 0) => {
-    // Check if roomId is defined before proceeding
-    if (!roomId) {
-      setErrorMessage('채팅방 ID가 유효하지 않습니다.');
+    // roomId 검증 - 더 명확한 에러 처리
+    if (!roomId || !isRoomValidated) {
+      setErrorMessage('채팅방이 아직 로딩 중입니다. 잠시 후 다시 시도해주세요.');
       return;
     }
+    
     setIsSearching(true);
     setShowSearchSidebar(true);
     setSearchKeyword(keyword);
-    setErrorMessage(null); // 이전 에러 메시지 초기화
+    setErrorMessage(null);
 
     try {
       const response = await axiosInstance.get(`/chat/search/${roomId}`, {
@@ -183,7 +202,7 @@ const ChatRoom = () => {
       const data = response.data;
       const validatedResults = (data.content || []).map(msg => {
       const sendAt = new Date(msg.sendAt);
-      const isInvalid = !msg.sendAt || isNaN(sendAt.getTime()); // NaN = Invalid Date
+      const isInvalid = !msg.sendAt || isNaN(sendAt.getTime());
 
       return isInvalid
         ? { ...msg, sendAt: new Date().toISOString() }
@@ -271,15 +290,14 @@ const ChatRoom = () => {
   const sendMessage = (overrideMessage = null) => {
     const client = stompClientRef.current;
     
-    // roomId가 없거나 연결이 끊긴 경우 처리
-    if (!roomId) {
+    // 방 검증 상태 확인
+    if (!roomId || !isRoomValidated) {
       alert('채팅방 정보를 로딩 중입니다. 잠시 후 다시 시도해주세요.');
       return;
     }
     
     if (!client || !client.connected) {
       alert('⚠️ 서버와 연결이 끊어졌습니다. 재연결을 시도합니다.');
-      // 재연결 로직이 있다면 여기서 처리
       return;
     }
 
@@ -309,7 +327,7 @@ const ChatRoom = () => {
     setInputMode('TEXT');
   };
 
-  //메세지 수정 요청
+  // 메시지 수정 요청
   const handleEditMessage = (messageId) => {
     const client = stompClientRef.current;
     if (!client || !client.connected) {
@@ -332,7 +350,7 @@ const ChatRoom = () => {
     setEditContent('');
   };
 
-  //메세지 삭제 요청
+  // 메시지 삭제 요청
   const handleDeleteMessage = (messageId) => {
     const client = stompClientRef.current;
     if (!client || !client.connected) {
@@ -347,6 +365,24 @@ const ChatRoom = () => {
 
     setContextMenuId(null); // 메뉴 닫기
   };
+
+  // 로딩 상태 표시
+  if (isInitializing) {
+    return (
+      <div style={{
+        backgroundColor: '#f5f7fa',
+        height: '100vh',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif'
+      }}>
+        <div style={{ textAlign: 'center' }}>
+          <div>채팅방을 불러오는 중...</div>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div

--- a/frontend/src/pages/ErrorPage.jsx
+++ b/frontend/src/pages/ErrorPage.jsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+
+const ErrorPage = () => {
+  const location = useLocation();
+  const navigate = useNavigate();
+  
+  const { title, message } = location.state || {
+    title: '페이지를 찾을 수 없습니다',
+    message: '요청하신 페이지가 존재하지 않습니다.'
+  };
+
+  return (
+    <div style={{ 
+      height: '100vh', 
+      display: 'flex', 
+      flexDirection: 'column',
+      justifyContent: 'center', 
+      alignItems: 'center',
+      backgroundColor: '#f5f7fa',
+      fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif'
+    }}>
+      <div style={{ fontSize: '72px', marginBottom: '24px' }}>😵</div>
+      <h1 style={{ 
+        fontSize: '28px', 
+        color: '#dc3545', 
+        marginBottom: '16px',
+        textAlign: 'center',
+        fontWeight: '600'
+      }}>
+        {title}
+      </h1>
+      <p style={{ 
+        fontSize: '16px', 
+        color: '#666', 
+        marginBottom: '32px', 
+        textAlign: 'center',
+        maxWidth: '500px',
+        lineHeight: '1.5'
+      }}>
+        {message}
+      </p>
+      <button 
+        onClick={() => navigate('/')}
+        style={{
+          padding: '12px 24px',
+          backgroundColor: '#2588F1',
+          color: 'white',
+          border: 'none',
+          borderRadius: '8px',
+          cursor: 'pointer',
+          fontSize: '16px',
+          fontWeight: '500',
+          transition: 'background-color 0.2s ease'
+        }}
+        onMouseEnter={(e) => e.target.style.backgroundColor = '#1c6ec7'}
+        onMouseLeave={(e) => e.target.style.backgroundColor = '#2588F1'}
+      >
+        메인으로 돌아가기
+      </button>
+    </div>
+  );
+};
+
+export default ErrorPage;

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -28,11 +28,16 @@ const Home = () => {
       .then(res => {
         const roomId = res.data.roomId;
         const inviteCode = res.data.inviteCode;
-        console.log(roomId);
-        if (roomId) {
-            navigate(`/chat/${roomId}/${inviteCode}`);
+        console.log('최근 방 - roomId:', roomId, 'inviteCode:', inviteCode);
+        
+        if (inviteCode) {
+            navigate(`/chat/${inviteCode}`); // ✅ inviteCode만 사용
+        } else if (roomId) {
+            // inviteCode가 없지만 roomId가 있는 경우 fallback
+            console.warn('inviteCode가 없어서 /blank로 이동');
+            navigate('/blank');
         } else {
-            console.warn('roomId가 응답에 없음');
+            console.warn('roomId와 inviteCode가 모두 응답에 없음');
             navigate('/blank'); // fallback
         }
       })

--- a/frontend/src/pages/profile.jsx
+++ b/frontend/src/pages/profile.jsx
@@ -58,8 +58,8 @@ const ProfilePage = () => {
     fetchUserRooms();
   }, [userDetails, navigate]);
 
-  const handleJoinClick = (roomId, inviteCode) => {
-    navigate(`/chat/${roomId}/${inviteCode}`);
+  const handleJoinClick = (inviteCode) => {
+    navigate(`/chat/${inviteCode}`);
   };
 
   if (!userDetails) {
@@ -127,7 +127,7 @@ const ProfilePage = () => {
                       </div>
                       <button
                         className={styles["join-button"]}
-                        onClick={() => handleJoinClick(room.roomId, room.inviteCode)}
+                        onClick={() => handleJoinClick(room.inviteCode)}
                       >
                         Join
                       </button>


### PR DESCRIPTION
## 🛰️ Issue Number
#135 

## 🪐 작업 내용
<img width="459" alt="image" src="https://github.com/user-attachments/assets/67da02fe-e6ca-438b-a45c-7bef9c0bdb9c" /><br>
url에서 roomId 제거.
하지만 roomId를 통해 api를 호출하거나, 사용하는 부분은 건들지 않음. 
즉 navigate에 roomId가 있었거나, roomId를 url에서 따오는 경우에 대해서 리팩토링.


<img width="721" alt="image" src="https://github.com/user-attachments/assets/f5cc882a-a0e8-4bb5-9932-daf73601a7fe" /><br>
- ChatRoom에 필요한 정보를 가져오는 메서드로 바꿈(현재는 roomName과 roomId정도만 가져오지만.)
- 메세지 조회는 따로 호출.(메세지 조회에 검증 로직 추가)



<img width="1505" alt="image" src="https://github.com/user-attachments/assets/19e9a839-678d-4c77-865a-653d946d58a6" />
- 채팅방 url잘못 건들면 에러페이지로 가도록 추가.<br>

---
SideBar에서 roomName을 가져오는 방식은 생각해보니 좀 이상하다고 생각합니다.
ChatRoom이 부모이고 SideBar가 자식인 구조인데 자식한테서 roomName을 가져온다...? 잘 모르겠네요.
가져온다고 하더라도 SideBar에 채팅방이름 목록들을 가져오는 api와 ChatRoom 헤더에 뜨는 roomName은 구별해주는게
다르다고 생각합니다 (용도가 다르니까?) 여튼 roomName이 말썽이네요


## 📚 Reference


## ✅ Check List
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] 테스트 코드를 통과했나요?
- [ ] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?