### PR TITLE
Refactor: 채팅 내역 커서기반 무한스크롤 적용

### DIFF
--- a/backend/src/main/java/project/backend/domain/chat/chatmessage/api/ChatMessageController.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatmessage/api/ChatMessageController.java
@@ -21,6 +21,7 @@ import project.backend.domain.chat.chatmessage.dto.ChatMessageRequest;
 import project.backend.domain.chat.chatmessage.dto.ChatMessageResponse;
 import project.backend.domain.chat.chatmessage.dto.ChatMessageSearchRequest;
 import project.backend.domain.chat.chatmessage.dto.ChatMessageSearchResponse;
+import project.backend.domain.chat.chatmessage.dto.ChatScrollResponse;
 import project.backend.domain.imagefile.ImageFile;
 import project.backend.domain.imagefile.ImageFileService;
 import project.backend.domain.imagefile.ImageType;
@@ -71,14 +72,12 @@ public class ChatMessageController {
 	}
 
 	@GetMapping("/{roomId}/messages")
-	public List<ChatMessageResponse> getMessages(@PathVariable Long roomId,
-		@AuthenticationPrincipal MemberDetails memberDetails) {
-
-		if (memberDetails == null) {
-			throw new AuthException(AuthErrorCode.UNAUTHORIZED_USER);
-		}
-
-		return chatMessageService.getMessagesByRoomId(roomId, memberDetails.getId());
+	public ChatScrollResponse getMessages(
+		@PathVariable Long roomId,
+		@RequestParam(required = false) Long cursor,
+		@RequestParam(defaultValue = "30") int size
+	) {
+		return chatMessageService.getMessagesByRoomId(roomId, cursor, size);
 	}
 
 	@MessageMapping("/delete-message/{roomId}")

--- a/backend/src/main/java/project/backend/domain/chat/chatmessage/api/ChatMessageController.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatmessage/api/ChatMessageController.java
@@ -22,6 +22,8 @@ import project.backend.domain.chat.chatmessage.dto.ChatMessageResponse;
 import project.backend.domain.chat.chatmessage.dto.ChatMessageSearchRequest;
 import project.backend.domain.chat.chatmessage.dto.ChatMessageSearchResponse;
 import project.backend.domain.chat.chatmessage.dto.ChatScrollResponse;
+import project.backend.domain.chat.chatroom.app.ChatRoomService;
+import project.backend.domain.chat.chatroom.dao.ChatParticipantRepository;
 import project.backend.domain.imagefile.ImageFile;
 import project.backend.domain.imagefile.ImageFileService;
 import project.backend.domain.imagefile.ImageType;
@@ -33,9 +35,11 @@ import project.backend.global.security.dto.MemberDetails;
 @RequiredArgsConstructor
 public class ChatMessageController {
 
+	private final ChatRoomService chatRoomService;
 	private final ChatMessageService chatMessageService;
 	private final ImageFileService imageFileService;
 	private final SimpMessagingTemplate messagingTemplate;
+	private final ChatParticipantRepository chatParticipantRepository;
 
 	@MessageMapping("/send-message/{roomId}") //클라이언트가 메세지를 보낼 경로
 	public ChatMessageResponse sendMessage(@DestinationVariable Long roomId,
@@ -61,6 +65,7 @@ public class ChatMessageController {
 
 	@GetMapping("/chat/search/{roomId}")
 	public Page<ChatMessageSearchResponse> searchMessages(
+		@AuthenticationPrincipal MemberDetails memberDetails,
 		@PathVariable("roomId") Long roomId,
 		@RequestParam("keyword") String keyword,
 		@RequestParam(defaultValue = "0") int page,
@@ -68,16 +73,17 @@ public class ChatMessageController {
 	) {
 		ChatMessageSearchRequest request = ChatMessageSearchRequest.of(keyword, page, size);
 
-		return chatMessageService.searchMessages(roomId, request);
+		return chatMessageService.searchMessages(memberDetails.getId(), roomId, request);
 	}
 
 	@GetMapping("/{roomId}/messages")
 	public ChatScrollResponse getMessages(
+		@AuthenticationPrincipal MemberDetails memberDetails,
 		@PathVariable Long roomId,
 		@RequestParam(required = false) Long cursor,
 		@RequestParam(defaultValue = "30") int size
 	) {
-		return chatMessageService.getMessagesByRoomId(roomId, cursor, size);
+		return chatMessageService.getMessagesByRoomId(memberDetails.getId(), roomId, cursor, size);
 	}
 
 	@MessageMapping("/delete-message/{roomId}")

--- a/backend/src/main/java/project/backend/domain/chat/chatmessage/app/ChatMessageService.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatmessage/app/ChatMessageService.java
@@ -90,7 +90,7 @@ public class ChatMessageService {
 	}
 
 	@Transactional(readOnly = true)
-	public Page<ChatMessageSearchResponse> searchMessages(Long roomId,
+	public Page<ChatMessageSearchResponse> searchMessages(Long memberId, Long roomId,
 		@Valid ChatMessageSearchRequest request) {
 
 		String keyword = request.getKeyword();
@@ -98,6 +98,7 @@ public class ChatMessageService {
 		int size = request.getPageSize();
 		int offset = page * size;
 
+		chatRoomService.validateNotParticipant(memberId, roomId);
 		// messageIds는 DESC 정렬 보장
 		List<Long> messageIds = chatMessageSearchRepository.searchIdsByKeywordAndRoomId(keyword,
 			roomId, size, offset);
@@ -181,9 +182,10 @@ public class ChatMessageService {
 
 	// 예외 처리
 	@Transactional(readOnly = true)
-	public ChatScrollResponse getMessagesByRoomId(Long roomId, Long cursor, int size) {
-		chatRoomRepository.findById(roomId)
-			.orElseThrow(() -> new ChatRoomException(ChatRoomErrorCode.CHATROOM_NOT_FOUND));
+	public ChatScrollResponse getMessagesByRoomId(Long memberId, Long roomId, Long cursor,
+		int size) {
+		chatRoomService.getRoomById(roomId);
+		chatRoomService.validateNotParticipant(memberId, roomId);
 
 		PageRequest pageRequest = PageRequest.of(0, size + 1);
 		List<ChatMessage> result;

--- a/backend/src/main/java/project/backend/domain/chat/chatmessage/app/ChatMessageService.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatmessage/app/ChatMessageService.java
@@ -19,6 +19,7 @@ import project.backend.domain.chat.chatmessage.dto.ChatMessageRequest;
 import project.backend.domain.chat.chatmessage.dto.ChatMessageResponse;
 import project.backend.domain.chat.chatmessage.dto.ChatMessageSearchRequest;
 import project.backend.domain.chat.chatmessage.dto.ChatMessageSearchResponse;
+import project.backend.domain.chat.chatmessage.dto.ChatScrollResponse;
 import project.backend.domain.chat.chatmessage.entity.ChatMessage;
 import project.backend.domain.chat.chatmessage.entity.ChatMessageSearch;
 import project.backend.domain.chat.chatmessage.entity.MessageType;
@@ -31,6 +32,7 @@ import project.backend.domain.imagefile.ImageFile;
 import project.backend.domain.imagefile.ImageFileService;
 import project.backend.domain.member.app.MemberService;
 import project.backend.domain.member.entity.Member;
+import project.backend.global.common.ScrollPaginationCollection;
 import project.backend.global.exception.errorcode.AuthErrorCode;
 import project.backend.global.exception.errorcode.ChatMessageErrorCode;
 import project.backend.global.exception.errorcode.ChatRoomErrorCode;
@@ -179,19 +181,28 @@ public class ChatMessageService {
 
 	// 예외 처리
 	@Transactional(readOnly = true)
-	public List<ChatMessageResponse> getMessagesByRoomId(Long roomId, Long memberId) {
+	public ChatScrollResponse getMessagesByRoomId(Long roomId, Long cursor, int size) {
 		chatRoomRepository.findById(roomId)
 			.orElseThrow(() -> new ChatRoomException(ChatRoomErrorCode.CHATROOM_NOT_FOUND));
 
-		if (!chatParticipantRepository.
-			existsByParticipantIdAndChatRoomId(memberId, roomId)) {
-			throw new ChatRoomException(ChatRoomErrorCode.NOT_PARTICIPANT);
-		}
+		PageRequest pageRequest = PageRequest.of(0, size + 1);
+		List<ChatMessage> result;
 
-		List<ChatMessage> messages = chatMessageRepository.findByChatRoom_IdOrderBySendAtAsc(
-			roomId);
-		return messages.stream()
-			.map(messageMapper::toResponse)
-			.toList();
+		if (cursor == null) {
+			result = chatMessageRepository.findByChatRoom_IdOrderByIdDesc(
+				roomId, pageRequest);
+		} else {
+			result = chatMessageRepository.findByChatRoom_IdAndIdLessThanOrderByIdDesc(
+				roomId, cursor, pageRequest);
+		}
+		ScrollPaginationCollection<ChatMessage> scroll = ScrollPaginationCollection.of(result,
+			size);
+
+		List<ChatMessageResponse> responses = scroll.getCurrentScrollItems().stream()
+			.map(messageMapper::toResponse).toList();
+
+		Long nextCursor = scroll.isLastScroll() ? null : scroll.getNextCursor().getId();
+
+		return new ChatScrollResponse(responses, nextCursor);
 	}
 }

--- a/backend/src/main/java/project/backend/domain/chat/chatmessage/dao/ChatMessageRepository.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatmessage/dao/ChatMessageRepository.java
@@ -1,6 +1,7 @@
 package project.backend.domain.chat.chatmessage.dao;
 
 import java.util.List;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import project.backend.domain.chat.chatmessage.entity.ChatMessage;
 
@@ -9,4 +10,11 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
 	List<ChatMessage> findByChatRoom_IdOrderBySendAtAsc(Long roomId);
 
 	List<ChatMessage> findByIdIn(List<Long> ids);
+
+	// 채팅방 입장 시, cursor가 null값이므로, 초반 메시지를 가져올 메서드
+	List<ChatMessage> findByChatRoom_IdOrderByIdDesc(Long roomId, Pageable pageable);
+
+	// 커서기반 무한스크롤 메서드
+	List<ChatMessage> findByChatRoom_IdAndIdLessThanOrderByIdDesc(Long roomId, Long cursor,
+		Pageable pageable);
 }

--- a/backend/src/main/java/project/backend/domain/chat/chatmessage/dto/ChatScrollResponse.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatmessage/dto/ChatScrollResponse.java
@@ -1,0 +1,13 @@
+package project.backend.domain.chat.chatmessage.dto;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ChatScrollResponse {
+
+	private List<ChatMessageResponse> messages;
+	private Long nextCursor;
+}

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/api/ChatRoomController.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/api/ChatRoomController.java
@@ -76,9 +76,7 @@ public class ChatRoomController {
 	public Page<RoomInfoResponse> getChatRooms(
 		@AuthenticationPrincipal MemberDetails memberDetails,
 		@PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
-		if (memberDetails == null) {
-			throw new AuthException(AuthErrorCode.UNAUTHORIZED_USER);
-		}
+
 		Long memberId = memberDetails.getId();
 		// 채팅방 목록 리스트로 가져오기
 		return chatRoomService.findChatRoomsByMemberId(memberId, pageable);
@@ -89,11 +87,7 @@ public class ChatRoomController {
 		@PathVariable Long roomId,
 		@AuthenticationPrincipal MemberDetails memberDetails) {
 
-		if (memberDetails == null) {
-			throw new AuthException(AuthErrorCode.UNAUTHORIZED_USER);
-		}
-
-		return chatRoomService.getParticipants(roomId);
+		return chatRoomService.getParticipants(memberDetails.getId(), roomId);
 	}
 
 	// 자신이 만든 채팅방 가져오기 -> 주후 인증객체 id로 조회가능 할듯(Authentication)

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomService.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomService.java
@@ -138,9 +138,11 @@ public class ChatRoomService {
 
 	// 채팅방의 참가자 목록 조회
 	@Transactional(readOnly = true)
-	public List<ChatParticipantResponse> getParticipants(Long roomId) {
+	public List<ChatParticipantResponse> getParticipants(Long memberId, Long roomId) {
 		ChatRoom chatRoom = chatRoomRepository.findById(roomId)
 			.orElseThrow(() -> new ChatRoomException(ChatRoomErrorCode.CHATROOM_NOT_FOUND));
+
+		validateAlreadyParticipant(memberId, chatRoom);
 
 		List<ChatParticipant> participants = chatParticipantRepository.findByChatRoom(chatRoom);
 

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomService.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomService.java
@@ -142,7 +142,7 @@ public class ChatRoomService {
 		ChatRoom chatRoom = chatRoomRepository.findById(roomId)
 			.orElseThrow(() -> new ChatRoomException(ChatRoomErrorCode.CHATROOM_NOT_FOUND));
 
-		validateAlreadyParticipant(memberId, chatRoom);
+		validateNotParticipant(memberId, roomId);
 
 		List<ChatParticipant> participants = chatParticipantRepository.findByChatRoom(chatRoom);
 

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/listener/ChatRoomEventListener.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/listener/ChatRoomEventListener.java
@@ -58,9 +58,6 @@ public class ChatRoomEventListener {
 		log.debug("🔥 프로필 업데이트 이벤트 수신: userId={}, nickname={}",
 			updateEvent.userId(), updateEvent.nickname());
 
-		simpMessagingTemplate.convertAndSend("/topic/profile-update",
-			new ProfileUpdateEvent(updateEvent.userId(), updateEvent.nickname(),
-				updateEvent.profileImageUrl())
-		);
+		simpMessagingTemplate.convertAndSend("/topic/profile-update", updateEvent);
 	}
 }

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/listener/ChatRoomEventListener.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/listener/ChatRoomEventListener.java
@@ -50,10 +50,6 @@ public class ChatRoomEventListener {
 		// 입장 메시지 전송
 		simpMessagingTemplate.convertAndSend("/topic/chat/" + joinEvent.roomId(),
 			eventMessageResponse);
-
-		// 채팅방 인원 갱신 트리거 전송
-		simpMessagingTemplate.convertAndSend("/topic/chat/" + joinEvent.roomId() + "/refresh",
-			joinEvent.roomId());
 	}
 
 	@Async

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/listener/ChatRoomEventListener.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/listener/ChatRoomEventListener.java
@@ -1,6 +1,7 @@
 package project.backend.domain.chat.chatroom.listener;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
@@ -17,10 +18,12 @@ import project.backend.domain.chat.chatroom.entity.ChatParticipant;
 import project.backend.domain.chat.chatroom.entity.ChatRoom;
 import project.backend.domain.chat.chatroom.mapper.ChatRoomMapper;
 import project.backend.domain.member.app.MemberService;
+import project.backend.domain.member.dto.event.ProfileUpdateEvent;
 import project.backend.domain.member.entity.Member;
 import project.backend.global.exception.errorcode.ChatRoomErrorCode;
 import project.backend.global.exception.ex.ChatRoomException;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class ChatRoomEventListener {
@@ -53,8 +56,15 @@ public class ChatRoomEventListener {
 			joinEvent.roomId());
 	}
 
-	private ChatParticipant getParticipantByRoomAndMember(Long roomId, Long memberId) {
-		return chatParticipantRepository.findByChatRoom_IdAndParticipant_Id(roomId, memberId)
-			.orElseThrow(() -> new ChatRoomException(ChatRoomErrorCode.CHATROOM_NOT_FOUND));
+	@Async
+	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+	public void handleProfileUpdate(ProfileUpdateEvent updateEvent) {
+		log.debug("🔥 프로필 업데이트 이벤트 수신: userId={}, nickname={}",
+			updateEvent.userId(), updateEvent.nickname());
+
+		simpMessagingTemplate.convertAndSend("/topic/profile-update",
+			new ProfileUpdateEvent(updateEvent.userId(), updateEvent.nickname(),
+				updateEvent.profileImageUrl())
+		);
 	}
 }

--- a/backend/src/main/java/project/backend/domain/member/app/MemberService.java
+++ b/backend/src/main/java/project/backend/domain/member/app/MemberService.java
@@ -64,11 +64,9 @@ public class MemberService {
 		boolean isUpdated = updateMemberFields(targetMember, request);
 
 		if (isUpdated) {
-			eventPublisher.publishEvent(new ProfileUpdateEvent(
-				targetMember.getId(),
-				targetMember.getNickname(),
-				targetMember.getProfileImage().getStoreFileName()
-			));
+			eventPublisher.publishEvent(
+				ProfileUpdateEvent.of(targetMember)
+			);
 		}
 
 		return MemberMapper.toResponse(targetMember);

--- a/backend/src/main/java/project/backend/domain/member/app/MemberService.java
+++ b/backend/src/main/java/project/backend/domain/member/app/MemberService.java
@@ -3,6 +3,7 @@ package project.backend.domain.member.app;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -13,6 +14,7 @@ import project.backend.domain.imagefile.ImageFile;
 import project.backend.domain.imagefile.ImageFileService;
 import project.backend.domain.imagefile.ImageType;
 import project.backend.domain.member.dao.MemberRepository;
+import project.backend.domain.member.dto.event.ProfileUpdateEvent;
 import project.backend.global.security.dto.MemberDetails;
 import project.backend.domain.member.dto.MemberResponse;
 import project.backend.domain.member.dto.MemberUpdateRequest;
@@ -31,6 +33,7 @@ public class MemberService {
 	private final MemberRepository memberRepository;
 	private final ImageFileService imageFileService;
 	private final PasswordEncoder passwordEncoder;
+	private final ApplicationEventPublisher eventPublisher;
 
 	@Value("${file.images.profile.default}")
 	private String defaultProfile;
@@ -55,13 +58,29 @@ public class MemberService {
 
 
 	public MemberResponse updateMember(Authentication auth, MemberUpdateRequest request) {
-
 		MemberDetails memberDetails = (MemberDetails) auth.getPrincipal();
-
 		Member targetMember = getMemberById(memberDetails.getId());
+
+		boolean isUpdated = updateMemberFields(targetMember, request);
+
+		if (isUpdated) {
+			eventPublisher.publishEvent(new ProfileUpdateEvent(
+				targetMember.getId(),
+				targetMember.getNickname(),
+				targetMember.getProfileImage().getStoreFileName()
+			));
+		}
+
+		return MemberMapper.toResponse(targetMember);
+	}
+
+	// 로직 변경 필요 (setter -> update 메서드로 엔티티에 책임 위임)
+	private boolean updateMemberFields(Member targetMember, MemberUpdateRequest request) {
+		boolean isUpdated = false;
 
 		if (request.getNickname() != null) {
 			targetMember.setNickname(request.getNickname());
+			isUpdated = true;
 		}
 
 		if (request.getPassword() != null) {
@@ -72,9 +91,10 @@ public class MemberService {
 			ImageFile newProfile = imageFileService.saveImageFile(request.getProfileImg(),
 				ImageType.PROFILE_IMAGE);
 			targetMember.setProfileImage(newProfile);
+			isUpdated = true;
 		}
 
-		return MemberMapper.toResponse(targetMember);
+		return isUpdated;
 	}
 
 	// Spring Security에서 UsernameNotFoundException을 처리하도록 유도하는 메서드

--- a/backend/src/main/java/project/backend/domain/member/dto/event/ProfileUpdateEvent.java
+++ b/backend/src/main/java/project/backend/domain/member/dto/event/ProfileUpdateEvent.java
@@ -1,9 +1,23 @@
 package project.backend.domain.member.dto.event;
 
+import java.util.Optional;
+import project.backend.domain.imagefile.ImageFile;
+import project.backend.domain.member.entity.Member;
+
 public record ProfileUpdateEvent(
 	Long userId,
 	String nickname,
 	String profileImageUrl
 ) {
+
+	public static ProfileUpdateEvent of(Member member) {
+		return new ProfileUpdateEvent(
+			member.getId(),
+			member.getNickname(),
+			Optional.ofNullable(member.getProfileImage())
+				.map(ImageFile::getStoreFileName)
+				.orElse("default.jpg")
+		);
+	}
 
 }

--- a/backend/src/main/java/project/backend/domain/member/dto/event/ProfileUpdateEvent.java
+++ b/backend/src/main/java/project/backend/domain/member/dto/event/ProfileUpdateEvent.java
@@ -1,0 +1,9 @@
+package project.backend.domain.member.dto.event;
+
+public record ProfileUpdateEvent(
+	Long userId,
+	String nickname,
+	String profileImageUrl
+) {
+
+}

--- a/backend/src/main/java/project/backend/global/common/ScrollPaginationCollection.java
+++ b/backend/src/main/java/project/backend/global/common/ScrollPaginationCollection.java
@@ -1,0 +1,34 @@
+package project.backend.global.common;
+
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class ScrollPaginationCollection<T> {
+
+	private final List<T> itemsWithNextCursor;
+	private final int size;
+
+	public static <T> ScrollPaginationCollection<T> of(List<T> itemsWithNextCursor, int size) {
+		return new ScrollPaginationCollection<>(itemsWithNextCursor, size);
+	}
+
+	public List<T> getCurrentScrollItems() {
+		if (isLastScroll()) {
+			return itemsWithNextCursor;
+		}
+		return itemsWithNextCursor.subList(0, size);
+	}
+
+	public T getNextCursor() {
+		if (isLastScroll()) {
+			return null;
+		}
+		return itemsWithNextCursor.get(size - 1);
+	}
+
+	public boolean isLastScroll() {
+		return itemsWithNextCursor.size() < size;
+	}
+}

--- a/backend/src/main/java/project/backend/global/security/handler/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/project/backend/global/security/handler/JwtAuthenticationFilter.java
@@ -38,7 +38,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 		FilterChain filterChain)
 		throws ServletException, IOException {
 
-		if (WHITE_LIST.contains(request.getRequestURI())) {
+		String requestURI = request.getRequestURI();
+		if (requestURI.startsWith("/github/") || WHITE_LIST.contains(request.getRequestURI())) {
 			filterChain.doFilter(request, response); // JWT 검사 건너뜀
 			return;
 		}

--- a/backend/src/main/resources/db/migration/V1__add_fulltext_index.sql
+++ b/backend/src/main/resources/db/migration/V1__add_fulltext_index.sql
@@ -1,7 +1,3 @@
 ALTER TABLE chat_message_search
     ADD FULLTEXT INDEX idx_content_ngram (content)
         WITH PARSER ngram;
-
-ALTER TABLE chat_message_search
-    ADD INDEX idx_room_id (room_id);
-

--- a/frontend/src/components/SideBar.jsx
+++ b/frontend/src/components/SideBar.jsx
@@ -1,20 +1,18 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { FaRegCommentDots, FaInfoCircle, FaAngleLeft, FaAngleRight, FaComments, FaPlus } from 'react-icons/fa';
-import { Client } from '@stomp/stompjs';
-import SockJS from 'sockjs-client';
 
 import CreateRoomModal from './modals/CreateRoomModal';
 import JoinRoomModal from './modals/JoinRoomModal';
 import RoomInfoModal from './modals/RoomInfoModal';
 import Toast from './common/Toast';
 import axiosInstance from "./api/axiosInstance"
+import useWebSocket from './common/useWebSocket'; // useWebSocket 훅 import
 
 const Sidebar = () => {
   const navigate = useNavigate();
   const { inviteCode } = useParams();
   const sidebarRef = useRef(null);
-  const stompClientRef = useRef(null);
 
   const [chatRooms, setChatRooms] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -41,61 +39,31 @@ const Sidebar = () => {
   const [unreadMessages, setUnreadMessages] = useState({});
   const [roomId, setRoomId] = useState(null);
 
+  // 사이드바 메시지 처리 콜백
+  const handleSidebarMessage = (roomUniqueId, message) => {
+    // 현재 있는 채팅방이 아닌 경우에만 알림 표시
+    if (Number(roomId) !== Number(roomUniqueId)) {
+      setUnreadMessages(prev => ({
+        ...prev,
+        [roomUniqueId]: true
+      }));
+      console.log(`📨 New message in room ${roomUniqueId}`);
+    }
+  };
+
+  // useWebSocket 훅 사용 - 사이드바용 구독만 활성화
+  const stompClientRef = useWebSocket({
+    roomId: null, // 메인 채팅방 구독은 비활성화
+    onMessageReceived: () => {}, // 메인 메시지 처리는 비활성화
+    chatRooms, // 채팅방 목록 전달
+    currentRoomId: roomId, // 현재 활성화된 채팅방 ID
+    onSidebarMessage: handleSidebarMessage, // 사이드바 메시지 처리 콜백
+  });
+
   useEffect(() => {
     fetchChatRooms(currentPage);
     fetchCurrentUser();
   }, [currentPage]);
-
-  // WebSocket 연결 설정
-  useEffect(() => {
-    if (chatRooms.length === 0) return;
-
-    const client = new Client({
-      webSocketFactory: () => new SockJS('http://localhost:8080/ws'),
-      reconnectDelay: 1000,
-      heartbeatIncoming: 15000,
-      heartbeatOutgoing: 10000,
-      debug: (str) => console.log(`[SIDEBAR STOMP] ${str}`),
-      onConnect: () => {
-        console.log('✅ Sidebar connected to WebSocket');
-
-        // 모든 채팅방에 대해 구독
-        chatRooms.forEach(room => {
-          const subscription = client.subscribe(`/topic/chat/${room.uniqueId}`, (message) => {
-            try {
-              const received = JSON.parse(message.body);
-
-              // 현재 있는 채팅방이 아닌 경우에만 알림 표시
-              if (Number(roomId) !== Number(room.uniqueId)) {
-                setUnreadMessages(prev => ({
-                  ...prev,
-                  [room.uniqueId]: true
-                }));
-                console.log(`📨 New message in room ${room.uniqueId}`);
-              }
-            } catch (e) {
-              console.error("📛 Failed to parse sidebar message", e);
-            }
-          });
-        });
-      },
-      onWebSocketClose: () => {
-        console.log('❌ Sidebar WebSocket disconnected');
-      },
-      onStompError: (frame) => {
-        console.error("💥 Sidebar STOMP error:", frame.headers['message']);
-      }
-    });
-
-    client.activate();
-    stompClientRef.current = client;
-
-    return () => {
-      if (stompClientRef.current) {
-        stompClientRef.current.deactivate();
-      }
-    };
-  }, [chatRooms, roomId]);
 
   // 현재 채팅방이 변경될 때 해당 방의 읽지 않은 메시지 상태 제거
   useEffect(() => {

--- a/frontend/src/components/chatroom/MessageInput.jsx
+++ b/frontend/src/components/chatroom/MessageInput.jsx
@@ -1,4 +1,4 @@
-//입력 모드 전환과 입력 필드
+// 입력 모드 전환과 입력 필드
 import React, { useRef } from 'react';
 import { FaTrashAlt } from 'react-icons/fa';
 
@@ -9,15 +9,15 @@ const MessageInput = ({
   setContent,
   language,
   setLanguage,
-  sendMessage,
-  handleUnifiedSend,
+  // sendMessage, // ⚡️ 이 prop은 더 이상 받지 않으므로 제거하거나 주석 처리
+  handleUnifiedSend, // ✅ 이 prop을 사용합니다.
   setImageFile,
   imagePreviewUrl,
   setImagePreviewUrl,
 }) => {
     const fileInputRef = useRef(null);
     const isComposingRef = useRef(false);
-    
+
     return (
         <>
           <div style={{ marginBottom: '12px', display: 'flex', alignItems: 'center'}}>
@@ -162,7 +162,8 @@ const MessageInput = ({
                     onKeyDown={(e) => {
                       if (e.key === 'Enter' && !e.shiftKey && !isComposingRef.current) {
                         e.preventDefault();
-                        sendMessage(e.target.value);
+                        // ⚡️ 중요: sendMessage 대신 handleUnifiedSend를 호출합니다.
+                        handleUnifiedSend();
                       }
                     }}
                     placeholder={inputMode === 'CODE' ? '코드를 입력하세요.' : inputMode === 'IMAGE' ? '이미지를 업로드 해주세요.' : '메시지를 입력하세요.'}
@@ -202,7 +203,7 @@ const MessageInput = ({
                   />
 
                   <button
-                    onClick={handleUnifiedSend}
+                    onClick={handleUnifiedSend} // 이 버튼은 이미 handleUnifiedSend를 호출하고 있습니다.
                     style={{
                       backgroundColor: '#4a6cf7',
                       color: 'white',

--- a/frontend/src/components/chatroom/MessageList.jsx
+++ b/frontend/src/components/chatroom/MessageList.jsx
@@ -47,10 +47,10 @@ const HighlightedCode = ({ content, language }) => {
   );
 };
 
-//프로필 이미지, 날짜, 수정 삭제 메뉴
+// 프로필 이미지, 날짜, 수정 삭제 메뉴
 const MessageItem = ({ msg, currentUser, contextMenuId, setContextMenuId, setEditMessageId, setEditContent, handleEditMessage, handleDeleteMessage, editMessageId, editContent }) => {
 
-  //이벤트 타입은 메세지만 렌더링
+  // 이벤트 타입은 메시지만 렌더링 (원래 로직 유지)
   if(msg.type === 'EVENT'){
     return(
       <MessageContent
@@ -297,7 +297,7 @@ const MessageContent = ({msg, editMessageId, editContent, setEditContent, handle
           {msg.content.split('\n').map((line, i) => (
              <div key={i}>
               {i === 0 ? (
-                <strong>{line}</strong>
+                <strong>{renderWithLink(line)}</strong> // renderWithLink 적용
               ) : (
                 <>{renderWithLink(line)}</>
               )}
@@ -413,7 +413,7 @@ const MessageContent = ({msg, editMessageId, editContent, setEditContent, handle
       wordBreak: 'break-word',
       whiteSpace: 'pre-wrap'
     }}>
-      {msg.content}
+      {renderWithLink(msg.content)} {/* renderWithLink 적용 */}
       {(msg.status === "EDITED") && (
         <span style={{
           marginLeft: '6px',
@@ -475,7 +475,7 @@ const MessageList = ({ messages, currentUser, contextMenuId, setContextMenuId, s
     // 메시지 추가
     result.push(
       <MessageItem
-      key={`msg-${index}`}
+      key={`msg-${msg.messageId || index}`} // messageId가 없는 경우를 대비해 index 사용
       msg={msg}
       currentUser={currentUser}
       contextMenuId={contextMenuId}
@@ -493,4 +493,3 @@ const MessageList = ({ messages, currentUser, contextMenuId, setContextMenuId, s
 };
 
 export default MessageList;
-  

--- a/frontend/src/components/chatroom/MessageList.jsx
+++ b/frontend/src/components/chatroom/MessageList.jsx
@@ -297,7 +297,7 @@ const MessageContent = ({msg, editMessageId, editContent, setEditContent, handle
           {msg.content.split('\n').map((line, i) => (
              <div key={i}>
               {i === 0 ? (
-                <strong>{renderWithLink(line)}</strong> // renderWithLink 적용
+                <strong>{line}</strong>
               ) : (
                 <>{renderWithLink(line)}</>
               )}

--- a/frontend/src/components/common/useWebSocket.jsx
+++ b/frontend/src/components/common/useWebSocket.jsx
@@ -6,27 +6,22 @@ import { useNavigate } from 'react-router-dom';
 const useWebSocket = ({
     roomId,
     onMessageReceived,
-    chatRooms = [], // 사이드바에서 사용할 채팅방 목록
-    currentRoomId, // 현재 활성화된 채팅방 ID
-    onSidebarMessage, // 사이드바 메시지 처리 콜백
+    chatRooms = [],
+    currentRoomId,
+    onSidebarMessage,
     onProfileUpdate,
 }) => {
     const stompClientRef = useRef(null);
     const subscriptionRef = useRef(null);
     const profileSubscriptionRef = useRef(null);
-    const hasConnectedRef = useRef(false); // 실제 연결에 성공했는지 추적
-    const sidebarSubscriptionsRef = useRef(new Map()); // 사이드바 구독들 관리하는 Map
+    const hasConnectedRef = useRef(false);
+    const sidebarSubscriptionsRef = useRef(new Map());
     const keepAliveIntervalRef = useRef(null);
 
-    const navigate = useNavigate(); 
+    const navigate = useNavigate();
 
+    // WebSocket 연결 초기화 (한 번만 실행)
     useEffect(() => {
-        
-        if (!roomId) {
-            console.log('⏳ roomId가 없어서 웹소켓 연결을 대기합니다.');
-            return;
-        }
-
         const client = new Client({
             webSocketFactory: () => new SockJS('http://localhost:8080/ws'),
             reconnectDelay: 1000,
@@ -35,90 +30,34 @@ const useWebSocket = ({
             debug: (str) => console.log(`[STOMP] ${str}`),
 
             onConnect: () => {
-            console.log('✅ Connected to WebSocket');
-            hasConnectedRef.current = true;
+                console.log('✅ Connected to WebSocket');
+                hasConnectedRef.current = true;
 
-            if (subscriptionRef.current) {
-                subscriptionRef.current.unsubscribe();
-                console.log("🔁 Previous subscription cleared.");
-            }
-
-            subscriptionRef.current = client.subscribe(`/topic/chat/${roomId}`, (message) => {
-                try {
-                    const received = JSON.parse(message.body);
-                    // received.sendAt ||= new Date().toISOString();
-                    // sendAt → 없으면 joinAt → 없으면 현재 시간
-                    received.sendAt = received.sendAt || new Date().toISOString();
-                    onMessageReceived(received)
-                } catch (e) {
-                console.error("📛 Failed to parse incoming message", e);
+                // 프로필 업데이트 구독 (한 번만 설정)
+                if (onProfileUpdate && !profileSubscriptionRef.current) {
+                    profileSubscriptionRef.current = client.subscribe('/topic/profile-update', (message) => {
+                        try {
+                            const profileUpdate = JSON.parse(message.body);
+                            console.log('🔥 프로필 업데이트 수신:', profileUpdate);
+                            onProfileUpdate(profileUpdate);
+                        } catch (e) {
+                            console.error("📛 Failed to parse profile update message", e);
+                        }
+                    });
+                    console.log('👤 프로필 업데이트 구독 완료');
                 }
-            });
 
-            // 사이드바용 채팅방들 구독 관리
-            if (chatRooms.length > 0 && onSidebarMessage) {
-            // 기존 사이드바 구독들 정리
-            sidebarSubscriptionsRef.current.forEach((subscription, roomId) => {
-                subscription.unsubscribe();
-                console.log(`🔁 Previous sidebar subscription for room ${roomId} cleared.`);
-            });
-            sidebarSubscriptionsRef.current.clear();
-
-            // 모든 채팅방에 대해 구독 설정
-            chatRooms.forEach(room => {
-                const roomUniqueId = room.uniqueId;
-                if (roomUniqueId) {
-                const subscription = client.subscribe(`/topic/chat/${roomUniqueId}`, (message) => {
-                    try {
-                    const received = JSON.parse(message.body);
-                    
-                    // 현재 있는 채팅방이 아닌 경우에만 사이드바 알림 처리
-                    if (Number(currentRoomId) !== Number(roomUniqueId)) {
-                        onSidebarMessage(roomUniqueId, received);
-                        console.log(`📨 New message in room ${roomUniqueId}`);
+                // Keep-alive 설정
+                if (keepAliveIntervalRef.current) clearInterval(keepAliveIntervalRef.current);
+                keepAliveIntervalRef.current = setInterval(() => {
+                    if (client && client.connected) {
+                        client.publish({
+                            destination: '/app/ping',
+                            body: 'ping'
+                        });
+                        console.log("📡 Sent keep-alive ping");
                     }
-                    } catch (e) {
-                    console.error("📛 Failed to parse sidebar message", e);
-                    }
-                });
-                
-                sidebarSubscriptionsRef.current.set(roomUniqueId, subscription);
-                console.log(`📡 Subscribed to sidebar room: ${roomUniqueId}`);
-                }
-            });
-            }
-
-            // 프로필 업데이트 구독
-            if (onProfileUpdate) {
-            if (profileSubscriptionRef.current) {
-                profileSubscriptionRef.current.unsubscribe();
-                console.log("🔁 Previous profile subscription cleared.");
-            }
-            
-            profileSubscriptionRef.current = client.subscribe('/topic/profile-update', (message) => {
-                try {
-                const profileUpdate = JSON.parse(message.body);
-                console.log('🔥 프로필 업데이트 수신:', profileUpdate);
-                onProfileUpdate(profileUpdate);
-                } catch (e) {
-                console.error("📛 Failed to parse profile update message", e);
-                }
-            });
-            
-            console.log('👤 프로필 업데이트 구독 완료');
-            }
-
-            if (keepAliveIntervalRef.current) clearInterval(keepAliveIntervalRef.current);
-
-            keepAliveIntervalRef.current = setInterval(() => {
-                if (client && client.connected) {
-                client.publish({
-                    destination: '/app/ping',
-                    body: 'ping'
-                });
-                console.log("📡 Sent keep-alive ping");
-                }
-            }, 20000);
+                }, 20000);
             },
             
             onStompError: (frame) => {
@@ -140,18 +79,101 @@ const useWebSocket = ({
                 keepAliveIntervalRef.current = null;
                 console.log("🔕 Stopped keep-alive ping");
             }
+
+            // 모든 구독 해제
             if (subscriptionRef.current) {
                 subscriptionRef.current.unsubscribe();
                 subscriptionRef.current = null;
-                console.log("🔌 Subscription unsubscribed.");
             }
+
+            if (profileSubscriptionRef.current) {
+                profileSubscriptionRef.current.unsubscribe();
+                profileSubscriptionRef.current = null;
+            }
+
+            sidebarSubscriptionsRef.current.forEach((subscription) => {
+                subscription.unsubscribe();
+            });
+            sidebarSubscriptionsRef.current.clear();
+
             if (client && client.active) {
                 client.deactivate().then(() => {
                     console.log("🛑 Disconnected from WebSocket");
                 });
             }
         };
-    }, [currentRoomId, navigate, onProfileUpdate, roomId]);
+    }, []); // 의존성 배열을 비워서 한 번만 실행
+
+    // 메인 채팅방 구독 관리 (roomId 변경 시에만)
+    useEffect(() => {
+        const client = stompClientRef.current;
+        if (!client || !client.connected || !roomId || !onMessageReceived) {
+            console.log('⏳ 메인 채팅방 구독 대기 중...');
+            return;
+        }
+
+        console.log(`🔄 메인 채팅방 구독 변경: ${roomId}`);
+
+        // 기존 메인 채팅방 구독 해제
+        if (subscriptionRef.current) {
+            subscriptionRef.current.unsubscribe();
+            console.log("🔁 Previous main subscription cleared.");
+        }
+
+        // 새로운 메인 채팅방 구독
+        subscriptionRef.current = client.subscribe(`/topic/chat/${roomId}`, (message) => {
+            try {
+                const received = JSON.parse(message.body);
+                received.sendAt = received.sendAt || new Date().toISOString();
+                onMessageReceived(received);
+            } catch (e) {
+                console.error("📛 Failed to parse incoming message", e);
+            }
+        });
+
+        console.log(`📡 메인 채팅방 구독 완료: ${roomId}`);
+    }, [roomId, onMessageReceived]);
+
+    // 사이드바 채팅방들 구독 관리 (chatRooms 변경 시에만)
+    useEffect(() => {
+        const client = stompClientRef.current;
+        if (!client || !client.connected || chatRooms.length === 0 || !onSidebarMessage) {
+            console.log('⏳ 사이드바 구독 대기 중...');
+            return;
+        }
+
+        console.log('🔄 사이드바 구독 목록 업데이트');
+
+        // 기존 사이드바 구독들 정리
+        sidebarSubscriptionsRef.current.forEach((subscription, roomId) => {
+            subscription.unsubscribe();
+            console.log(`🔁 Previous sidebar subscription for room ${roomId} cleared.`);
+        });
+        sidebarSubscriptionsRef.current.clear();
+
+        // 모든 채팅방에 대해 구독 설정
+        chatRooms.forEach(room => {
+            const roomUniqueId = room.uniqueId;
+            if (roomUniqueId) {
+                const subscription = client.subscribe(`/topic/chat/${roomUniqueId}`, (message) => {
+                    try {
+                        const received = JSON.parse(message.body);
+                        
+                        // 현재 있는 채팅방이 아닌 경우에만 사이드바 알림 처리
+                        if (Number(currentRoomId) !== Number(roomUniqueId)) {
+                            onSidebarMessage(roomUniqueId, received);
+                            console.log(`📨 New message in room ${roomUniqueId}`);
+                        }
+                    } catch (e) {
+                        console.error("📛 Failed to parse sidebar message", e);
+                    }
+                });
+                
+                sidebarSubscriptionsRef.current.set(roomUniqueId, subscription);
+                console.log(`📡 Subscribed to sidebar room: ${roomUniqueId}`);
+            }
+        });
+    }, [chatRooms, currentRoomId, onSidebarMessage]);
 
     return stompClientRef;
 };

--- a/frontend/src/components/common/useWebSocket.jsx
+++ b/frontend/src/components/common/useWebSocket.jsx
@@ -6,22 +6,27 @@ import { useNavigate } from 'react-router-dom';
 const useWebSocket = ({
     roomId,
     onMessageReceived,
-    chatRooms = [],
-    currentRoomId,
-    onSidebarMessage,
+    chatRooms = [], // 사이드바에서 사용할 채팅방 목록
+    currentRoomId, // 현재 활성화된 채팅방 ID
+    onSidebarMessage, // 사이드바 메시지 처리 콜백
     onProfileUpdate,
 }) => {
     const stompClientRef = useRef(null);
     const subscriptionRef = useRef(null);
     const profileSubscriptionRef = useRef(null);
-    const hasConnectedRef = useRef(false);
-    const sidebarSubscriptionsRef = useRef(new Map());
+    const hasConnectedRef = useRef(false); // 실제 연결에 성공했는지 추적
+    const sidebarSubscriptionsRef = useRef(new Map()); // 사이드바 구독들 관리하는 Map
     const keepAliveIntervalRef = useRef(null);
 
-    const navigate = useNavigate();
+    const navigate = useNavigate(); 
 
-    // WebSocket 연결 초기화 (한 번만 실행)
     useEffect(() => {
+        
+        if (!roomId) {
+            console.log('⏳ roomId가 없어서 웹소켓 연결을 대기합니다.');
+            return;
+        }
+
         const client = new Client({
             webSocketFactory: () => new SockJS('http://localhost:8080/ws'),
             reconnectDelay: 1000,
@@ -30,34 +35,90 @@ const useWebSocket = ({
             debug: (str) => console.log(`[STOMP] ${str}`),
 
             onConnect: () => {
-                console.log('✅ Connected to WebSocket');
-                hasConnectedRef.current = true;
+            console.log('✅ Connected to WebSocket');
+            hasConnectedRef.current = true;
 
-                // 프로필 업데이트 구독 (한 번만 설정)
-                if (onProfileUpdate && !profileSubscriptionRef.current) {
-                    profileSubscriptionRef.current = client.subscribe('/topic/profile-update', (message) => {
-                        try {
-                            const profileUpdate = JSON.parse(message.body);
-                            console.log('🔥 프로필 업데이트 수신:', profileUpdate);
-                            onProfileUpdate(profileUpdate);
-                        } catch (e) {
-                            console.error("📛 Failed to parse profile update message", e);
-                        }
-                    });
-                    console.log('👤 프로필 업데이트 구독 완료');
+            if (subscriptionRef.current) {
+                subscriptionRef.current.unsubscribe();
+                console.log("🔁 Previous subscription cleared.");
+            }
+
+            subscriptionRef.current = client.subscribe(`/topic/chat/${roomId}`, (message) => {
+                try {
+                    const received = JSON.parse(message.body);
+                    // received.sendAt ||= new Date().toISOString();
+                    // sendAt → 없으면 joinAt → 없으면 현재 시간
+                    received.sendAt = received.sendAt || new Date().toISOString();
+                    onMessageReceived(received)
+                } catch (e) {
+                console.error("📛 Failed to parse incoming message", e);
                 }
+            });
 
-                // Keep-alive 설정
-                if (keepAliveIntervalRef.current) clearInterval(keepAliveIntervalRef.current);
-                keepAliveIntervalRef.current = setInterval(() => {
-                    if (client && client.connected) {
-                        client.publish({
-                            destination: '/app/ping',
-                            body: 'ping'
-                        });
-                        console.log("📡 Sent keep-alive ping");
+            // 사이드바용 채팅방들 구독 관리
+            if (chatRooms.length > 0 && onSidebarMessage) {
+            // 기존 사이드바 구독들 정리
+            sidebarSubscriptionsRef.current.forEach((subscription, roomId) => {
+                subscription.unsubscribe();
+                console.log(`🔁 Previous sidebar subscription for room ${roomId} cleared.`);
+            });
+            sidebarSubscriptionsRef.current.clear();
+
+            // 모든 채팅방에 대해 구독 설정
+            chatRooms.forEach(room => {
+                const roomUniqueId = room.uniqueId;
+                if (roomUniqueId) {
+                const subscription = client.subscribe(`/topic/chat/${roomUniqueId}`, (message) => {
+                    try {
+                    const received = JSON.parse(message.body);
+                    
+                    // 현재 있는 채팅방이 아닌 경우에만 사이드바 알림 처리
+                    if (Number(currentRoomId) !== Number(roomUniqueId)) {
+                        onSidebarMessage(roomUniqueId, received);
+                        console.log(`📨 New message in room ${roomUniqueId}`);
                     }
-                }, 20000);
+                    } catch (e) {
+                    console.error("📛 Failed to parse sidebar message", e);
+                    }
+                });
+                
+                sidebarSubscriptionsRef.current.set(roomUniqueId, subscription);
+                console.log(`📡 Subscribed to sidebar room: ${roomUniqueId}`);
+                }
+            });
+            }
+
+            // 프로필 업데이트 구독
+            if (onProfileUpdate) {
+            if (profileSubscriptionRef.current) {
+                profileSubscriptionRef.current.unsubscribe();
+                console.log("🔁 Previous profile subscription cleared.");
+            }
+            
+            profileSubscriptionRef.current = client.subscribe('/topic/profile-update', (message) => {
+                try {
+                const profileUpdate = JSON.parse(message.body);
+                console.log('🔥 프로필 업데이트 수신:', profileUpdate);
+                onProfileUpdate(profileUpdate);
+                } catch (e) {
+                console.error("📛 Failed to parse profile update message", e);
+                }
+            });
+            
+            console.log('👤 프로필 업데이트 구독 완료');
+            }
+
+            if (keepAliveIntervalRef.current) clearInterval(keepAliveIntervalRef.current);
+
+            keepAliveIntervalRef.current = setInterval(() => {
+                if (client && client.connected) {
+                client.publish({
+                    destination: '/app/ping',
+                    body: 'ping'
+                });
+                console.log("📡 Sent keep-alive ping");
+                }
+            }, 20000);
             },
             
             onStompError: (frame) => {
@@ -79,101 +140,18 @@ const useWebSocket = ({
                 keepAliveIntervalRef.current = null;
                 console.log("🔕 Stopped keep-alive ping");
             }
-
-            // 모든 구독 해제
             if (subscriptionRef.current) {
                 subscriptionRef.current.unsubscribe();
                 subscriptionRef.current = null;
+                console.log("🔌 Subscription unsubscribed.");
             }
-
-            if (profileSubscriptionRef.current) {
-                profileSubscriptionRef.current.unsubscribe();
-                profileSubscriptionRef.current = null;
-            }
-
-            sidebarSubscriptionsRef.current.forEach((subscription) => {
-                subscription.unsubscribe();
-            });
-            sidebarSubscriptionsRef.current.clear();
-
             if (client && client.active) {
                 client.deactivate().then(() => {
                     console.log("🛑 Disconnected from WebSocket");
                 });
             }
         };
-    }, []); // 의존성 배열을 비워서 한 번만 실행
-
-    // 메인 채팅방 구독 관리 (roomId 변경 시에만)
-    useEffect(() => {
-        const client = stompClientRef.current;
-        if (!client || !client.connected || !roomId || !onMessageReceived) {
-            console.log('⏳ 메인 채팅방 구독 대기 중...');
-            return;
-        }
-
-        console.log(`🔄 메인 채팅방 구독 변경: ${roomId}`);
-
-        // 기존 메인 채팅방 구독 해제
-        if (subscriptionRef.current) {
-            subscriptionRef.current.unsubscribe();
-            console.log("🔁 Previous main subscription cleared.");
-        }
-
-        // 새로운 메인 채팅방 구독
-        subscriptionRef.current = client.subscribe(`/topic/chat/${roomId}`, (message) => {
-            try {
-                const received = JSON.parse(message.body);
-                received.sendAt = received.sendAt || new Date().toISOString();
-                onMessageReceived(received);
-            } catch (e) {
-                console.error("📛 Failed to parse incoming message", e);
-            }
-        });
-
-        console.log(`📡 메인 채팅방 구독 완료: ${roomId}`);
-    }, [roomId, onMessageReceived]);
-
-    // 사이드바 채팅방들 구독 관리 (chatRooms 변경 시에만)
-    useEffect(() => {
-        const client = stompClientRef.current;
-        if (!client || !client.connected || chatRooms.length === 0 || !onSidebarMessage) {
-            console.log('⏳ 사이드바 구독 대기 중...');
-            return;
-        }
-
-        console.log('🔄 사이드바 구독 목록 업데이트');
-
-        // 기존 사이드바 구독들 정리
-        sidebarSubscriptionsRef.current.forEach((subscription, roomId) => {
-            subscription.unsubscribe();
-            console.log(`🔁 Previous sidebar subscription for room ${roomId} cleared.`);
-        });
-        sidebarSubscriptionsRef.current.clear();
-
-        // 모든 채팅방에 대해 구독 설정
-        chatRooms.forEach(room => {
-            const roomUniqueId = room.uniqueId;
-            if (roomUniqueId) {
-                const subscription = client.subscribe(`/topic/chat/${roomUniqueId}`, (message) => {
-                    try {
-                        const received = JSON.parse(message.body);
-                        
-                        // 현재 있는 채팅방이 아닌 경우에만 사이드바 알림 처리
-                        if (Number(currentRoomId) !== Number(roomUniqueId)) {
-                            onSidebarMessage(roomUniqueId, received);
-                            console.log(`📨 New message in room ${roomUniqueId}`);
-                        }
-                    } catch (e) {
-                        console.error("📛 Failed to parse sidebar message", e);
-                    }
-                });
-                
-                sidebarSubscriptionsRef.current.set(roomUniqueId, subscription);
-                console.log(`📡 Subscribed to sidebar room: ${roomUniqueId}`);
-            }
-        });
-    }, [chatRooms, currentRoomId, onSidebarMessage]);
+    }, [currentRoomId, navigate, onProfileUpdate, roomId]);
 
     return stompClientRef;
 };

--- a/frontend/src/components/common/useWebSocket.jsx
+++ b/frontend/src/components/common/useWebSocket.jsx
@@ -6,12 +6,16 @@ import { useNavigate } from 'react-router-dom';
 const useWebSocket = ({
     roomId,
     onMessageReceived,
+    chatRooms = [], // 사이드바에서 사용할 채팅방 목록
+    currentRoomId, // 현재 활성화된 채팅방 ID
+    onSidebarMessage, // 사이드바 메시지 처리 콜백
     onProfileUpdate,
 }) => {
     const stompClientRef = useRef(null);
     const subscriptionRef = useRef(null);
-    const profileSubscriptionRef = useRef(null); // 프로필 업데이트 구독 ref 추가
+    const profileSubscriptionRef = useRef(null);
     const hasConnectedRef = useRef(false); // 실제 연결에 성공했는지 추적
+    const sidebarSubscriptionsRef = useRef(new Map()); // 사이드바 구독들 관리하는 Map
     const keepAliveIntervalRef = useRef(null);
 
     const navigate = useNavigate(); 
@@ -50,19 +54,49 @@ const useWebSocket = ({
                 console.error("📛 Failed to parse incoming message", e);
                 }
             });
-            
-            // 프로필 업데이트 구독 추가
-            // 콜백이 전달된 경우에만 실행
+
+            // 사이드바용 채팅방들 구독 관리
+            if (chatRooms.length > 0 && onSidebarMessage) {
+            // 기존 사이드바 구독들 정리
+            sidebarSubscriptionsRef.current.forEach((subscription, roomId) => {
+                subscription.unsubscribe();
+                console.log(`🔁 Previous sidebar subscription for room ${roomId} cleared.`);
+            });
+            sidebarSubscriptionsRef.current.clear();
+
+            // 모든 채팅방에 대해 구독 설정
+            chatRooms.forEach(room => {
+                const roomUniqueId = room.uniqueId;
+                if (roomUniqueId) {
+                const subscription = client.subscribe(`/topic/chat/${roomUniqueId}`, (message) => {
+                    try {
+                    const received = JSON.parse(message.body);
+                    
+                    // 현재 있는 채팅방이 아닌 경우에만 사이드바 알림 처리
+                    if (Number(currentRoomId) !== Number(roomUniqueId)) {
+                        onSidebarMessage(roomUniqueId, received);
+                        console.log(`📨 New message in room ${roomUniqueId}`);
+                    }
+                    } catch (e) {
+                    console.error("📛 Failed to parse sidebar message", e);
+                    }
+                });
+                
+                sidebarSubscriptionsRef.current.set(roomUniqueId, subscription);
+                console.log(`📡 Subscribed to sidebar room: ${roomUniqueId}`);
+                }
+            });
+            }
+
+            // 프로필 업데이트 구독
             if (onProfileUpdate) {
-                // 중복 구독 방지
             if (profileSubscriptionRef.current) {
                 profileSubscriptionRef.current.unsubscribe();
                 console.log("🔁 Previous profile subscription cleared.");
             }
-            // 구독 시작
+            
             profileSubscriptionRef.current = client.subscribe('/topic/profile-update', (message) => {
                 try {
-                    // 수신 메시지 JSON 파싱
                 const profileUpdate = JSON.parse(message.body);
                 console.log('🔥 프로필 업데이트 수신:', profileUpdate);
                 onProfileUpdate(profileUpdate);
@@ -117,7 +151,7 @@ const useWebSocket = ({
                 });
             }
         };
-    }, [roomId, onProfileUpdate]);
+    }, [currentRoomId, navigate, onProfileUpdate, chatRooms, roomId]);
 
     return stompClientRef;
 };

--- a/frontend/src/components/common/useWebSocket.jsx
+++ b/frontend/src/components/common/useWebSocket.jsx
@@ -151,7 +151,7 @@ const useWebSocket = ({
                 });
             }
         };
-    }, [currentRoomId, navigate, onProfileUpdate, chatRooms, roomId]);
+    }, [currentRoomId, navigate, onProfileUpdate, roomId]);
 
     return stompClientRef;
 };

--- a/frontend/src/components/common/useWebSocket.jsx
+++ b/frontend/src/components/common/useWebSocket.jsx
@@ -6,9 +6,11 @@ import { useNavigate } from 'react-router-dom';
 const useWebSocket = ({
     roomId,
     onMessageReceived,
+    onProfileUpdate,
 }) => {
     const stompClientRef = useRef(null);
     const subscriptionRef = useRef(null);
+    const profileSubscriptionRef = useRef(null); // 프로필 업데이트 구독 ref 추가
     const hasConnectedRef = useRef(false); // 실제 연결에 성공했는지 추적
     const keepAliveIntervalRef = useRef(null);
 
@@ -48,6 +50,29 @@ const useWebSocket = ({
                 console.error("📛 Failed to parse incoming message", e);
                 }
             });
+            
+            // 프로필 업데이트 구독 추가
+            // 콜백이 전달된 경우에만 실행
+            if (onProfileUpdate) {
+                // 중복 구독 방지
+            if (profileSubscriptionRef.current) {
+                profileSubscriptionRef.current.unsubscribe();
+                console.log("🔁 Previous profile subscription cleared.");
+            }
+            // 구독 시작
+            profileSubscriptionRef.current = client.subscribe('/topic/profile-update', (message) => {
+                try {
+                    // 수신 메시지 JSON 파싱
+                const profileUpdate = JSON.parse(message.body);
+                console.log('🔥 프로필 업데이트 수신:', profileUpdate);
+                onProfileUpdate(profileUpdate);
+                } catch (e) {
+                console.error("📛 Failed to parse profile update message", e);
+                }
+            });
+            
+            console.log('👤 프로필 업데이트 구독 완료');
+            }
 
             if (keepAliveIntervalRef.current) clearInterval(keepAliveIntervalRef.current);
 
@@ -92,7 +117,7 @@ const useWebSocket = ({
                 });
             }
         };
-    }, [roomId]);
+    }, [roomId, onProfileUpdate]);
 
     return stompClientRef;
 };

--- a/frontend/src/components/modals/RoomInfoModal.jsx
+++ b/frontend/src/components/modals/RoomInfoModal.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import {
   FaInfoCircle,
   FaTimes,
@@ -6,15 +6,11 @@ import {
   FaUser,
   FaCrown
 } from 'react-icons/fa';
-import SockJS from 'sockjs-client';
-import { Client } from '@stomp/stompjs';
 import axiosInstance from "../api/axiosInstance"
 
 const RoomInfoModal = ({ room, sidebarRef, onClose, showToast }) => {
   const [participants, setParticipants] = useState([]);
   const [loading, setLoading] = useState(false);
-  const stompClientRef = useRef(null);
-  const hasLoadedInitialData = useRef(false);
 
   const fetchParticipants = async () => {
     setLoading(true);
@@ -30,33 +26,9 @@ const RoomInfoModal = ({ room, sidebarRef, onClose, showToast }) => {
   };
 
   useEffect(() => {
-    if (room?.roomId && !hasLoadedInitialData.current) {
+    if (room?.roomId) {
       fetchParticipants();
-      hasLoadedInitialData.current = true;
     }
-
-    if (!room?.roomId) return;
-
-    const socket = new SockJS('http://localhost:8080/ws');
-    const stomp = new Client({
-      webSocketFactory: () => socket,
-      reconnectDelay: 5000,
-      onConnect: () => {
-        stomp.subscribe(`/topic/chat/${room.roomId}/refresh`, () => {
-          fetchParticipants();
-        });
-      },
-      onStompError: (frame) => {
-        console.error('STOMP error', frame);
-      }
-    });
-
-    stomp.activate();
-    stompClientRef.current = stomp;
-
-    return () => {
-      stomp.deactivate();
-    };
   }, [room?.roomId]);
 
   // 프로필 이미지 컴포넌트

--- a/frontend/src/pages/ChatRoom.jsx
+++ b/frontend/src/pages/ChatRoom.jsx
@@ -153,11 +153,6 @@ const ChatRoom = () => {
           ...prev,
           isMessagesLoaded: true
         }));
-        // ✅ 초기 로드 완료 후 맨 아래로 스크롤
-        setIsInitialLoad(false); // 먼저 false로 설정하여 아래 useEffect가 발동하도록
-        // requestAnimationFrame(() => { // scrollToBottom 내부에 requestAnimationFrame이 있으므로 여기서는 생략
-        //   scrollToBottom();
-        // });
       }
 
       // 커서와 hasMore 상태 업데이트
@@ -171,9 +166,8 @@ const ChatRoom = () => {
       console.error('❌ Error fetching messages:', error);
     } finally {
       setIsLoadingMessages(false);
-      // setIsInitialLoad(false); // 이 위치는 초기 로드 완료 후 맨 아래로 스크롤 로직에 방해가 될 수 있음
     }
-  }, [roomId]); // scrollToBottom을 의존성 배열에서 제거 (내부에서 requestAnimationFrame 처리)
+  }, [roomId]);
 
   // 3. 로그인 유저 정보 가져오기
   const fetchCurrentUser = useCallback(async () => {
@@ -229,11 +223,11 @@ const ChatRoom = () => {
   const stompClientRef = useWebSocket({
     roomId: initState.isRoomValidated ? roomId : null,
     onMessageReceived: (received) => {
+      // ⭐ 서버에서 받은 메시지만을 로컬 상태에 추가/업데이트
       setMessages(prev => {
-        // ⭐ 서버에서 받은 메시지로 기존 (임시) 메시지를 업데이트하거나 새 메시지 추가
         // 동일한 messageId를 가진 메시지가 이미 존재하면 업데이트하고, 없으면 추가
         const updated = prev.some(m => m.messageId === received.messageId)
-          ? prev.map(m => m.messageId === received.messageId ? { ...received, isSending: false } : m) // isSending 상태 업데이트
+          ? prev.map(m => m.messageId === received.messageId ? received : m)
           : [...prev, received];
 
         const sorted = [...updated].sort((a, b) => new Date(a.sendAt).getTime() - new Date(b.sendAt).getTime());
@@ -243,6 +237,7 @@ const ChatRoom = () => {
         if (messageContainerRef.current) {
           const { scrollTop, clientHeight, scrollHeight } = messageContainerRef.current;
           const isNearBottom = (scrollTop + clientHeight) >= (scrollHeight - 100); // 100px 여유
+          // 새 메시지가 나(currentUser)의 메시지이거나, 스크롤이 거의 맨 아래에 있을 때만 스크롤
           if (isNearBottom || received.senderId === currentUser?.userId) {
             scrollToBottom();
           }
@@ -353,23 +348,23 @@ const ChatRoom = () => {
   // roomId가 설정되고 방 정보가 유효하며, 초기 로드가 아직 안된 경우 메시지 로드
   useEffect(() => {
     // isInitialLoad가 true일 때만 fetchMessages를 호출하여 초기 로드를 제어
-    // fetchMessages 내부에서 isInitialLoad를 false로 변경하고 scrollToBottom 호출
     if (roomId && initState.isRoomValidated && isInitialLoad) {
       fetchMessages();
+      setIsInitialLoad(false); // 초기 로드 후 바로 false로 설정
     }
   }, [roomId, initState.isRoomValidated, isInitialLoad, fetchMessages]);
 
-  // 메시지 로드 후 스크롤 위치 조정 (무한 스크롤 시에만 restoreScrollPosition 호출)
+  // 메시지 로드 후 스크롤 위치 조정
   useEffect(() => {
-    // isInitialLoad가 false일 때만 restoreScrollPosition을 호출 (추가 메시지 로드 시)
-    // 초기 로드 시에는 fetchMessages 내에서 scrollToBottom이 직접 호출됨
-    if (!isInitialLoad && messages.length > 0 && isLoadingMessages) { // isLoadingMessages 조건 추가
+    // 초기 로딩이 완료된 후 메시지가 있고 더 이상 로딩 중이 아닐 때 맨 아래로 스크롤
+    // isInitialLoad가 false일 때만 실행하며, isLoadingMessages가 false일 때 즉시 스크롤
+    if (!isInitialLoad && messages.length > 0 && !isLoadingMessages) {
+      scrollToBottom();
+    } else if (!isInitialLoad && messages.length > 0 && isLoadingMessages) {
+      // 추가 메시지 로드 중일 때 스크롤 위치 복원
       requestAnimationFrame(() => {
         restoreScrollPosition();
       });
-    } else if (isInitialLoad === false && messages.length > 0 && !isLoadingMessages) {
-      // 초기 로딩이 완료된 후, 메시지가 있고 더 이상 로딩 중이 아닐 때 맨 아래로 스크롤 (초기 로드 완료 시)
-      scrollToBottom();
     }
   }, [messages, isInitialLoad, restoreScrollPosition, isLoadingMessages, scrollToBottom]);
 
@@ -464,21 +459,18 @@ const ChatRoom = () => {
         const formData = new FormData();
         formData.append('image', imageFile);
 
-        // 이미지 파일을 먼저 업로드하고 ID를 받습니다.
         const response = await axiosInstance.post('/send-image', formData, {
           headers: { 'Content-Type': 'multipart/form-data' }
         });
 
         const imageId = response.data;
 
-        // 이미지 ID를 포함하여 메시지를 웹소켓으로 보냅니다.
-        // 이미지의 경우 임시 전송 로직을 사용하지 않고, 서버에서 받은 응답으로만 처리
-        // (즉, 웹소켓 onMessageReceived를 통해 이미지가 수신될 때만 화면에 표시)
+        // 이미지 메시지는 서버에서 완전한 메시지를 받아올 때까지 화면에 표시하지 않음
         sendMessage({
           type: 'IMAGE',
           content: '', // 이미지 메시지는 content가 비어있을 수 있습니다.
           imageFileId: imageId
-        }, false); // isTemporary = false로 설정하여 임시 메시지 생성 방지
+        });
 
         setImageFile(null);
         setImagePreviewUrl(null);
@@ -487,13 +479,13 @@ const ChatRoom = () => {
         alert("이미지 전송에 실패했습니다. 다시 시도해주세요.");
       }
     } else {
-      // 텍스트, 코드 메시지 전송 (임시 전송 로직 사용)
+      // 텍스트, 코드 메시지 전송 (임시 메시지 로직 제거)
       sendMessage();
     }
   };
 
-  // 메시지 전송
-  const sendMessage = (overrideMessage = null, isTemporary = true) => { // isTemporary 파라미터 추가
+  // 메시지 전송 (임시 메시지 로직 제거)
+  const sendMessage = (overrideMessage = null) => { // isTemporary 파라미터 제거
     const client = stompClientRef.current;
 
     if (!roomId || !initState.isRoomValidated) {
@@ -526,48 +518,12 @@ const ChatRoom = () => {
       return;
     }
 
-    // ⭐ 중요: 서버에 보낼 메시지에 임시 messageId를 추가하고 로컬 상태에 즉시 반영
-    // 이미지를 제외하고 텍스트/코드 메시지에만 임시 전송 로직 적용
-    if (isTemporary) { // isTemporary가 true일 때만 임시 메시지 생성
-      const tempMessageId = `temp-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
-      const messageWithTempId = {
-        ...messageToSend,
-        messageId: tempMessageId, // 임시 ID
-        senderId: currentUser.userId,
-        senderName: currentUser.nickname,
-        profileImageUrl: currentUser.profileImg || '',
-        isSending: true // 전송 중 상태 표시 (옵션)
-      };
-
-      // 1. 서버에 메시지 전송 (웹소켓 publish)
-      client.publish({
-        destination: `/chat/send-message/${roomId}`,
-        body: JSON.stringify(messageWithTempId) // 임시 ID가 포함된 메시지 전송
-      });
-
-      // 2. 메시지를 로컬 상태에 즉시 추가하여 화면에 표시
-      setMessages(prev => {
-        // 기존 메시지 중 동일한 임시 ID가 있으면 업데이트 (혹시 모를 중복 방지), 없으면 새로 추가
-        const updated = prev.some(m => m.messageId === messageWithTempId.messageId)
-          ? prev.map(m => m.messageId === messageWithTempId.messageId ? messageWithTempId : m)
-          : [...prev, messageWithTempId];
-
-        const sorted = [...updated].sort(
-          (a, b) => new Date(a.sendAt).getTime() - new Date(b.sendAt).getTime()
-        );
-
-        // 맨 아래로 스크롤
-        scrollToBottom();
-
-        return sorted;
-      });
-    } else {
-      // isTemporary가 false일 경우 (예: 이미지 메시지) 서버로만 전송
-      client.publish({
-        destination: `/chat/send-message/${roomId}`,
-        body: JSON.stringify(messageToSend)
-      });
-    }
+    // ⭐ 중요: 서버에 보낼 메시지를 즉시 로컬 상태에 추가하지 않고,
+    // 서버에서 다시 브로드캐스트된 메시지만을 onMessageReceived에서 처리
+    client.publish({
+      destination: `/chat/send-message/${roomId}`,
+      body: JSON.stringify(messageToSend)
+    });
 
     // 입력 필드 초기화
     setContent('');

--- a/frontend/src/pages/ChatRoom.jsx
+++ b/frontend/src/pages/ChatRoom.jsx
@@ -36,7 +36,7 @@ const ChatRoom = () => {
 
   const [roomName, setRoomName] = useState("로딩 중...");
   const [roomId, setRoomId] = useState(null);
-  
+
   // ✅ 초기화 상태를 하나로 통합하고 단계별로 관리
   const [initState, setInitState] = useState({
     isRoomValidated: false,
@@ -47,15 +47,18 @@ const ChatRoom = () => {
   });
 
   // ✅ 전체 로딩 상태를 계산으로 처리 (별도 상태 없음)
-  const isFullyLoaded = initState.isRoomValidated && 
-                       initState.isUserLoaded && 
-                       initState.isMessagesLoaded;
+  const isFullyLoaded = initState.isRoomValidated &&
+    initState.isUserLoaded &&
+    initState.isMessagesLoaded;
 
   // 맨 아래로 스크롤하는 함수 (새 메시지 수신용 및 초기 로드 완료 시 사용)
   const scrollToBottom = useCallback(() => {
     if (messageContainerRef.current) {
       const container = messageContainerRef.current;
-      container.scrollTop = container.scrollHeight;
+      // scrollHeight가 변경될 때까지 기다렸다가 스크롤
+      requestAnimationFrame(() => {
+        container.scrollTop = container.scrollHeight;
+      });
     }
   }, []);
 
@@ -67,13 +70,13 @@ const ChatRoom = () => {
 
       setRoomId(roomData.roomId);
       setRoomName(roomData.roomName);
-      
+
       // ✅ 한 번에 상태 업데이트
       setInitState(prev => ({
         ...prev,
         isRoomValidated: true
       }));
-      
+
       return roomData.roomId;
     } catch (error) {
       console.error('방 정보 조회 실패:', error);
@@ -89,7 +92,7 @@ const ChatRoom = () => {
   // 2. 메시지 목록 불러오기 (커서 기반)
   const fetchMessages = useCallback(async (cursorValue = null, isLoadMore = false) => {
     console.log('🔍 fetchMessages 호출:', { cursorValue, isLoadMore });
-    
+
     setIsLoadingMessages(prev => {
       if (prev) {
         console.log('❌ 이미 로딩 중이므로 중단');
@@ -102,7 +105,7 @@ const ChatRoom = () => {
       const params = {
         size: 30
       };
-      
+
       if (cursorValue) {
         params.cursor = cursorValue;
       }
@@ -112,7 +115,7 @@ const ChatRoom = () => {
       const data = res.data;
 
       const messageList = data.messages || [];
-      
+
       if (!Array.isArray(messageList)) {
         console.error('❌ Message list is not an array:', messageList);
         return;
@@ -144,7 +147,7 @@ const ChatRoom = () => {
       } else {
         // 초기 로드
         setMessages(sortedMessages);
-        
+
         // ✅ 초기 메시지 로드 완료 상태 업데이트
         setInitState(prev => ({
           ...prev,
@@ -152,25 +155,25 @@ const ChatRoom = () => {
         }));
         // ✅ 초기 로드 완료 후 맨 아래로 스크롤
         setIsInitialLoad(false); // 먼저 false로 설정하여 아래 useEffect가 발동하도록
-        requestAnimationFrame(() => {
-          scrollToBottom(); // 초기 로드 시 맨 아래로 스크롤
-        });
+        // requestAnimationFrame(() => { // scrollToBottom 내부에 requestAnimationFrame이 있으므로 여기서는 생략
+        //   scrollToBottom();
+        // });
       }
 
       // 커서와 hasMore 상태 업데이트
       const nextCursor = data.nextCursor;
       setCursor(nextCursor);
-      
+
       let hasMore = nextCursor !== null && messageList.length > 0;
       setHasMoreMessages(hasMore);
-      
+
     } catch (error) {
       console.error('❌ Error fetching messages:', error);
     } finally {
       setIsLoadingMessages(false);
       // setIsInitialLoad(false); // 이 위치는 초기 로드 완료 후 맨 아래로 스크롤 로직에 방해가 될 수 있음
     }
-  }, [roomId, scrollToBottom]); // scrollToBottom을 의존성 배열에 추가
+  }, [roomId]); // scrollToBottom을 의존성 배열에서 제거 (내부에서 requestAnimationFrame 처리)
 
   // 3. 로그인 유저 정보 가져오기
   const fetchCurrentUser = useCallback(async () => {
@@ -186,15 +189,15 @@ const ChatRoom = () => {
       }
 
       const user = await res.json();
-      console.log("현재 사용자 정보:", user); 
+      console.log("현재 사용자 정보:", user);
       setCurrentUser(user);
-      
+
       // ✅ 사용자 정보 로드 완료 상태 업데이트
       setInitState(prev => ({
         ...prev,
         isUserLoaded: true
       }));
-      
+
     } catch (error) {
       console.error('사용자 정보 요청 실패:', error);
       setInitState(prev => ({
@@ -207,7 +210,7 @@ const ChatRoom = () => {
   // 프로필 업데이트 처리 함수
   const handleProfileUpdate = useCallback((profileUpdateData) => {
     console.log('👤 프로필 업데이트 수신:', profileUpdateData);
-    
+
     setMessages(prevMessages => {
       return prevMessages.map(msg => {
         if (msg.senderId === profileUpdateData.userId) {
@@ -228,16 +231,22 @@ const ChatRoom = () => {
     onMessageReceived: (received) => {
       setMessages(prev => {
         // ⭐ 서버에서 받은 메시지로 기존 (임시) 메시지를 업데이트하거나 새 메시지 추가
+        // 동일한 messageId를 가진 메시지가 이미 존재하면 업데이트하고, 없으면 추가
         const updated = prev.some(m => m.messageId === received.messageId)
           ? prev.map(m => m.messageId === received.messageId ? { ...received, isSending: false } : m) // isSending 상태 업데이트
           : [...prev, received];
 
-        const sorted = [...updated].sort((a, b) => new Date(a.sendAt) - new Date(b.sendAt));
-        
-        requestAnimationFrame(() => {
-          scrollToBottom();
-        });
-        
+        const sorted = [...updated].sort((a, b) => new Date(a.sendAt).getTime() - new Date(b.sendAt).getTime());
+
+        // 새 메시지가 추가되었을 때만 맨 아래로 스크롤
+        // 현재 스크롤 위치가 거의 맨 아래에 있다면 스크롤, 아니면 유지
+        if (messageContainerRef.current) {
+          const { scrollTop, clientHeight, scrollHeight } = messageContainerRef.current;
+          const isNearBottom = (scrollTop + clientHeight) >= (scrollHeight - 100); // 100px 여유
+          if (isNearBottom || received.senderId === currentUser?.userId) {
+            scrollToBottom();
+          }
+        }
         return sorted;
       });
     },
@@ -247,32 +256,32 @@ const ChatRoom = () => {
   // 스크롤 위치 복원 함수 (무한 스크롤 시 사용)
   const restoreScrollPosition = useCallback(() => {
     if (!messageContainerRef.current) return;
-    
+
     const container = messageContainerRef.current;
     const newScrollHeight = container.scrollHeight;
     const oldScrollHeight = prevScrollHeightRef.current;
-    
+
     if (newScrollHeight > oldScrollHeight) {
       const scrollDiff = newScrollHeight - oldScrollHeight;
       const currentScrollTop = container.scrollTop;
       const newScrollTop = currentScrollTop + scrollDiff;
-      
+
       container.scrollTop = newScrollTop;
     }
-    
+
     prevScrollHeightRef.current = newScrollHeight;
   }, []);
 
   // 스크롤 이벤트 핸들러
   const handleScroll = useCallback(() => {
     if (!messageContainerRef.current || !roomId || !initState.isRoomValidated) return;
-    
+
     const container = messageContainerRef.current;
     const { scrollTop, scrollHeight } = container;
-    
+
     const isAtTop = scrollTop <= 150;
     const canLoadMore = !isLoadingMessages && hasMoreMessages && cursor;
-    
+
     if (isAtTop && canLoadMore) {
       prevScrollHeightRef.current = scrollHeight;
       fetchMessages(cursor, true);
@@ -308,30 +317,30 @@ const ChatRoom = () => {
       // ✅ 한 번에 모든 초기 상태 설정
       setInitState({
         isRoomValidated: false,
-        isUserLoaded: false, 
+        isUserLoaded: false,
         isMessagesLoaded: false,
         hasError: false,
         errorMessage: ''
       });
-      
+
       setMessages([]);
       setCursor(null);
       setHasMoreMessages(true);
       setIsInitialLoad(true); // 초기 로딩 상태를 true로 재설정
       setIsLoadingMessages(false);
-      
+
       try {
         // 방 정보와 사용자 정보를 병렬로 로드
         const [fetchedRoomId] = await Promise.all([
           fetchRoomInfo(),
           fetchCurrentUser()
         ]);
-        
+
         if (!fetchedRoomId) {
           navigate("/error");
           return;
         }
-        
+
       } catch (error) {
         console.error('방 초기화 중 오류:', error);
         navigate("/error");
@@ -358,8 +367,12 @@ const ChatRoom = () => {
       requestAnimationFrame(() => {
         restoreScrollPosition();
       });
+    } else if (isInitialLoad === false && messages.length > 0 && !isLoadingMessages) {
+      // 초기 로딩이 완료된 후, 메시지가 있고 더 이상 로딩 중이 아닐 때 맨 아래로 스크롤 (초기 로드 완료 시)
+      scrollToBottom();
     }
-  }, [messages, isInitialLoad, restoreScrollPosition, isLoadingMessages]);
+  }, [messages, isInitialLoad, restoreScrollPosition, isLoadingMessages, scrollToBottom]);
+
 
   const handleLeaveRoom = async () => {
     try {
@@ -386,7 +399,7 @@ const ChatRoom = () => {
       setErrorMessage('채팅방이 아직 로딩 중입니다. 잠시 후 다시 시도해주세요.');
       return;
     }
-    
+
     setIsSearching(true);
     setShowSearchSidebar(true);
     setSearchKeyword(keyword);
@@ -424,11 +437,11 @@ const ChatRoom = () => {
         behavior: 'smooth',
         block: 'center'
       });
-      
+
       messageElement.style.backgroundColor = '#e8f4fd';
       messageElement.style.borderRadius = '6px';
       messageElement.style.transition = 'all 0.3s ease';
-      
+
       setTimeout(() => {
         messageElement.style.backgroundColor = '';
         messageElement.style.borderRadius = '';
@@ -457,35 +470,37 @@ const ChatRoom = () => {
         });
 
         const imageId = response.data;
-        
+
         // 이미지 ID를 포함하여 메시지를 웹소켓으로 보냅니다.
-        // sendMessage 함수 내부에서 currentUser 정보를 활용할 것이므로 여기서는 넘기지 않아도 됩니다.
+        // 이미지의 경우 임시 전송 로직을 사용하지 않고, 서버에서 받은 응답으로만 처리
+        // (즉, 웹소켓 onMessageReceived를 통해 이미지가 수신될 때만 화면에 표시)
         sendMessage({
           type: 'IMAGE',
           content: '', // 이미지 메시지는 content가 비어있을 수 있습니다.
           imageFileId: imageId
-        });
+        }, false); // isTemporary = false로 설정하여 임시 메시지 생성 방지
 
         setImageFile(null);
         setImagePreviewUrl(null);
       } catch (err) {
         console.error("이미지 전송 실패: ", err);
+        alert("이미지 전송에 실패했습니다. 다시 시도해주세요.");
       }
     } else {
-      // 텍스트, 코드 메시지 전송
+      // 텍스트, 코드 메시지 전송 (임시 전송 로직 사용)
       sendMessage();
     }
   };
 
   // 메시지 전송
-  const sendMessage = (overrideMessage = null) => {
+  const sendMessage = (overrideMessage = null, isTemporary = true) => { // isTemporary 파라미터 추가
     const client = stompClientRef.current;
-    
+
     if (!roomId || !initState.isRoomValidated) {
       alert('채팅방 정보를 로딩 중입니다. 잠시 후 다시 시도해주세요.');
       return;
     }
-    
+
     if (!client || !client.connected) {
       alert('⚠️ 서버와 연결이 끊어졌습니다. 재연결을 시도합니다.');
       return;
@@ -512,40 +527,47 @@ const ChatRoom = () => {
     }
 
     // ⭐ 중요: 서버에 보낼 메시지에 임시 messageId를 추가하고 로컬 상태에 즉시 반영
-    const tempMessageId = `temp-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
-    const messageWithTempId = {
-      ...messageToSend,
-      messageId: tempMessageId, // 임시 ID
-      senderId: currentUser.userId, 
-      senderName: currentUser.nickname, 
-      profileImageUrl: currentUser.profileImg || '', 
-      isSending: true // 전송 중 상태 표시 (옵션)
-    };
+    // 이미지를 제외하고 텍스트/코드 메시지에만 임시 전송 로직 적용
+    if (isTemporary) { // isTemporary가 true일 때만 임시 메시지 생성
+      const tempMessageId = `temp-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
+      const messageWithTempId = {
+        ...messageToSend,
+        messageId: tempMessageId, // 임시 ID
+        senderId: currentUser.userId,
+        senderName: currentUser.nickname,
+        profileImageUrl: currentUser.profileImg || '',
+        isSending: true // 전송 중 상태 표시 (옵션)
+      };
 
-    // 1. 서버에 메시지 전송 (웹소켓 publish)
-    client.publish({
-      destination: `/chat/send-message/${roomId}`,
-      body: JSON.stringify(messageWithTempId) // 임시 ID가 포함된 메시지 전송
-    });
-
-    // 2. 메시지를 로컬 상태에 즉시 추가하여 화면에 표시
-    setMessages(prev => {
-      // 기존 메시지 중 동일한 임시 ID가 있으면 업데이트 (혹시 모를 중복 방지), 없으면 새로 추가
-      const updated = prev.some(m => m.messageId === messageWithTempId.messageId)
-        ? prev.map(m => m.messageId === messageWithTempId.messageId ? messageWithTempId : m)
-        : [...prev, messageWithTempId];
-
-      const sorted = [...updated].sort(
-        (a, b) => new Date(a.sendAt).getTime() - new Date(b.sendAt).getTime()
-      );
-      
-      // 맨 아래로 스크롤
-      requestAnimationFrame(() => {
-        scrollToBottom();
+      // 1. 서버에 메시지 전송 (웹소켓 publish)
+      client.publish({
+        destination: `/chat/send-message/${roomId}`,
+        body: JSON.stringify(messageWithTempId) // 임시 ID가 포함된 메시지 전송
       });
 
-      return sorted;
-    });
+      // 2. 메시지를 로컬 상태에 즉시 추가하여 화면에 표시
+      setMessages(prev => {
+        // 기존 메시지 중 동일한 임시 ID가 있으면 업데이트 (혹시 모를 중복 방지), 없으면 새로 추가
+        const updated = prev.some(m => m.messageId === messageWithTempId.messageId)
+          ? prev.map(m => m.messageId === messageWithTempId.messageId ? messageWithTempId : m)
+          : [...prev, messageWithTempId];
+
+        const sorted = [...updated].sort(
+          (a, b) => new Date(a.sendAt).getTime() - new Date(b.sendAt).getTime()
+        );
+
+        // 맨 아래로 스크롤
+        scrollToBottom();
+
+        return sorted;
+      });
+    } else {
+      // isTemporary가 false일 경우 (예: 이미지 메시지) 서버로만 전송
+      client.publish({
+        destination: `/chat/send-message/${roomId}`,
+        body: JSON.stringify(messageToSend)
+      });
+    }
 
     // 입력 필드 초기화
     setContent('');
@@ -605,7 +627,7 @@ const ChatRoom = () => {
           <div style={{ color: '#dc3545', marginBottom: '16px' }}>
             {initState.errorMessage}
           </div>
-          <button 
+          <button
             onClick={() => navigate('/')}
             style={{
               padding: '8px 16px',
@@ -660,7 +682,7 @@ const ChatRoom = () => {
             onLeaveRoom={handleLeaveRoom}
           />
 
-          <div 
+          <div
             ref={messageContainerRef}
             style={{
               flex: 1,
@@ -670,7 +692,7 @@ const ChatRoom = () => {
               minHeight: 0,
               position: 'relative'
             }}>
-            
+
             {/* ✅ 초기 로딩 상태 표시 (깜빡임 없이) */}
             {!isFullyLoaded && (
               <div style={{
@@ -694,7 +716,7 @@ const ChatRoom = () => {
                 }} />
               </div>
             )}
-            
+
             {/* 무한 스크롤 로딩 */}
             {isLoadingMessages && hasMoreMessages && (
               <div style={{
@@ -714,7 +736,7 @@ const ChatRoom = () => {
                 ⏳ 메시지 로딩 중...
               </div>
             )}
-            
+
             {/* 메시지 끝 표시 */}
             {!hasMoreMessages && messages.length > 0 && !isInitialLoad && (
               <div style={{
@@ -730,9 +752,9 @@ const ChatRoom = () => {
                 💬 모든 메시지를 불러왔습니다
               </div>
             )}
-            
+
             <div ref={messagesStartRef} />
-            
+
             {/* ✅ 메시지 목록은 항상 렌더링 (비어있어도) */}
             <MessageList
               messages={messages}
@@ -766,7 +788,7 @@ const ChatRoom = () => {
               setContent={setContent}
               language={language}
               setLanguage={setLanguage}
-              sendMessage={sendMessage}
+              // sendMessage={sendMessage} // 이 부분을 handleUnifiedSend로 대체
               handleUnifiedSend={handleUnifiedSend}
               setImageFile={setImageFile}
               imagePreviewUrl={imagePreviewUrl}

--- a/frontend/src/pages/ChatRoom.jsx
+++ b/frontend/src/pages/ChatRoom.jsx
@@ -186,6 +186,7 @@ const ChatRoom = () => {
       }
 
       const user = await res.json();
+      console.log("현재 사용자 정보:", user); 
       setCurrentUser(user);
       
       // ✅ 사용자 정보 로드 완료 상태 업데이트
@@ -226,8 +227,9 @@ const ChatRoom = () => {
     roomId: initState.isRoomValidated ? roomId : null,
     onMessageReceived: (received) => {
       setMessages(prev => {
+        // ⭐ 서버에서 받은 메시지로 기존 (임시) 메시지를 업데이트하거나 새 메시지 추가
         const updated = prev.some(m => m.messageId === received.messageId)
-          ? prev.map(m => m.messageId === received.messageId ? received : m)
+          ? prev.map(m => m.messageId === received.messageId ? { ...received, isSending: false } : m) // isSending 상태 업데이트
           : [...prev, received];
 
         const sorted = [...updated].sort((a, b) => new Date(a.sendAt) - new Date(b.sendAt));
@@ -244,13 +246,12 @@ const ChatRoom = () => {
 
   // 스크롤 위치 복원 함수 (무한 스크롤 시 사용)
   const restoreScrollPosition = useCallback(() => {
-    if (!messageContainerRef.current) return; // isInitialLoad 조건 제거
+    if (!messageContainerRef.current) return;
     
     const container = messageContainerRef.current;
     const newScrollHeight = container.scrollHeight;
     const oldScrollHeight = prevScrollHeightRef.current;
     
-    // 이 로직은 '추가 로드' 시에만 유효하도록 조정
     if (newScrollHeight > oldScrollHeight) {
       const scrollDiff = newScrollHeight - oldScrollHeight;
       const currentScrollTop = container.scrollTop;
@@ -260,7 +261,7 @@ const ChatRoom = () => {
     }
     
     prevScrollHeightRef.current = newScrollHeight;
-  }, []); // isInitialLoad 의존성 제거
+  }, []);
 
   // 스크롤 이벤트 핸들러
   const handleScroll = useCallback(() => {
@@ -450,14 +451,18 @@ const ChatRoom = () => {
         const formData = new FormData();
         formData.append('image', imageFile);
 
+        // 이미지 파일을 먼저 업로드하고 ID를 받습니다.
         const response = await axiosInstance.post('/send-image', formData, {
           headers: { 'Content-Type': 'multipart/form-data' }
         });
 
         const imageId = response.data;
+        
+        // 이미지 ID를 포함하여 메시지를 웹소켓으로 보냅니다.
+        // sendMessage 함수 내부에서 currentUser 정보를 활용할 것이므로 여기서는 넘기지 않아도 됩니다.
         sendMessage({
           type: 'IMAGE',
-          content: '',
+          content: '', // 이미지 메시지는 content가 비어있을 수 있습니다.
           imageFileId: imageId
         });
 
@@ -467,6 +472,7 @@ const ChatRoom = () => {
         console.error("이미지 전송 실패: ", err);
       }
     } else {
+      // 텍스트, 코드 메시지 전송
       sendMessage();
     }
   };
@@ -485,6 +491,12 @@ const ChatRoom = () => {
       return;
     }
 
+    if (!currentUser) {
+      console.warn('Current user not loaded yet. Cannot send message.');
+      alert('사용자 정보를 불러오는 중입니다. 잠시 후 다시 시도해주세요.');
+      return;
+    }
+
     let baseMessage = {
       content: content,
       type: inputMode,
@@ -492,18 +504,50 @@ const ChatRoom = () => {
       ...(inputMode === 'CODE' && { language })
     };
 
-    const message = overrideMessage ? { ...baseMessage, ...overrideMessage } : baseMessage;
+    const messageToSend = overrideMessage ? { ...baseMessage, ...overrideMessage } : baseMessage;
 
-    const trimmed = String(message.content).trim();
-    if (message.type !== 'IMAGE' && trimmed === '') {
+    const trimmed = String(messageToSend.content).trim();
+    if (messageToSend.type !== 'IMAGE' && trimmed === '') {
       return;
     }
 
+    // ⭐ 중요: 서버에 보낼 메시지에 임시 messageId를 추가하고 로컬 상태에 즉시 반영
+    const tempMessageId = `temp-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
+    const messageWithTempId = {
+      ...messageToSend,
+      messageId: tempMessageId, // 임시 ID
+      senderId: currentUser.userId, 
+      senderName: currentUser.nickname, 
+      profileImageUrl: currentUser.profileImg || '', 
+      isSending: true // 전송 중 상태 표시 (옵션)
+    };
+
+    // 1. 서버에 메시지 전송 (웹소켓 publish)
     client.publish({
       destination: `/chat/send-message/${roomId}`,
-      body: JSON.stringify(message)
+      body: JSON.stringify(messageWithTempId) // 임시 ID가 포함된 메시지 전송
     });
 
+    // 2. 메시지를 로컬 상태에 즉시 추가하여 화면에 표시
+    setMessages(prev => {
+      // 기존 메시지 중 동일한 임시 ID가 있으면 업데이트 (혹시 모를 중복 방지), 없으면 새로 추가
+      const updated = prev.some(m => m.messageId === messageWithTempId.messageId)
+        ? prev.map(m => m.messageId === messageWithTempId.messageId ? messageWithTempId : m)
+        : [...prev, messageWithTempId];
+
+      const sorted = [...updated].sort(
+        (a, b) => new Date(a.sendAt).getTime() - new Date(b.sendAt).getTime()
+      );
+      
+      // 맨 아래로 스크롤
+      requestAnimationFrame(() => {
+        scrollToBottom();
+      });
+
+      return sorted;
+    });
+
+    // 입력 필드 초기화
     setContent('');
     setInputMode('TEXT');
   };

--- a/frontend/src/pages/ChatRoom.jsx
+++ b/frontend/src/pages/ChatRoom.jsx
@@ -31,13 +31,13 @@ const ChatRoom = () => {
   const messagesEndRef = useRef(null);
   const messagesStartRef = useRef(null);
   const messageContainerRef = useRef(null);
-  const prevScrollHeightRef = useRef(0);
+  const prevScrollHeightRef = useRef(0); // 이전 스크롤 높이 저장
   const navigate = useNavigate();
 
   const [roomName, setRoomName] = useState("로딩 중...");
   const [roomId, setRoomId] = useState(null);
 
-  // ✅ 초기화 상태를 하나로 통합하고 단계별로 관리
+  // 초기화 상태를 하나로 통합하고 단계별로 관리
   const [initState, setInitState] = useState({
     isRoomValidated: false,
     isUserLoaded: false,
@@ -46,7 +46,7 @@ const ChatRoom = () => {
     errorMessage: ''
   });
 
-  // ✅ 전체 로딩 상태를 계산으로 처리 (별도 상태 없음)
+  // 전체 로딩 상태를 계산으로 처리
   const isFullyLoaded = initState.isRoomValidated &&
     initState.isUserLoaded &&
     initState.isMessagesLoaded;
@@ -71,7 +71,7 @@ const ChatRoom = () => {
       setRoomId(roomData.roomId);
       setRoomName(roomData.roomName);
 
-      // ✅ 한 번에 상태 업데이트
+      // 한 번에 상태 업데이트
       setInitState(prev => ({
         ...prev,
         isRoomValidated: true
@@ -138,6 +138,9 @@ const ChatRoom = () => {
       );
 
       if (isLoadMore) {
+        // 이전 스크롤 높이를 저장
+        prevScrollHeightRef.current = messageContainerRef.current ? messageContainerRef.current.scrollHeight : 0;
+
         // 이전 메시지들을 현재 메시지 앞에 추가
         setMessages(prev => {
           const existingIds = new Set(prev.map(msg => msg.messageId));
@@ -148,7 +151,7 @@ const ChatRoom = () => {
         // 초기 로드
         setMessages(sortedMessages);
 
-        // ✅ 초기 메시지 로드 완료 상태 업데이트
+        // 초기 메시지 로드 완료 상태 업데이트
         setInitState(prev => ({
           ...prev,
           isMessagesLoaded: true
@@ -186,7 +189,7 @@ const ChatRoom = () => {
       console.log("현재 사용자 정보:", user);
       setCurrentUser(user);
 
-      // ✅ 사용자 정보 로드 완료 상태 업데이트
+      // 사용자 정보 로드 완료 상태 업데이트
       setInitState(prev => ({
         ...prev,
         isUserLoaded: true
@@ -223,7 +226,7 @@ const ChatRoom = () => {
   const stompClientRef = useWebSocket({
     roomId: initState.isRoomValidated ? roomId : null,
     onMessageReceived: (received) => {
-      // ⭐ 서버에서 받은 메시지만을 로컬 상태에 추가/업데이트
+      // 서버에서 받은 메시지만을 로컬 상태에 추가/업데이트
       setMessages(prev => {
         // 동일한 messageId를 가진 메시지가 이미 존재하면 업데이트하고, 없으면 추가
         const updated = prev.some(m => m.messageId === received.messageId)
@@ -258,13 +261,9 @@ const ChatRoom = () => {
 
     if (newScrollHeight > oldScrollHeight) {
       const scrollDiff = newScrollHeight - oldScrollHeight;
-      const currentScrollTop = container.scrollTop;
-      const newScrollTop = currentScrollTop + scrollDiff;
-
-      container.scrollTop = newScrollTop;
+      // 이전 스크롤 위치에 새로 추가된 메시지 높이만큼 더해서 조정
+      container.scrollTop = container.scrollTop + scrollDiff;
     }
-
-    prevScrollHeightRef.current = newScrollHeight;
   }, []);
 
   // 스크롤 이벤트 핸들러
@@ -274,10 +273,11 @@ const ChatRoom = () => {
     const container = messageContainerRef.current;
     const { scrollTop, scrollHeight } = container;
 
-    const isAtTop = scrollTop <= 150;
+    const isAtTop = scrollTop <= 150; // 상단에서 150px 이내
     const canLoadMore = !isLoadingMessages && hasMoreMessages && cursor;
 
     if (isAtTop && canLoadMore) {
+      // 메시지를 불러오기 전에 현재 스크롤 높이를 저장
       prevScrollHeightRef.current = scrollHeight;
       fetchMessages(cursor, true);
     }
@@ -291,7 +291,7 @@ const ChatRoom = () => {
     let timeoutId = null;
     const debouncedHandleScroll = () => {
       if (timeoutId) clearTimeout(timeoutId);
-      timeoutId = setTimeout(handleScroll, 150);
+      timeoutId = setTimeout(handleScroll, 150); // 디바운싱
     };
 
     container.addEventListener('scroll', debouncedHandleScroll, { passive: true });
@@ -301,7 +301,7 @@ const ChatRoom = () => {
     };
   }, [handleScroll]);
 
-  // ✅ 초기화 로직 - 한 번에 모든 상태 리셋
+  // 초기화 로직 - 한 번에 모든 상태 리셋
   useEffect(() => {
     if (!inviteCode) {
       navigate("/error");
@@ -309,7 +309,7 @@ const ChatRoom = () => {
     }
 
     const initializeRoom = async () => {
-      // ✅ 한 번에 모든 초기 상태 설정
+      // 한 번에 모든 초기 상태 설정
       setInitState({
         isRoomValidated: false,
         isUserLoaded: false,
@@ -323,6 +323,7 @@ const ChatRoom = () => {
       setHasMoreMessages(true);
       setIsInitialLoad(true); // 초기 로딩 상태를 true로 재설정
       setIsLoadingMessages(false);
+      prevScrollHeightRef.current = 0; // 스크롤 높이 참조 초기화
 
       try {
         // 방 정보와 사용자 정보를 병렬로 로드
@@ -356,15 +357,26 @@ const ChatRoom = () => {
 
   // 메시지 로드 후 스크롤 위치 조정
   useEffect(() => {
-    // 초기 로딩이 완료된 후 메시지가 있고 더 이상 로딩 중이 아닐 때 맨 아래로 스크롤
-    // isInitialLoad가 false일 때만 실행하며, isLoadingMessages가 false일 때 즉시 스크롤
-    if (!isInitialLoad && messages.length > 0 && !isLoadingMessages) {
-      scrollToBottom();
-    } else if (!isInitialLoad && messages.length > 0 && isLoadingMessages) {
-      // 추가 메시지 로드 중일 때 스크롤 위치 복원
-      requestAnimationFrame(() => {
-        restoreScrollPosition();
-      });
+    // 초기 로딩이 완료되고 메시지가 있을 때만 스크롤 조정
+    if (!isInitialLoad && messages.length > 0) {
+      if (isLoadingMessages) {
+        // 메시지 추가 로드 중일 때 스크롤 위치 복원
+        // DOM 업데이트가 완전히 반영되도록 다음 프레임에서 실행
+        requestAnimationFrame(() => {
+          requestAnimationFrame(() => { // 한 번 더 requestAnimationFrame을 사용하여 확실히 DOM 반영 후
+            restoreScrollPosition();
+          });
+        });
+      } else {
+        // 초기 로드 완료 시 (isInitialLoad가 false로 변하는 시점) 맨 아래로 스크롤
+        // 이 조건은 컴포넌트 마운트 후 최초 메시지 로드 시에만 적용됩니다.
+        if (prevScrollHeightRef.current === 0 && messageContainerRef.current) {
+          // prevScrollHeightRef가 0이라는 것은 초기 로드이거나, 메시지가 없었다가 처음 생겼다는 의미
+          // (prevScrollHeightRef는 isLoadMore일 때만 업데이트되므로, 이 조건은 첫 로드에만 해당)
+          scrollToBottom();
+        }
+        // 새 메시지 수신으로 인한 스크롤은 useWebSocket 내부 onMessageReceived에서 처리
+      }
     }
   }, [messages, isInitialLoad, restoreScrollPosition, isLoadingMessages, scrollToBottom]);
 
@@ -485,7 +497,7 @@ const ChatRoom = () => {
   };
 
   // 메시지 전송 (임시 메시지 로직 제거)
-  const sendMessage = (overrideMessage = null) => { // isTemporary 파라미터 제거
+  const sendMessage = (overrideMessage = null) => {
     const client = stompClientRef.current;
 
     if (!roomId || !initState.isRoomValidated) {
@@ -518,7 +530,7 @@ const ChatRoom = () => {
       return;
     }
 
-    // ⭐ 중요: 서버에 보낼 메시지를 즉시 로컬 상태에 추가하지 않고,
+    // 서버에 보낼 메시지를 즉시 로컬 상태에 추가하지 않고,
     // 서버에서 다시 브로드캐스트된 메시지만을 onMessageReceived에서 처리
     client.publish({
       destination: `/chat/send-message/${roomId}`,
@@ -568,7 +580,7 @@ const ChatRoom = () => {
     setContextMenuId(null);
   };
 
-  // ✅ 에러 상태 처리
+  // 에러 상태 처리
   if (initState.hasError) {
     return (
       <div style={{
@@ -626,7 +638,7 @@ const ChatRoom = () => {
           flexDirection: 'column',
           boxShadow: '0 4px 20px rgba(0, 0, 0, 0.08)',
           overflow: 'hidden',
-          // ✅ 로딩 중에도 레이아웃 유지하되 투명도로 처리
+          // 로딩 중에도 레이아웃 유지하되 투명도로 처리
           opacity: isFullyLoaded ? 1 : 0.7,
           transition: 'opacity 0.3s ease'
         }}>
@@ -649,7 +661,7 @@ const ChatRoom = () => {
               position: 'relative'
             }}>
 
-            {/* ✅ 초기 로딩 상태 표시 (깜빡임 없이) */}
+            {/* 초기 로딩 상태 표시 (깜빡임 없이) */}
             {!isFullyLoaded && (
               <div style={{
                 position: 'absolute',
@@ -711,7 +723,7 @@ const ChatRoom = () => {
 
             <div ref={messagesStartRef} />
 
-            {/* ✅ 메시지 목록은 항상 렌더링 (비어있어도) */}
+            {/* 메시지 목록은 항상 렌더링 (비어있어도) */}
             <MessageList
               messages={messages}
               currentUser={currentUser}
@@ -734,7 +746,7 @@ const ChatRoom = () => {
             padding: '16px 24px',
             display: 'flex',
             flexDirection: 'column',
-            // ✅ 로딩 중에는 입력 비활성화
+            // 로딩 중에는 입력 비활성화
             pointerEvents: isFullyLoaded ? 'auto' : 'none'
           }}>
             <MessageInput
@@ -744,7 +756,6 @@ const ChatRoom = () => {
               setContent={setContent}
               language={language}
               setLanguage={setLanguage}
-              // sendMessage={sendMessage} // 이 부분을 handleUnifiedSend로 대체
               handleUnifiedSend={handleUnifiedSend}
               setImageFile={setImageFile}
               imagePreviewUrl={imagePreviewUrl}

--- a/frontend/src/pages/ChatRoom.jsx
+++ b/frontend/src/pages/ChatRoom.jsx
@@ -26,7 +26,7 @@ const ChatRoom = () => {
   const [cursor, setCursor] = useState(null);
   const [hasMoreMessages, setHasMoreMessages] = useState(true);
   const [isLoadingMessages, setIsLoadingMessages] = useState(false);
-  const [isInitialLoad, setIsInitialLoad] = useState(true);
+  const [isInitialLoad, setIsInitialLoad] = useState(true); // 초기 로딩 상태
 
   const messagesEndRef = useRef(null);
   const messagesStartRef = useRef(null);
@@ -37,11 +37,21 @@ const ChatRoom = () => {
   const [roomName, setRoomName] = useState("로딩 중...");
   const [roomId, setRoomId] = useState(null);
   
-  // 초기화 상태 관리
-  const [isRoomValidated, setIsRoomValidated] = useState(false);
-  const [isInitializing, setIsInitializing] = useState(true);
+  // ✅ 초기화 상태를 하나로 통합하고 단계별로 관리
+  const [initState, setInitState] = useState({
+    isRoomValidated: false,
+    isUserLoaded: false,
+    isMessagesLoaded: false,
+    hasError: false,
+    errorMessage: ''
+  });
 
-  // 맨 아래로 스크롤하는 함수 (새 메시지 수신용)
+  // ✅ 전체 로딩 상태를 계산으로 처리 (별도 상태 없음)
+  const isFullyLoaded = initState.isRoomValidated && 
+                       initState.isUserLoaded && 
+                       initState.isMessagesLoaded;
+
+  // 맨 아래로 스크롤하는 함수 (새 메시지 수신용 및 초기 로드 완료 시 사용)
   const scrollToBottom = useCallback(() => {
     if (messageContainerRef.current) {
       const container = messageContainerRef.current;
@@ -57,13 +67,24 @@ const ChatRoom = () => {
 
       setRoomId(roomData.roomId);
       setRoomName(roomData.roomName);
+      
+      // ✅ 한 번에 상태 업데이트
+      setInitState(prev => ({
+        ...prev,
+        isRoomValidated: true
+      }));
+      
       return roomData.roomId;
     } catch (error) {
       console.error('방 정보 조회 실패:', error);
-      navigate(`/error`);
+      setInitState(prev => ({
+        ...prev,
+        hasError: true,
+        errorMessage: '방 정보를 불러올 수 없습니다.'
+      }));
       return null;
     }
-  }, [inviteCode, navigate]);
+  }, [inviteCode]);
 
   // 2. 메시지 목록 불러오기 (커서 기반)
   const fetchMessages = useCallback(async (cursorValue = null, isLoadMore = false) => {
@@ -89,12 +110,6 @@ const ChatRoom = () => {
       console.log('📡 API 요청:', `/${roomId}/messages`, params);
       const res = await axiosInstance.get(`/${roomId}/messages`, { params });
       const data = res.data;
-      console.log('📨 API 응답:', {
-        messagesCount: data.messages?.length,
-        nextCursor: data.nextCursor,
-        hasNext: data.nextCursor !== null,
-        fullResponse: data
-      });
 
       const messageList = data.messages || [];
       
@@ -122,52 +137,40 @@ const ChatRoom = () => {
       if (isLoadMore) {
         // 이전 메시지들을 현재 메시지 앞에 추가
         setMessages(prev => {
-          // 중복 제거를 위한 Set 사용
           const existingIds = new Set(prev.map(msg => msg.messageId));
           const newMessages = sortedMessages.filter(msg => !existingIds.has(msg.messageId));
-          console.log('➕ 새로 추가할 메시지:', newMessages.length, '개');
           return [...newMessages, ...prev];
         });
       } else {
         // 초기 로드
         setMessages(sortedMessages);
-        console.log('🆕 초기 메시지 설정:', sortedMessages.length, '개');
+        
+        // ✅ 초기 메시지 로드 완료 상태 업데이트
+        setInitState(prev => ({
+          ...prev,
+          isMessagesLoaded: true
+        }));
+        // ✅ 초기 로드 완료 후 맨 아래로 스크롤
+        setIsInitialLoad(false); // 먼저 false로 설정하여 아래 useEffect가 발동하도록
+        requestAnimationFrame(() => {
+          scrollToBottom(); // 초기 로드 시 맨 아래로 스크롤
+        });
       }
 
       // 커서와 hasMore 상태 업데이트
       const nextCursor = data.nextCursor;
       setCursor(nextCursor);
       
-      let hasMore = true;
-      
-      if (nextCursor === null) {
-        hasMore = false;
-        console.log('🔄 hasMore = false (nextCursor가 null)');
-      } else if (messageList.length === 0) {
-        hasMore = false;
-        console.log('🔄 hasMore = false (받은 메시지가 0개)');
-      } else {
-        hasMore = true;
-        console.log('🔄 hasMore = true (nextCursor 존재하고 메시지 있음)');
-      }
-      
+      let hasMore = nextCursor !== null && messageList.length > 0;
       setHasMoreMessages(hasMore);
-      
-      console.log('🔄 상태 업데이트:', {
-        nextCursor,
-        hasMore,
-        receivedCount: messageList.length,
-        requestedSize: params.size
-      });
       
     } catch (error) {
       console.error('❌ Error fetching messages:', error);
-      console.log('❌ 에러 발생했지만 hasMoreMessages 상태 유지');
     } finally {
       setIsLoadingMessages(false);
-      setIsInitialLoad(false);
+      // setIsInitialLoad(false); // 이 위치는 초기 로드 완료 후 맨 아래로 스크롤 로직에 방해가 될 수 있음
     }
-  }, [roomId]);
+  }, [roomId, scrollToBottom]); // scrollToBottom을 의존성 배열에 추가
 
   // 3. 로그인 유저 정보 가져오기
   const fetchCurrentUser = useCallback(async () => {
@@ -184,8 +187,19 @@ const ChatRoom = () => {
 
       const user = await res.json();
       setCurrentUser(user);
+      
+      // ✅ 사용자 정보 로드 완료 상태 업데이트
+      setInitState(prev => ({
+        ...prev,
+        isUserLoaded: true
+      }));
+      
     } catch (error) {
       console.error('사용자 정보 요청 실패:', error);
+      setInitState(prev => ({
+        ...prev,
+        isUserLoaded: true // 실패해도 진행
+      }));
     }
   }, []);
 
@@ -195,7 +209,6 @@ const ChatRoom = () => {
     
     setMessages(prevMessages => {
       return prevMessages.map(msg => {
-        // 해당 사용자의 메시지인 경우 프로필 정보 업데이트
         if (msg.senderId === profileUpdateData.userId) {
           return {
             ...msg,
@@ -208,9 +221,9 @@ const ChatRoom = () => {
     });
   }, []);
 
-  // 웹소켓 연결 (방이 검증된 후에만 연결 + 프로필 업데이트 구독)
+  // 웹소켓 연결
   const stompClientRef = useWebSocket({
-    roomId: isRoomValidated ? roomId : null, // 방이 검증된 후에만 roomId 전달
+    roomId: initState.isRoomValidated ? roomId : null,
     onMessageReceived: (received) => {
       setMessages(prev => {
         const updated = prev.some(m => m.messageId === received.messageId)
@@ -219,7 +232,6 @@ const ChatRoom = () => {
 
         const sorted = [...updated].sort((a, b) => new Date(a.sendAt) - new Date(b.sendAt));
         
-        // 새 메시지가 추가되면 스크롤을 맨 아래로 (즉시)
         requestAnimationFrame(() => {
           scrollToBottom();
         });
@@ -227,68 +239,46 @@ const ChatRoom = () => {
         return sorted;
       });
     },
-    onProfileUpdate: handleProfileUpdate // 프로필 업데이트 콜백 추가
+    onProfileUpdate: handleProfileUpdate
   });
 
-  // 개선된 스크롤 위치 복원 함수
+  // 스크롤 위치 복원 함수 (무한 스크롤 시 사용)
   const restoreScrollPosition = useCallback(() => {
-    if (!messageContainerRef.current || isInitialLoad) return;
+    if (!messageContainerRef.current) return; // isInitialLoad 조건 제거
     
     const container = messageContainerRef.current;
     const newScrollHeight = container.scrollHeight;
     const oldScrollHeight = prevScrollHeightRef.current;
     
-    console.log('📏 스크롤 높이 비교:', {
-      old: oldScrollHeight,
-      new: newScrollHeight,
-      diff: newScrollHeight - oldScrollHeight
-    });
-    
-    // 새로운 메시지가 추가되어 스크롤 높이가 증가한 경우
+    // 이 로직은 '추가 로드' 시에만 유효하도록 조정
     if (newScrollHeight > oldScrollHeight) {
       const scrollDiff = newScrollHeight - oldScrollHeight;
       const currentScrollTop = container.scrollTop;
       const newScrollTop = currentScrollTop + scrollDiff;
       
-      console.log('📍 스크롤 위치 조정:', {
-        currentScrollTop,
-        scrollDiff,
-        newScrollTop
-      });
-      
-      // 즉시 스크롤 위치 조정
       container.scrollTop = newScrollTop;
     }
     
-    // 현재 스크롤 높이를 다음을 위해 저장
     prevScrollHeightRef.current = newScrollHeight;
-  }, [isInitialLoad]);
+  }, []); // isInitialLoad 의존성 제거
 
-  // 개선된 스크롤 이벤트 핸들러
+  // 스크롤 이벤트 핸들러
   const handleScroll = useCallback(() => {
-    if (!messageContainerRef.current || !roomId || !isRoomValidated) return;
+    if (!messageContainerRef.current || !roomId || !initState.isRoomValidated) return;
     
     const container = messageContainerRef.current;
     const { scrollTop, scrollHeight } = container;
     
     const isAtTop = scrollTop <= 150;
-    const currentHasMore = hasMoreMessages;
-    const currentCursor = cursor;
-    const currentIsLoading = isLoadingMessages;
-    
-    const canLoadMore = !currentIsLoading && currentHasMore && currentCursor;
+    const canLoadMore = !isLoadingMessages && hasMoreMessages && cursor;
     
     if (isAtTop && canLoadMore) {
-      console.log('🚀 무한 스크롤 트리거! 이전 메시지 로드 시작');
-      
-      // ✅ 현재 스크롤 높이를 저장 (메시지 로드 전)
       prevScrollHeightRef.current = scrollHeight;
-      
-      fetchMessages(currentCursor, true);
+      fetchMessages(cursor, true);
     }
-  }, [fetchMessages, hasMoreMessages, cursor, isLoadingMessages, roomId, isRoomValidated]);
+  }, [fetchMessages, hasMoreMessages, cursor, isLoadingMessages, roomId, initState.isRoomValidated]);
 
-  // 스크롤 이벤트 리스너 등록 (디바운스 적용)
+  // 스크롤 이벤트 리스너 등록
   useEffect(() => {
     const container = messageContainerRef.current;
     if (!container) return;
@@ -296,7 +286,7 @@ const ChatRoom = () => {
     let timeoutId = null;
     const debouncedHandleScroll = () => {
       if (timeoutId) clearTimeout(timeoutId);
-      timeoutId = setTimeout(handleScroll, 150); // 150ms 디바운스
+      timeoutId = setTimeout(handleScroll, 150);
     };
 
     container.addEventListener('scroll', debouncedHandleScroll, { passive: true });
@@ -306,93 +296,76 @@ const ChatRoom = () => {
     };
   }, [handleScroll]);
 
-  // 초기화 로직 
+  // ✅ 초기화 로직 - 한 번에 모든 상태 리셋
   useEffect(() => {
     if (!inviteCode) {
-      console.error("No inviteCode available");
       navigate("/error");
       return;
     }
 
     const initializeRoom = async () => {
-      setIsInitializing(true);
-      setIsRoomValidated(false);
-      setMessages([]);
+      // ✅ 한 번에 모든 초기 상태 설정
+      setInitState({
+        isRoomValidated: false,
+        isUserLoaded: false, 
+        isMessagesLoaded: false,
+        hasError: false,
+        errorMessage: ''
+      });
       
-      // 무한 스크롤 상태 초기화
+      setMessages([]);
       setCursor(null);
       setHasMoreMessages(true);
-      setIsInitialLoad(true);
+      setIsInitialLoad(true); // 초기 로딩 상태를 true로 재설정
       setIsLoadingMessages(false);
       
       try {
-        // 1단계: 방 정보 검증 및 로딩
-        const fetchedRoomId = await fetchRoomInfo();
+        // 방 정보와 사용자 정보를 병렬로 로드
+        const [fetchedRoomId] = await Promise.all([
+          fetchRoomInfo(),
+          fetchCurrentUser()
+        ]);
         
         if (!fetchedRoomId) {
+          navigate("/error");
           return;
         }
-
-        // 2단계: 방 검증 완료 표시
-        setIsRoomValidated(true);
-        
-        // 3단계: 사용자 정보 로딩과 메시지 로딩을 순차적으로 처리
-        await fetchCurrentUser();
-        
-        // ✅ roomId가 설정된 후에 메시지를 로드하도록 수정
-        // fetchMessages는 roomId 의존성이 있으므로 별도로 처리
         
       } catch (error) {
         console.error('방 초기화 중 오류:', error);
         navigate("/error");
-      } finally {
-        setIsInitializing(false);
       }
     };
 
     initializeRoom();
   }, [inviteCode, navigate, fetchRoomInfo, fetchCurrentUser]);
 
+  // roomId가 설정되고 방 정보가 유효하며, 초기 로드가 아직 안된 경우 메시지 로드
   useEffect(() => {
-    if (roomId && isRoomValidated && isInitialLoad) {
-      console.log('🚀 roomId 설정 완료, 초기 메시지 로드 시작:', roomId);
+    // isInitialLoad가 true일 때만 fetchMessages를 호출하여 초기 로드를 제어
+    // fetchMessages 내부에서 isInitialLoad를 false로 변경하고 scrollToBottom 호출
+    if (roomId && initState.isRoomValidated && isInitialLoad) {
       fetchMessages();
     }
-  }, [roomId, isRoomValidated, isInitialLoad, fetchMessages]);
+  }, [roomId, initState.isRoomValidated, isInitialLoad, fetchMessages]);
 
-  // 초기 메시지 로드 완료 후 최신 메시지로 스크롤
+  // 메시지 로드 후 스크롤 위치 조정 (무한 스크롤 시에만 restoreScrollPosition 호출)
   useEffect(() => {
-    if (!isInitialLoad && messages.length > 0) {
-      // DOM 업데이트가 완전히 완료된 후 스크롤 위치 복원
-      // requestAnimationFrame을 두 번 사용해서 더 확실하게 DOM 업데이트를 기다림
-      requestAnimationFrame(() => {
-        requestAnimationFrame(() => {
-          restoreScrollPosition();
-        });
-      });
-    }
-  }, [messages, isInitialLoad, restoreScrollPosition]);
-
-  // 메시지 로드 후 스크롤 위치 조정 (무한 스크롤용)
-  useEffect(() => {
-    if (!isInitialLoad && messages.length > 0) {
-      // 이전 메시지 로드 시 스크롤 위치 복원
+    // isInitialLoad가 false일 때만 restoreScrollPosition을 호출 (추가 메시지 로드 시)
+    // 초기 로드 시에는 fetchMessages 내에서 scrollToBottom이 직접 호출됨
+    if (!isInitialLoad && messages.length > 0 && isLoadingMessages) { // isLoadingMessages 조건 추가
       requestAnimationFrame(() => {
         restoreScrollPosition();
       });
     }
-  }, [messages, isInitialLoad, restoreScrollPosition]);
+  }, [messages, isInitialLoad, restoreScrollPosition, isLoadingMessages]);
 
   const handleLeaveRoom = async () => {
     try {
       await axiosInstance.delete(`/chat-rooms/${roomId}/leave`);
       return { success: true };
     } catch (err) {
-      const errorMsg =
-        err.response?.data?.message ||
-        err.message ||
-        '나가기 실패';
-
+      const errorMsg = err.response?.data?.message || err.message || '나가기 실패';
       return { success: false, error: errorMsg };
     }
   };
@@ -408,8 +381,7 @@ const ChatRoom = () => {
   const [errorMessage, setErrorMessage] = useState(null);
 
   const handleSearch = async (keyword, page = 0) => {
-    // roomId 검증 - 더 명확한 에러 처리
-    if (!roomId || !isRoomValidated) {
+    if (!roomId || !initState.isRoomValidated) {
       setErrorMessage('채팅방이 아직 로딩 중입니다. 잠시 후 다시 시도해주세요.');
       return;
     }
@@ -421,21 +393,14 @@ const ChatRoom = () => {
 
     try {
       const response = await axiosInstance.get(`/chat/search/${roomId}`, {
-        params: {
-          keyword,
-          page,
-          size: 10
-        }
+        params: { keyword, page, size: 10 }
       });
 
       const data = response.data;
       const validatedResults = (data.content || []).map(msg => {
         const sendAt = new Date(msg.sendAt);
         const isInvalid = !msg.sendAt || isNaN(sendAt.getTime());
-
-        return isInvalid
-          ? { ...msg, sendAt: new Date().toISOString() }
-          : msg;
+        return isInvalid ? { ...msg, sendAt: new Date().toISOString() } : msg;
       });
 
       setSearchResults(validatedResults);
@@ -459,12 +424,10 @@ const ChatRoom = () => {
         block: 'center'
       });
       
-      // 깔끔한 하이라이트
       messageElement.style.backgroundColor = '#e8f4fd';
       messageElement.style.borderRadius = '6px';
       messageElement.style.transition = 'all 0.3s ease';
       
-      // 2초 후 제거
       setTimeout(() => {
         messageElement.style.backgroundColor = '';
         messageElement.style.borderRadius = '';
@@ -475,7 +438,7 @@ const ChatRoom = () => {
   const [imageFile, setImageFile] = useState(null);
   const [imagePreviewUrl, setImagePreviewUrl] = useState(null);
 
-  // 전송 버튼 클릭 시 호출되는 공통 핸들러 함수 (이미지 업로드 고려)
+  // 통합 전송 핸들러
   const handleUnifiedSend = async () => {
     if (inputMode === 'IMAGE') {
       if (!imageFile) {
@@ -488,9 +451,7 @@ const ChatRoom = () => {
         formData.append('image', imageFile);
 
         const response = await axiosInstance.post('/send-image', formData, {
-          headers: {
-            'Content-Type': 'multipart/form-data'
-          }
+          headers: { 'Content-Type': 'multipart/form-data' }
         });
 
         const imageId = response.data;
@@ -510,12 +471,11 @@ const ChatRoom = () => {
     }
   };
 
-  // 메시지 전송 (텍스트/코드/이미지 모두 처리)
+  // 메시지 전송
   const sendMessage = (overrideMessage = null) => {
     const client = stompClientRef.current;
     
-    // 방 검증 상태 확인
-    if (!roomId || !isRoomValidated) {
+    if (!roomId || !initState.isRoomValidated) {
       alert('채팅방 정보를 로딩 중입니다. 잠시 후 다시 시도해주세요.');
       return;
     }
@@ -525,7 +485,6 @@ const ChatRoom = () => {
       return;
     }
 
-    // 기본 메시지 구조
     let baseMessage = {
       content: content,
       type: inputMode,
@@ -533,10 +492,8 @@ const ChatRoom = () => {
       ...(inputMode === 'CODE' && { language })
     };
 
-    // overrideMessage가 있으면 병합 (예: 이미지 메시지 함께 전송)
     const message = overrideMessage ? { ...baseMessage, ...overrideMessage } : baseMessage;
 
-    // 메시지 비어있는 경우 전송 방지
     const trimmed = String(message.content).trim();
     if (message.type !== 'IMAGE' && trimmed === '') {
       return;
@@ -551,7 +508,7 @@ const ChatRoom = () => {
     setInputMode('TEXT');
   };
 
-  // 메시지 수정 요청
+  // 메시지 수정
   const handleEditMessage = (messageId) => {
     const client = stompClientRef.current;
     if (!client || !client.connected) {
@@ -569,12 +526,11 @@ const ChatRoom = () => {
       body: JSON.stringify(editPayload)
     });
 
-    // 수정 모드 종료
     setEditMessageId(null);
     setEditContent('');
   };
 
-  // 메시지 삭제 요청
+  // 메시지 삭제
   const handleDeleteMessage = (messageId) => {
     const client = stompClientRef.current;
     if (!client || !client.connected) {
@@ -587,11 +543,11 @@ const ChatRoom = () => {
       body: messageId
     });
 
-    setContextMenuId(null); // 메뉴 닫기
+    setContextMenuId(null);
   };
 
-  // 로딩 상태 표시
-  if (isInitializing) {
+  // ✅ 에러 상태 처리
+  if (initState.hasError) {
     return (
       <div style={{
         backgroundColor: '#f5f7fa',
@@ -602,7 +558,22 @@ const ChatRoom = () => {
         fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif'
       }}>
         <div style={{ textAlign: 'center' }}>
-          <div>채팅방을 불러오는 중...</div>
+          <div style={{ color: '#dc3545', marginBottom: '16px' }}>
+            {initState.errorMessage}
+          </div>
+          <button 
+            onClick={() => navigate('/')}
+            style={{
+              padding: '8px 16px',
+              backgroundColor: '#007bff',
+              color: 'white',
+              border: 'none',
+              borderRadius: '4px',
+              cursor: 'pointer'
+            }}
+          >
+            홈으로 돌아가기
+          </button>
         </div>
       </div>
     );
@@ -619,14 +590,11 @@ const ChatRoom = () => {
         fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif'
       }}>
 
-      {/* Top Bar */}
-      <Header></Header>
+      <Header />
 
-      {/* 본문 전체 영역 */}
       <div style={{ flex: 1, display: 'flex', overflow: 'hidden' }}>
         <Sidebar />
 
-        {/* Chat area */}
         <div style={{
           flex: 1,
           width: '700px',
@@ -635,18 +603,19 @@ const ChatRoom = () => {
           display: 'flex',
           flexDirection: 'column',
           boxShadow: '0 4px 20px rgba(0, 0, 0, 0.08)',
-          overflow: 'hidden'
+          overflow: 'hidden',
+          // ✅ 로딩 중에도 레이아웃 유지하되 투명도로 처리
+          opacity: isFullyLoaded ? 1 : 0.7,
+          transition: 'opacity 0.3s ease'
         }}>
 
-          {/* 채팅방 헤더 - 채팅방 이름, 초대 코드 복사 버튼, 나가기 버튼, 메세지 검색 창 */}
           <RoomHeader
             roomName={roomName}
             inviteCode={inviteCode}
-            onSearch={handleSearch} // 메시지 검색 api 요청 함수
-            onLeaveRoom={handleLeaveRoom} // 방 나가기 api 요청 함수
+            onSearch={handleSearch}
+            onLeaveRoom={handleLeaveRoom}
           />
 
-          {/* 메시지 목록 */}
           <div 
             ref={messageContainerRef}
             style={{
@@ -658,7 +627,31 @@ const ChatRoom = () => {
               position: 'relative'
             }}>
             
-            {/* 개선된 로딩 인디케이터 */}
+            {/* ✅ 초기 로딩 상태 표시 (깜빡임 없이) */}
+            {!isFullyLoaded && (
+              <div style={{
+                position: 'absolute',
+                top: '50%',
+                left: '50%',
+                transform: 'translate(-50%, -50%)',
+                textAlign: 'center',
+                color: '#666',
+                zIndex: 10
+              }}>
+                <div style={{ fontSize: '14px' }}>채팅방을 불러오는 중...</div>
+                <div style={{
+                  width: '40px',
+                  height: '40px',
+                  border: '3px solid #f0f0f0',
+                  borderTop: '3px solid #007bff',
+                  borderRadius: '50%',
+                  animation: 'spin 1s linear infinite',
+                  margin: '12px auto'
+                }} />
+              </div>
+            )}
+            
+            {/* 무한 스크롤 로딩 */}
             {isLoadingMessages && hasMoreMessages && (
               <div style={{
                 position: 'sticky',
@@ -678,7 +671,7 @@ const ChatRoom = () => {
               </div>
             )}
             
-            {/* 더 이상 메시지가 없을 때 표시 */}
+            {/* 메시지 끝 표시 */}
             {!hasMoreMessages && messages.length > 0 && !isInitialLoad && (
               <div style={{
                 textAlign: 'center',
@@ -696,6 +689,7 @@ const ChatRoom = () => {
             
             <div ref={messagesStartRef} />
             
+            {/* ✅ 메시지 목록은 항상 렌더링 (비어있어도) */}
             <MessageList
               messages={messages}
               currentUser={currentUser}
@@ -711,13 +705,15 @@ const ChatRoom = () => {
             <div ref={messagesEndRef} />
           </div>
 
-          {/* 메시지 입력 폼 */}
+          {/* 메시지 입력 */}
           <div style={{
             backgroundColor: '#fbfbfd',
             borderTop: '1px solid #eaedf0',
             padding: '16px 24px',
             display: 'flex',
-            flexDirection: 'column'
+            flexDirection: 'column',
+            // ✅ 로딩 중에는 입력 비활성화
+            pointerEvents: isFullyLoaded ? 'auto' : 'none'
           }}>
             <MessageInput
               inputMode={inputMode}
@@ -735,7 +731,7 @@ const ChatRoom = () => {
           </div>
         </div>
 
-        {/* 메세지 검색 바 */}
+        {/* 검색 사이드바 */}
         {showSearchSidebar && (
           <SearchSidebar
             searchKeyword={searchKeyword}

--- a/frontend/src/pages/ChatRoom.jsx
+++ b/frontend/src/pages/ChatRoom.jsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useState, useRef } from 'react';
-import { useParams, useNavigate, useLocation } from 'react-router-dom';
+import React, { useEffect, useState, useRef, useCallback } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
 import Sidebar from '../components/SideBar';
 import Header from '../components/header';
 import SearchSidebar from '../components/SearchSideBar';
@@ -22,7 +22,16 @@ const ChatRoom = () => {
   const [editMessageId, setEditMessageId] = useState(null);
   const [editContent, setEditContent] = useState("");
 
+  // 무한 스크롤 관련 상태
+  const [cursor, setCursor] = useState(null);
+  const [hasMoreMessages, setHasMoreMessages] = useState(true);
+  const [isLoadingMessages, setIsLoadingMessages] = useState(false);
+  const [isInitialLoad, setIsInitialLoad] = useState(true);
+
   const messagesEndRef = useRef(null);
+  const messagesStartRef = useRef(null);
+  const messageContainerRef = useRef(null);
+  const prevScrollHeightRef = useRef(0);
   const navigate = useNavigate();
 
   const [roomName, setRoomName] = useState("로딩 중...");
@@ -32,8 +41,16 @@ const ChatRoom = () => {
   const [isRoomValidated, setIsRoomValidated] = useState(false);
   const [isInitializing, setIsInitializing] = useState(true);
 
+  // 맨 아래로 스크롤하는 함수 (새 메시지 수신용)
+  const scrollToBottom = useCallback(() => {
+    if (messageContainerRef.current) {
+      const container = messageContainerRef.current;
+      container.scrollTop = container.scrollHeight;
+    }
+  }, []);
+
   // 1. 방 정보 불러오기
-  const fetchRoomInfo = async () => {
+  const fetchRoomInfo = useCallback(async () => {
     try {
       const res = await axiosInstance.get(`/chat-rooms/${inviteCode}`);
       const roomData = res.data;
@@ -46,39 +63,114 @@ const ChatRoom = () => {
       navigate(`/error`);
       return null;
     }
-  };
+  }, [inviteCode, navigate]);
 
-  // 2. 메시지 목록 불러오기
-  const fetchMessages = async (roomId) => {
+  // 2. 메시지 목록 불러오기 (커서 기반)
+  const fetchMessages = useCallback(async (cursorValue = null, isLoadMore = false) => {
+    console.log('🔍 fetchMessages 호출:', { cursorValue, isLoadMore });
+    
+    setIsLoadingMessages(prev => {
+      if (prev) {
+        console.log('❌ 이미 로딩 중이므로 중단');
+        return prev;
+      }
+      return true;
+    });
+
     try {
-      const res = await axiosInstance.get(`/${roomId}/messages`); 
+      const params = {
+        size: 30
+      };
+      
+      if (cursorValue) {
+        params.cursor = cursorValue;
+      }
+
+      console.log('📡 API 요청:', `/${roomId}/messages`, params);
+      const res = await axiosInstance.get(`/${roomId}/messages`, { params });
       const data = res.data;
+      console.log('📨 API 응답:', {
+        messagesCount: data.messages?.length,
+        nextCursor: data.nextCursor,
+        hasNext: data.nextCursor !== null,
+        fullResponse: data
+      });
+
+      const messageList = data.messages || [];
+      
+      if (!Array.isArray(messageList)) {
+        console.error('❌ Message list is not an array:', messageList);
+        return;
+      }
 
       // 날짜 유효성 검사
-      const validatedData = data.map(msg => {
+      const validatedMessages = messageList.map(msg => {
         const sendAt = new Date(msg.sendAt);
         const isInvalidDate = isNaN(sendAt.getTime());
 
         if (!msg.sendAt || isInvalidDate) {
           return { ...msg, sendAt: new Date().toISOString() };
         }
-
         return msg;
       });
 
-      // sendAt 기준으로 메시지 정렬
-      const sortedData = validatedData.sort(
-          (a, b) => new Date(a.sendAt).getTime() - new Date(b.sendAt).getTime()
+      // sendAt 기준으로 메시지 정렬 (오래된 순)
+      const sortedMessages = validatedMessages.sort(
+        (a, b) => new Date(a.sendAt).getTime() - new Date(b.sendAt).getTime()
       );
 
-      setMessages(sortedData);
+      if (isLoadMore) {
+        // 이전 메시지들을 현재 메시지 앞에 추가
+        setMessages(prev => {
+          // 중복 제거를 위한 Set 사용
+          const existingIds = new Set(prev.map(msg => msg.messageId));
+          const newMessages = sortedMessages.filter(msg => !existingIds.has(msg.messageId));
+          console.log('➕ 새로 추가할 메시지:', newMessages.length, '개');
+          return [...newMessages, ...prev];
+        });
+      } else {
+        // 초기 로드
+        setMessages(sortedMessages);
+        console.log('🆕 초기 메시지 설정:', sortedMessages.length, '개');
+      }
+
+      // 커서와 hasMore 상태 업데이트
+      const nextCursor = data.nextCursor;
+      setCursor(nextCursor);
+      
+      let hasMore = true;
+      
+      if (nextCursor === null) {
+        hasMore = false;
+        console.log('🔄 hasMore = false (nextCursor가 null)');
+      } else if (messageList.length === 0) {
+        hasMore = false;
+        console.log('🔄 hasMore = false (받은 메시지가 0개)');
+      } else {
+        hasMore = true;
+        console.log('🔄 hasMore = true (nextCursor 존재하고 메시지 있음)');
+      }
+      
+      setHasMoreMessages(hasMore);
+      
+      console.log('🔄 상태 업데이트:', {
+        nextCursor,
+        hasMore,
+        receivedCount: messageList.length,
+        requestedSize: params.size
+      });
+      
     } catch (error) {
-      console.error('Error fetching messages:', error);
+      console.error('❌ Error fetching messages:', error);
+      console.log('❌ 에러 발생했지만 hasMoreMessages 상태 유지');
+    } finally {
+      setIsLoadingMessages(false);
+      setIsInitialLoad(false);
     }
-  };
+  }, [roomId]);
 
   // 3. 로그인 유저 정보 가져오기
-  const fetchCurrentUser = async () => {
+  const fetchCurrentUser = useCallback(async () => {
     try {
       const res = await fetch('http://localhost:8080/user/details', {
         method: 'GET',
@@ -95,22 +187,124 @@ const ChatRoom = () => {
     } catch (error) {
       console.error('사용자 정보 요청 실패:', error);
     }
-  };
+  }, []);
 
-  // 웹소켓 연결 (roomId가 검증된 후에만 연결)
+  // 프로필 업데이트 처리 함수
+  const handleProfileUpdate = useCallback((profileUpdateData) => {
+    console.log('👤 프로필 업데이트 수신:', profileUpdateData);
+    
+    setMessages(prevMessages => {
+      return prevMessages.map(msg => {
+        // 해당 사용자의 메시지인 경우 프로필 정보 업데이트
+        if (msg.senderId === profileUpdateData.userId) {
+          return {
+            ...msg,
+            senderName: profileUpdateData.nickname || msg.senderName,
+            profileImageUrl: profileUpdateData.profileImageUrl || msg.profileImageUrl
+          };
+        }
+        return msg;
+      });
+    });
+  }, []);
+
+  // 웹소켓 연결 (방이 검증된 후에만 연결 + 프로필 업데이트 구독)
   const stompClientRef = useWebSocket({
     roomId: isRoomValidated ? roomId : null, // 방이 검증된 후에만 roomId 전달
     onMessageReceived: (received) => {
       setMessages(prev => {
         const updated = prev.some(m => m.messageId === received.messageId)
-        ? prev.map(m => m.messageId === received.messageId ? received : m)
-        : [...prev, received];
+          ? prev.map(m => m.messageId === received.messageId ? received : m)
+          : [...prev, received];
 
-        // sendAt 기준으로 정렬
-        return [...updated].sort((a, b) => new Date(a.sendAt) - new Date(b.sendAt));
+        const sorted = [...updated].sort((a, b) => new Date(a.sendAt) - new Date(b.sendAt));
+        
+        // 새 메시지가 추가되면 스크롤을 맨 아래로 (즉시)
+        requestAnimationFrame(() => {
+          scrollToBottom();
+        });
+        
+        return sorted;
       });
-    }
+    },
+    onProfileUpdate: handleProfileUpdate // 프로필 업데이트 콜백 추가
   });
+
+  // 개선된 스크롤 위치 복원 함수
+  const restoreScrollPosition = useCallback(() => {
+    if (!messageContainerRef.current || isInitialLoad) return;
+    
+    const container = messageContainerRef.current;
+    const newScrollHeight = container.scrollHeight;
+    const oldScrollHeight = prevScrollHeightRef.current;
+    
+    console.log('📏 스크롤 높이 비교:', {
+      old: oldScrollHeight,
+      new: newScrollHeight,
+      diff: newScrollHeight - oldScrollHeight
+    });
+    
+    // 새로운 메시지가 추가되어 스크롤 높이가 증가한 경우
+    if (newScrollHeight > oldScrollHeight) {
+      const scrollDiff = newScrollHeight - oldScrollHeight;
+      const currentScrollTop = container.scrollTop;
+      const newScrollTop = currentScrollTop + scrollDiff;
+      
+      console.log('📍 스크롤 위치 조정:', {
+        currentScrollTop,
+        scrollDiff,
+        newScrollTop
+      });
+      
+      // 즉시 스크롤 위치 조정
+      container.scrollTop = newScrollTop;
+    }
+    
+    // 현재 스크롤 높이를 다음을 위해 저장
+    prevScrollHeightRef.current = newScrollHeight;
+  }, [isInitialLoad]);
+
+  // 개선된 스크롤 이벤트 핸들러
+  const handleScroll = useCallback(() => {
+    if (!messageContainerRef.current || !roomId || !isRoomValidated) return;
+    
+    const container = messageContainerRef.current;
+    const { scrollTop, scrollHeight } = container;
+    
+    const isAtTop = scrollTop <= 150;
+    const currentHasMore = hasMoreMessages;
+    const currentCursor = cursor;
+    const currentIsLoading = isLoadingMessages;
+    
+    const canLoadMore = !currentIsLoading && currentHasMore && currentCursor;
+    
+    if (isAtTop && canLoadMore) {
+      console.log('🚀 무한 스크롤 트리거! 이전 메시지 로드 시작');
+      
+      // ✅ 현재 스크롤 높이를 저장 (메시지 로드 전)
+      prevScrollHeightRef.current = scrollHeight;
+      
+      fetchMessages(currentCursor, true);
+    }
+  }, [fetchMessages, hasMoreMessages, cursor, isLoadingMessages, roomId, isRoomValidated]);
+
+  // 스크롤 이벤트 리스너 등록 (디바운스 적용)
+  useEffect(() => {
+    const container = messageContainerRef.current;
+    if (!container) return;
+
+    let timeoutId = null;
+    const debouncedHandleScroll = () => {
+      if (timeoutId) clearTimeout(timeoutId);
+      timeoutId = setTimeout(handleScroll, 150); // 150ms 디바운스
+    };
+
+    container.addEventListener('scroll', debouncedHandleScroll, { passive: true });
+    return () => {
+      container.removeEventListener('scroll', debouncedHandleScroll);
+      if (timeoutId) clearTimeout(timeoutId);
+    };
+  }, [handleScroll]);
 
   // 초기화 로직 
   useEffect(() => {
@@ -123,26 +317,31 @@ const ChatRoom = () => {
     const initializeRoom = async () => {
       setIsInitializing(true);
       setIsRoomValidated(false);
-      setMessages([]); // 이전 채팅방 메시지 제거
+      setMessages([]);
+      
+      // 무한 스크롤 상태 초기화
+      setCursor(null);
+      setHasMoreMessages(true);
+      setIsInitialLoad(true);
+      setIsLoadingMessages(false);
       
       try {
         // 1단계: 방 정보 검증 및 로딩
         const fetchedRoomId = await fetchRoomInfo();
         
         if (!fetchedRoomId) {
-          // 방 정보 로딩 실패 시 여기서 종료 (navigate는 fetchRoomInfo에서 처리)
           return;
         }
 
-        // 2단계: 방 검증 완료 표시 (이제 웹소켓 연결 가능)
+        // 2단계: 방 검증 완료 표시
         setIsRoomValidated(true);
         
-        // 3단계: 병렬로 사용자 정보와 메시지 로딩
-        await Promise.all([
-          fetchCurrentUser(),
-          fetchMessages(fetchedRoomId)
-        ]);
-
+        // 3단계: 사용자 정보 로딩과 메시지 로딩을 순차적으로 처리
+        await fetchCurrentUser();
+        
+        // ✅ roomId가 설정된 후에 메시지를 로드하도록 수정
+        // fetchMessages는 roomId 의존성이 있으므로 별도로 처리
+        
       } catch (error) {
         console.error('방 초기화 중 오류:', error);
         navigate("/error");
@@ -152,7 +351,37 @@ const ChatRoom = () => {
     };
 
     initializeRoom();
-  }, [inviteCode]);
+  }, [inviteCode, navigate, fetchRoomInfo, fetchCurrentUser]);
+
+  useEffect(() => {
+    if (roomId && isRoomValidated && isInitialLoad) {
+      console.log('🚀 roomId 설정 완료, 초기 메시지 로드 시작:', roomId);
+      fetchMessages();
+    }
+  }, [roomId, isRoomValidated, isInitialLoad, fetchMessages]);
+
+  // 초기 메시지 로드 완료 후 최신 메시지로 스크롤
+  useEffect(() => {
+    if (!isInitialLoad && messages.length > 0) {
+      // DOM 업데이트가 완전히 완료된 후 스크롤 위치 복원
+      // requestAnimationFrame을 두 번 사용해서 더 확실하게 DOM 업데이트를 기다림
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          restoreScrollPosition();
+        });
+      });
+    }
+  }, [messages, isInitialLoad, restoreScrollPosition]);
+
+  // 메시지 로드 후 스크롤 위치 조정 (무한 스크롤용)
+  useEffect(() => {
+    if (!isInitialLoad && messages.length > 0) {
+      // 이전 메시지 로드 시 스크롤 위치 복원
+      requestAnimationFrame(() => {
+        restoreScrollPosition();
+      });
+    }
+  }, [messages, isInitialLoad, restoreScrollPosition]);
 
   const handleLeaveRoom = async () => {
     try {
@@ -201,13 +430,13 @@ const ChatRoom = () => {
 
       const data = response.data;
       const validatedResults = (data.content || []).map(msg => {
-      const sendAt = new Date(msg.sendAt);
-      const isInvalid = !msg.sendAt || isNaN(sendAt.getTime());
+        const sendAt = new Date(msg.sendAt);
+        const isInvalid = !msg.sendAt || isNaN(sendAt.getTime());
 
-      return isInvalid
-        ? { ...msg, sendAt: new Date().toISOString() }
-        : msg;
-    });
+        return isInvalid
+          ? { ...msg, sendAt: new Date().toISOString() }
+          : msg;
+      });
 
       setSearchResults(validatedResults);
       setCurrentPage(data.pageable?.pageNumber || 0);
@@ -220,11 +449,6 @@ const ChatRoom = () => {
       setIsSearching(false);
     }
   };
-
-  // 메시지가 업데이트될 때마다 아래로 스크롤
-  useEffect(() => {
-    messagesEndRef.current?.scrollIntoView({ behavior: "instant" });
-  }, [messages]);
 
   // 검색 결과로 스크롤 이동
   const scrollToMessage = (messageId) => {
@@ -423,13 +647,55 @@ const ChatRoom = () => {
           />
 
           {/* 메시지 목록 */}
-          <div style={{
-            flex: 1,
-            overflowY: 'auto',
-            padding: '20px 24px',
-            backgroundColor: '#fff',
-            minHeight: 0
-          }}>
+          <div 
+            ref={messageContainerRef}
+            style={{
+              flex: 1,
+              overflowY: 'auto',
+              padding: '20px 24px',
+              backgroundColor: '#fff',
+              minHeight: 0,
+              position: 'relative'
+            }}>
+            
+            {/* 개선된 로딩 인디케이터 */}
+            {isLoadingMessages && hasMoreMessages && (
+              <div style={{
+                position: 'sticky',
+                top: 0,
+                textAlign: 'center',
+                padding: '8px 16px',
+                color: '#666',
+                fontSize: '13px',
+                backgroundColor: '#f8f9fa',
+                borderRadius: '16px',
+                margin: '0 auto 16px auto',
+                width: 'fit-content',
+                border: '1px solid #e9ecef',
+                boxShadow: '0 2px 4px rgba(0,0,0,0.1)'
+              }}>
+                ⏳ 메시지 로딩 중...
+              </div>
+            )}
+            
+            {/* 더 이상 메시지가 없을 때 표시 */}
+            {!hasMoreMessages && messages.length > 0 && !isInitialLoad && (
+              <div style={{
+                textAlign: 'center',
+                padding: '8px 16px',
+                color: '#999',
+                fontSize: '12px',
+                backgroundColor: '#f8f9fa',
+                borderRadius: '16px',
+                margin: '0 auto 16px auto',
+                width: 'fit-content'
+              }}>
+                💬 모든 메시지를 불러왔습니다
+              </div>
+            )}
+            
+            <div ref={messagesStartRef} />
+            
             <MessageList
               messages={messages}
               currentUser={currentUser}


### PR DESCRIPTION
## 🛰️ Issue Number
#139 

## 🪐 작업 내용

### 채팅 내역 커서기반 페이징 적용 (무한 스크롤)
- 페이지네이션으로 기본 사이즈 30개씩 채팅 내역을 가져옴
- 커서 기반 페이지네이션 적용하여, ChatRoom에 적용
- 자연스러운 UX 및 채팅 내역 로드를 위해, 로드 시, 이전 커서 위치를 기억해놨다가 로드된 채팅내역에 커서 적용

### 멤버 프로필 정보 변경 시, 채팅 내역에도 적용
- 프로필 이미지, 닉네임 수정 시, 해당 멤버의 프로필 변경 내역 이벤트 처리하여 비동기 전송방식으로 전역적으로 업데이트

### ChatMessageSearch테이블 roomId 인덱스 삭제
- full text index가 B-Tree 기반의 일반 인덱스와 복합적으로 사용될 수 없어, ChatMessageSearch 테이블의 roomId 인덱스 삭제

### FE 무한 스크롤, 프로필 업데이트 채팅에 적용
- useWebSocket 통합관리 (외부에서는 stompClientRef 객체 사용)
- 채팅방 구독은 chatRooms[] 배열로 받아오고 의존성 배열을 비워놔서 한 번만 실행되도도록 했습니다.
- isFullyLoaded를 사용해서 방 정보, 사용자 정보, 초기 메시지에 대해 확인을 하고, 입력 필드를 열도록 했습니다.
- 현재 무한 스크롤 최상단 위치 시, 로드할 채팅이 없다는 UI를 임시로 추가해놨는데, 디스코드와 슬랙 참고하여 꾸밀 예정
- 현재 아래와 같이 useWebSocket에 useEffect 의존성 배열에 함수를 추가하지 않았다는 경고가 뜨는데, chatRooms 의존성을 추가하면, 본인이 전송한 채팅이 자신에게는 보이지 않는 문제가 발생 (새로고침을 해야만 보임)
빼놓으면 작동에는 문제 없고 일단 시간이 좀 걸릴것같아 이대로 커밋했습니다.
`src/components/common/useWebSocket.jsx
  Line 154:8:  React Hook useEffect has missing dependencies: 'chatRooms', 'onMessageReceived', and 'onSidebarMessage'. Either include them or remove the dependency array. If 'onSidebarMessage' changes too often, find the parent component that defines it and wrap that definition in useCallback  react-hooks/exhaustive-deps`

### stompClientRef 부분 경고 
~~연결된 객체가 없어 사용되지 않는다고 경고가 뜨는데, 내부적으로 웹소켓과 연결이 되어있어서, 연결이 끊기면 채팅방의 구독도 끊겨서, 알림(빨간점)이 안뜹니다.~~
- 다른 채팅방에 채팅이 온 경우 빨간 점이 안뜨는 문제 발생
- 이건 내일 일어나서 고쳐보겠습니다...
<img width="509" alt="스크린샷 2025-06-07 오전 12 58 39" src="https://github.com/user-attachments/assets/dd47ca45-f159-4534-bad7-caaecf53837d" />

### gitHub WebHook 알림 허용
- JWT 필터에 GitHub 웹훅이 막혀져있었습니다. 따라서, /github/를 추가해서 인증권한을 패스하도록 했습니다.

### 웹소켓 연결 및 로그가 두 번 뜨는 현상
React에 StrictMode가 존재해서 개발 모드의 경우, 감싸서 개발하는 것이 일반적이라고 합니다. 다들 두 번씩 날아간다고 하셔서, 저도 이파일 저파일 찾아보다가 index.jsx에서 찾았습니다.
- 안전하지 않은 생명주기를 사용하는 컴포넌트 발견
- 레거시 문자열 ref 사용에 대한 경고
- 권장되지 않는 findDOMNode 사용에 대한 경고
- 예상치 못한 부작용 검사
- 레거시 context API 검사
- 재사용 가능한 상태 보장
등등의 이점이 존재한다고 합니다. 참고해주시면 감사하겠습니다. 자세한 글은 📚 Reference의 URL 참고해주시면 감사하겠습니다!

### 사용자의 참여 채팅방 연결 문제 (참여 채팅방 구독에 대한 생각)
어느정도 주관적인 판단이 있으므로, 확인에 확인을 하셔서 판단해주시면 감사하겠습니다. 🙇‍♂️
해당 문제는 지금은 문제가 되지는 않지만, 현재 사용자가 참여중인 채팅방의 모든 구독을 유지하고 있어서, 사용자가 늘어나거나, 채팅방이 늘어나는 경우, 클라이언트쪽의 리소스에 부담이 갑니다. 서버에서는 pub/sub으로 브로드캐스팅만 해주면 되서 부담은 없습니다. 개발환경이나 배포 서버에 대해서도 문제는 없지만, 해당 문제에 대해 지금 설계를 유지할 지, 다른 방식을 찾아볼지 또는 이 이상의 뭔가를 추가한다면, 오버엔지니어링일것 같은지 한번씩 코멘트에 달아주시면 감사하겠습니다!

부담이 간다라는 말의 근거는, 채널 수가 중요한건 아니지만, 채널량이 많아지면 메시지 트래픽이 많아지는 것이 일반적이므로 부담이 간다라는 표현을 사용했습니다. 리소스의 부담 기준은 클라이언트의 메모리와 CPU, 메시지 빈도 등에 따라서 달라집니다.


## 📚 Reference
https://shape-coding.tistory.com/entry/React-리액트-consolelog-두-번씩-찍히는-이유-렌더링이-두-번-되는-이슈

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?