### PR TITLE
인라인 코드 구현,웹훅 자동 삭제

### DIFF
--- a/backend/src/main/java/project/backend/domain/chat/chatmessage/app/ChatMessageService.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatmessage/app/ChatMessageService.java
@@ -59,7 +59,7 @@ public class ChatMessageService {
 
 		ChatRoom room = chatRoomService.getRoomById(roomId);
 
-		chatRoomService.validateNotParticipant(sender.getId(), roomId);
+		chatRoomService.validateParticipant(sender.getId(), roomId);
 
 		ChatMessage message;
 
@@ -97,7 +97,7 @@ public class ChatMessageService {
 		int size = request.getPageSize();
 		int offset = page * size;
 
-		chatRoomService.validateNotParticipant(memberId, roomId);
+		chatRoomService.validateParticipant(memberId, roomId);
 		// messageIds는 DESC 정렬 보장
 		List<Long> messageIds = chatMessageSearchRepository.searchIdsByKeywordAndRoomId(keyword,
 			roomId, size, offset);
@@ -184,7 +184,7 @@ public class ChatMessageService {
 	public ChatScrollResponse getMessagesByRoomId(Long memberId, Long roomId, Long cursor,
 		int size) {
 		chatRoomService.getRoomById(roomId);
-		chatRoomService.validateNotParticipant(memberId, roomId);
+		chatRoomService.validateParticipant(memberId, roomId);
 
 		PageRequest pageRequest = PageRequest.of(0, size + 1);
 		List<ChatMessage> result;

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomService.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomService.java
@@ -162,7 +162,7 @@ public class ChatRoomService {
 		ChatRoom chatRoom = chatRoomRepository.findById(roomId)
 			.orElseThrow(() -> new ChatRoomException(ChatRoomErrorCode.CHATROOM_NOT_FOUND));
 
-		validateNotParticipant(memberId, roomId);
+		validateParticipant(memberId, roomId);
 
 		List<ChatParticipant> participants = chatParticipantRepository.findByChatRoom(chatRoom);
 
@@ -221,7 +221,7 @@ public class ChatRoomService {
 	@Transactional
 	public EntryRoomResponse getEntryInfo(String inviteCode, Long memberId) {
 		ChatRoom room = getByInviteCode(inviteCode);
-		validateNotParticipant(memberId, room.getId());
+		validateParticipant(memberId, room.getId());
 
 		memberService.getMemberById(memberId).setRecentRoomId(room.getId()); //recentRoomId 업데이트
 
@@ -242,7 +242,7 @@ public class ChatRoomService {
 		return ChatRoomMapper.toListResponse(room);
 	}
 
-	public void validateNotParticipant(Long memberId, Long roomId) {
+	public void validateParticipant(Long memberId, Long roomId) {
 		if (!chatParticipantRepository.
 			existsByParticipantIdAndChatRoomIdAndIsActiveTrue(memberId, roomId)) {
 			throw new ChatRoomException(ChatRoomErrorCode.NOT_PARTICIPANT);

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomService.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomService.java
@@ -261,6 +261,8 @@ public class ChatRoomService {
 			throw new ChatRoomException(ChatRoomErrorCode.OWNER_PERMISSION_REQUIRED);
 		}
 
+		gitMessageService.deleteWebhook(room, memberId);
+
 		eventPublisher.publishEvent(
 			new DeleteChatRoomEvent(roomId, room.getName())
 		);

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/entity/ChatRoom.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/entity/ChatRoom.java
@@ -38,7 +38,6 @@ public class ChatRoom {
 
 	private String inviteCode;
 
-	@Setter
 	private Long webhookId;
 
 	@OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL, orphanRemoval = true)
@@ -71,5 +70,9 @@ public class ChatRoom {
 		return (int) participants.stream()
 			.filter(ChatParticipant::isActive)
 			.count();
+	}
+
+	public void updateWebhookId(Long webhookId) {
+		this.webhookId = webhookId;
 	}
 }

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/entity/ChatRoom.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/entity/ChatRoom.java
@@ -15,6 +15,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 import project.backend.domain.chat.chatmessage.entity.ChatMessage;
 
 @Entity
@@ -37,6 +38,9 @@ public class ChatRoom {
 
 	private String inviteCode;
 
+	@Setter
+	private Long webhookId;
+
 	@OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<ChatMessage> messages = new ArrayList<>();
 
@@ -45,11 +49,12 @@ public class ChatRoom {
 
 	@Builder
 	public ChatRoom(String name, LocalDateTime createdAt, String repositoryUrl, String inviteCode,
-		List<ChatMessage> messages, List<ChatParticipant> participants) {
+		Long webhookId, List<ChatMessage> messages, List<ChatParticipant> participants) {
 		this.name = name;
 		this.createdAt = createdAt != null ? createdAt : LocalDateTime.now();
 		this.repositoryUrl = repositoryUrl;
 		this.inviteCode = inviteCode;
+		this.webhookId = webhookId;
 		if (messages != null) {
 			this.messages = messages;
 		}

--- a/backend/src/main/java/project/backend/domain/chat/codereview/api/CodeReviewController.java
+++ b/backend/src/main/java/project/backend/domain/chat/codereview/api/CodeReviewController.java
@@ -45,7 +45,7 @@ public class CodeReviewController {
 
 	@PutMapping("/{reviewId}")
 	public CodeReviewResponse editReview(@PathVariable Long reviewId,
-		@RequestBody CodeReviewRequest request,
+		@Valid @RequestBody CodeReviewRequest request,
 		@AuthenticationPrincipal MemberDetails memberDetails) {
 		return codeReviewService.editReview(reviewId, request, memberDetails.getId());
 	}

--- a/backend/src/main/java/project/backend/domain/chat/codereview/api/CodeReviewController.java
+++ b/backend/src/main/java/project/backend/domain/chat/codereview/api/CodeReviewController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -40,5 +41,12 @@ public class CodeReviewController {
 	public void deleteReview(@PathVariable Long reviewId,
 		@AuthenticationPrincipal MemberDetails memberDetails) {
 		codeReviewService.deleteReview(reviewId, memberDetails.getId());
+	}
+
+	@PutMapping("/{reviewId}")
+	public CodeReviewResponse editReview(@PathVariable Long reviewId,
+		@RequestBody CodeReviewRequest request,
+		@AuthenticationPrincipal MemberDetails memberDetails) {
+		return codeReviewService.editReview(reviewId, request, memberDetails.getId());
 	}
 }

--- a/backend/src/main/java/project/backend/domain/chat/codereview/api/CodeReviewController.java
+++ b/backend/src/main/java/project/backend/domain/chat/codereview/api/CodeReviewController.java
@@ -14,7 +14,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import project.backend.auth.dto.MemberDetails;
 import project.backend.domain.chat.codereview.app.CodeReviewService;
-import project.backend.domain.chat.codereview.dto.CodeReviewRequest;
+import project.backend.domain.chat.codereview.dto.CodeReviewCreateRequest;
+import project.backend.domain.chat.codereview.dto.CodeReviewEditRequest;
 import project.backend.domain.chat.codereview.dto.CodeReviewResponse;
 
 @RestController
@@ -26,7 +27,7 @@ public class CodeReviewController {
 
 	@PostMapping
 	public CodeReviewResponse createReview(
-		@Valid @RequestBody CodeReviewRequest request,
+		@Valid @RequestBody CodeReviewCreateRequest request,
 		@AuthenticationPrincipal MemberDetails memberDetails) {
 		return codeReviewService.createReview(request, memberDetails.getId());
 	}
@@ -45,7 +46,7 @@ public class CodeReviewController {
 
 	@PutMapping("/{reviewId}")
 	public CodeReviewResponse editReview(@PathVariable Long reviewId,
-		@Valid @RequestBody CodeReviewRequest request,
+		@Valid @RequestBody CodeReviewEditRequest request,
 		@AuthenticationPrincipal MemberDetails memberDetails) {
 		return codeReviewService.editReview(reviewId, request, memberDetails.getId());
 	}

--- a/backend/src/main/java/project/backend/domain/chat/codereview/api/CodeReviewController.java
+++ b/backend/src/main/java/project/backend/domain/chat/codereview/api/CodeReviewController.java
@@ -4,6 +4,7 @@ import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -25,8 +26,7 @@ public class CodeReviewController {
 	@PostMapping
 	public CodeReviewResponse createReview(
 		@Valid @RequestBody CodeReviewRequest request,
-		@AuthenticationPrincipal MemberDetails memberDetails
-	) {
+		@AuthenticationPrincipal MemberDetails memberDetails) {
 		return codeReviewService.createReview(request, memberDetails.getId());
 	}
 
@@ -34,5 +34,11 @@ public class CodeReviewController {
 	public List<CodeReviewResponse> getReviews(@PathVariable Long messageId,
 		@AuthenticationPrincipal MemberDetails memberDetails) {
 		return codeReviewService.getReviewsByMessageId(messageId, memberDetails.getId());
+	}
+
+	@DeleteMapping("/{reviewId}")
+	public void deleteReview(@PathVariable Long reviewId,
+		@AuthenticationPrincipal MemberDetails memberDetails) {
+		codeReviewService.deleteReview(reviewId, memberDetails.getId());
 	}
 }

--- a/backend/src/main/java/project/backend/domain/chat/codereview/api/CodeReviewController.java
+++ b/backend/src/main/java/project/backend/domain/chat/codereview/api/CodeReviewController.java
@@ -1,8 +1,11 @@
 package project.backend.domain.chat.codereview.api;
 
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -25,5 +28,11 @@ public class CodeReviewController {
 		@AuthenticationPrincipal MemberDetails memberDetails
 	) {
 		return codeReviewService.createReview(request, memberDetails.getId());
+	}
+
+	@GetMapping("/{messageId}")
+	public List<CodeReviewResponse> getReviews(@PathVariable Long messageId,
+		@AuthenticationPrincipal MemberDetails memberDetails) {
+		return codeReviewService.getReviewsByMessageId(messageId, memberDetails.getId());
 	}
 }

--- a/backend/src/main/java/project/backend/domain/chat/codereview/api/CodeReviewController.java
+++ b/backend/src/main/java/project/backend/domain/chat/codereview/api/CodeReviewController.java
@@ -1,0 +1,29 @@
+package project.backend.domain.chat.codereview.api;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import project.backend.auth.dto.MemberDetails;
+import project.backend.domain.chat.codereview.app.CodeReviewService;
+import project.backend.domain.chat.codereview.dto.CodeReviewRequest;
+import project.backend.domain.chat.codereview.dto.CodeReviewResponse;
+
+@RestController
+@RequestMapping("/code-reviews")
+@RequiredArgsConstructor
+public class CodeReviewController {
+
+	private final CodeReviewService codeReviewService;
+
+	@PostMapping
+	public CodeReviewResponse createReview(
+		@Valid @RequestBody CodeReviewRequest request,
+		@AuthenticationPrincipal MemberDetails memberDetails
+	) {
+		return codeReviewService.createReview(request, memberDetails.getId());
+	}
+}

--- a/backend/src/main/java/project/backend/domain/chat/codereview/app/CodeReviewService.java
+++ b/backend/src/main/java/project/backend/domain/chat/codereview/app/CodeReviewService.java
@@ -42,6 +42,8 @@ public class CodeReviewService {
 			throw new CodeReviewException(CodeReviewErrorCode.INVALID_MESSAGE_TYPE);
 		}
 
+		chatRoomService.validateParticipant(authorId, message.getChatRoom().getId());
+
 		CodeReview codeReview = codeReviewMapper.toEntity(request, message, author);
 
 		CodeReview savedReview = codeReviewRepository.save(codeReview);
@@ -68,12 +70,18 @@ public class CodeReviewService {
 	public void deleteReview(Long reviewId, Long authorId) {
 		CodeReview codeReview = validateReviewOwnership(reviewId, authorId);
 
+		chatRoomService.validateParticipant(authorId,
+			codeReview.getMessage().getChatRoom().getId());
+
 		codeReviewRepository.delete(codeReview);
 	}
 
 	@Transactional
 	public CodeReviewResponse editReview(Long reviewId, CodeReviewEditRequest request, Long authorId) {
 		CodeReview editCodeReview = validateReviewOwnership(reviewId, authorId);
+
+		chatRoomService.validateParticipant(authorId,
+			editCodeReview.getMessage().getChatRoom().getId());
 
 		editCodeReview.editReview(request.content());
 

--- a/backend/src/main/java/project/backend/domain/chat/codereview/app/CodeReviewService.java
+++ b/backend/src/main/java/project/backend/domain/chat/codereview/app/CodeReviewService.java
@@ -61,4 +61,15 @@ public class CodeReviewService {
 			.toList();
 	}
 
+	@Transactional
+	public void deleteReview(Long reviewId, Long authorId) {
+		CodeReview codeReview = codeReviewRepository.findById(reviewId)
+			.orElseThrow(() -> new IllegalArgumentException("해당 코드리뷰 존재하지 않음."));
+
+		if (!codeReview.getAuthor().getId().equals(authorId)) {
+			throw new IllegalArgumentException("본인이 작성한 코드리뷰만 삭제할 수 있습니다");
+		}
+
+		codeReviewRepository.delete(codeReview);
+	}
 }

--- a/backend/src/main/java/project/backend/domain/chat/codereview/app/CodeReviewService.java
+++ b/backend/src/main/java/project/backend/domain/chat/codereview/app/CodeReviewService.java
@@ -15,7 +15,9 @@ import project.backend.domain.chat.codereview.mapper.CodeReviewMapper;
 import project.backend.domain.member.app.MemberService;
 import project.backend.domain.member.entity.Member;
 import project.backend.global.exception.errorcode.ChatMessageErrorCode;
+import project.backend.global.exception.errorcode.CodeReviewErrorCode;
 import project.backend.global.exception.ex.ChatMessageException;
+import project.backend.global.exception.ex.CodeReviewException;
 
 @Service
 @RequiredArgsConstructor
@@ -34,10 +36,8 @@ public class CodeReviewService {
 			.orElseThrow(() -> new ChatMessageException(ChatMessageErrorCode.MESSAGE_NOT_FOUND));
 
 		if (message.getType() != MessageType.CODE) {
-			throw new IllegalArgumentException("코드 메시지에만 리뷰 작성 가능");
+			throw new CodeReviewException(CodeReviewErrorCode.INVALID_MESSAGE_TYPE);
 		}
-
-		//참여자가 아닌 멤버가 리뷰남기는거 막는 거 필요?
 
 		CodeReview codeReview = codeReviewMapper.toEntity(request, message, author);
 
@@ -48,10 +48,10 @@ public class CodeReviewService {
 
 	@Transactional
 	public List<CodeReviewResponse> getReviewsByMessageId(Long messageId, Long memberId) {
-		ChatMessage message = chatMessageRepository.findById(messageId)
+		chatMessageRepository.findById(messageId)
 			.orElseThrow(() -> new ChatMessageException(ChatMessageErrorCode.MESSAGE_NOT_FOUND));
 
-		Member member = memberService.getMemberById(memberId);
+		memberService.getMemberById(memberId);
 
 		List<CodeReview> reviews = codeReviewRepository
 			.findByMessageIdOrderByLineNumberAscCreatedAtAsc(messageId);
@@ -63,27 +63,28 @@ public class CodeReviewService {
 
 	@Transactional
 	public void deleteReview(Long reviewId, Long authorId) {
-		CodeReview codeReview = codeReviewRepository.findById(reviewId)
-			.orElseThrow(() -> new IllegalArgumentException("해당 코드리뷰 존재하지 않음."));
-
-		if (!codeReview.getAuthor().getId().equals(authorId)) {
-			throw new IllegalArgumentException("본인이 작성한 코드리뷰만 삭제할 수 있습니다");
-		}
+		CodeReview codeReview = validateReviewOwnership(reviewId, authorId);
 
 		codeReviewRepository.delete(codeReview);
 	}
 
 	@Transactional
 	public CodeReviewResponse editReview(Long reviewId, CodeReviewRequest request, Long authorId) {
+		CodeReview editCodeReview = validateReviewOwnership(reviewId, authorId);
+
+		editCodeReview.editReview(request.content());
+
+		return codeReviewMapper.toResponse(editCodeReview);
+	}
+
+	private CodeReview validateReviewOwnership(Long reviewId, Long authorId) {
 		CodeReview codeReview = codeReviewRepository.findById(reviewId)
-			.orElseThrow(() -> new IllegalArgumentException("해당 코드리뷰 존재하지 않음."));
+			.orElseThrow(() -> new CodeReviewException(CodeReviewErrorCode.REVIEW_NOT_FOUND));
 
 		if (!codeReview.getAuthor().getId().equals(authorId)) {
-			throw new IllegalArgumentException("본인이 작성한 코드리뷰만 수정할 수 있습니다");
+			throw new CodeReviewException(CodeReviewErrorCode.UNAUTHORIZED_ACCESS);
 		}
 
-		codeReview.editReview(request.content());
-
-		return codeReviewMapper.toResponse(codeReview);
+		return codeReview;
 	}
 }

--- a/backend/src/main/java/project/backend/domain/chat/codereview/app/CodeReviewService.java
+++ b/backend/src/main/java/project/backend/domain/chat/codereview/app/CodeReviewService.java
@@ -9,7 +9,8 @@ import project.backend.domain.chat.chatmessage.entity.ChatMessage;
 import project.backend.domain.chat.chatmessage.entity.MessageType;
 import project.backend.domain.chat.chatroom.app.ChatRoomService;
 import project.backend.domain.chat.codereview.dao.CodeReviewRepository;
-import project.backend.domain.chat.codereview.dto.CodeReviewRequest;
+import project.backend.domain.chat.codereview.dto.CodeReviewCreateRequest;
+import project.backend.domain.chat.codereview.dto.CodeReviewEditRequest;
 import project.backend.domain.chat.codereview.dto.CodeReviewResponse;
 import project.backend.domain.chat.codereview.entity.CodeReview;
 import project.backend.domain.chat.codereview.mapper.CodeReviewMapper;
@@ -31,7 +32,7 @@ public class CodeReviewService {
 	private final ChatRoomService chatRoomService;
 
 	@Transactional
-	public CodeReviewResponse createReview(CodeReviewRequest request, Long authorId) {
+	public CodeReviewResponse createReview(CodeReviewCreateRequest request, Long authorId) {
 		Member author = memberService.getMemberById(authorId);
 
 		ChatMessage message = chatMessageRepository.findById(request.messageId())
@@ -71,7 +72,7 @@ public class CodeReviewService {
 	}
 
 	@Transactional
-	public CodeReviewResponse editReview(Long reviewId, CodeReviewRequest request, Long authorId) {
+	public CodeReviewResponse editReview(Long reviewId, CodeReviewEditRequest request, Long authorId) {
 		CodeReview editCodeReview = validateReviewOwnership(reviewId, authorId);
 
 		editCodeReview.editReview(request.content());

--- a/backend/src/main/java/project/backend/domain/chat/codereview/app/CodeReviewService.java
+++ b/backend/src/main/java/project/backend/domain/chat/codereview/app/CodeReviewService.java
@@ -1,5 +1,6 @@
 package project.backend.domain.chat.codereview.app;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -43,6 +44,21 @@ public class CodeReviewService {
 		CodeReview savedReview = codeReviewRepository.save(codeReview);
 
 		return codeReviewMapper.toResponse(savedReview);
+	}
+
+	@Transactional
+	public List<CodeReviewResponse> getReviewsByMessageId(Long messageId, Long memberId) {
+		ChatMessage message = chatMessageRepository.findById(messageId)
+			.orElseThrow(() -> new ChatMessageException(ChatMessageErrorCode.MESSAGE_NOT_FOUND));
+
+		Member member = memberService.getMemberById(memberId);
+
+		List<CodeReview> reviews = codeReviewRepository
+			.findByMessageIdOrderByLineNumberAscCreatedAtAsc(messageId);
+
+		return reviews.stream()
+			.map(codeReviewMapper::toResponse)
+			.toList();
 	}
 
 }

--- a/backend/src/main/java/project/backend/domain/chat/codereview/app/CodeReviewService.java
+++ b/backend/src/main/java/project/backend/domain/chat/codereview/app/CodeReviewService.java
@@ -7,6 +7,7 @@ import org.springframework.transaction.annotation.Transactional;
 import project.backend.domain.chat.chatmessage.dao.ChatMessageRepository;
 import project.backend.domain.chat.chatmessage.entity.ChatMessage;
 import project.backend.domain.chat.chatmessage.entity.MessageType;
+import project.backend.domain.chat.chatroom.app.ChatRoomService;
 import project.backend.domain.chat.codereview.dao.CodeReviewRepository;
 import project.backend.domain.chat.codereview.dto.CodeReviewRequest;
 import project.backend.domain.chat.codereview.dto.CodeReviewResponse;
@@ -27,6 +28,7 @@ public class CodeReviewService {
 	private final ChatMessageRepository chatMessageRepository;
 	private final MemberService memberService;
 	private final CodeReviewMapper codeReviewMapper;
+	private final ChatRoomService chatRoomService;
 
 	@Transactional
 	public CodeReviewResponse createReview(CodeReviewRequest request, Long authorId) {
@@ -46,12 +48,12 @@ public class CodeReviewService {
 		return codeReviewMapper.toResponse(savedReview);
 	}
 
-	@Transactional
+	@Transactional(readOnly = true)
 	public List<CodeReviewResponse> getReviewsByMessageId(Long messageId, Long memberId) {
-		chatMessageRepository.findById(messageId)
+		ChatMessage message = chatMessageRepository.findById(messageId)
 			.orElseThrow(() -> new ChatMessageException(ChatMessageErrorCode.MESSAGE_NOT_FOUND));
 
-		memberService.getMemberById(memberId);
+		chatRoomService.validateParticipant(memberId,message.getChatRoom().getId());
 
 		List<CodeReview> reviews = codeReviewRepository
 			.findByMessageIdOrderByLineNumberAscCreatedAtAsc(messageId);

--- a/backend/src/main/java/project/backend/domain/chat/codereview/app/CodeReviewService.java
+++ b/backend/src/main/java/project/backend/domain/chat/codereview/app/CodeReviewService.java
@@ -1,0 +1,48 @@
+package project.backend.domain.chat.codereview.app;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import project.backend.domain.chat.chatmessage.dao.ChatMessageRepository;
+import project.backend.domain.chat.chatmessage.entity.ChatMessage;
+import project.backend.domain.chat.chatmessage.entity.MessageType;
+import project.backend.domain.chat.codereview.dao.CodeReviewRepository;
+import project.backend.domain.chat.codereview.dto.CodeReviewRequest;
+import project.backend.domain.chat.codereview.dto.CodeReviewResponse;
+import project.backend.domain.chat.codereview.entity.CodeReview;
+import project.backend.domain.chat.codereview.mapper.CodeReviewMapper;
+import project.backend.domain.member.app.MemberService;
+import project.backend.domain.member.entity.Member;
+import project.backend.global.exception.errorcode.ChatMessageErrorCode;
+import project.backend.global.exception.ex.ChatMessageException;
+
+@Service
+@RequiredArgsConstructor
+public class CodeReviewService {
+
+	private final CodeReviewRepository codeReviewRepository;
+	private final ChatMessageRepository chatMessageRepository;
+	private final MemberService memberService;
+	private final CodeReviewMapper codeReviewMapper;
+
+	@Transactional
+	public CodeReviewResponse createReview(CodeReviewRequest request, Long authorId) {
+		Member author = memberService.getMemberById(authorId);
+
+		ChatMessage message = chatMessageRepository.findById(request.messageId())
+			.orElseThrow(() -> new ChatMessageException(ChatMessageErrorCode.MESSAGE_NOT_FOUND));
+
+		if (message.getType() != MessageType.CODE) {
+			throw new IllegalArgumentException("코드 메시지에만 리뷰 작성 가능");
+		}
+
+		//참여자가 아닌 멤버가 리뷰남기는거 막는 거 필요?
+
+		CodeReview codeReview = codeReviewMapper.toEntity(request, message, author);
+
+		CodeReview savedReview = codeReviewRepository.save(codeReview);
+
+		return codeReviewMapper.toResponse(savedReview);
+	}
+
+}

--- a/backend/src/main/java/project/backend/domain/chat/codereview/app/CodeReviewService.java
+++ b/backend/src/main/java/project/backend/domain/chat/codereview/app/CodeReviewService.java
@@ -72,4 +72,18 @@ public class CodeReviewService {
 
 		codeReviewRepository.delete(codeReview);
 	}
+
+	@Transactional
+	public CodeReviewResponse editReview(Long reviewId, CodeReviewRequest request, Long authorId) {
+		CodeReview codeReview = codeReviewRepository.findById(reviewId)
+			.orElseThrow(() -> new IllegalArgumentException("해당 코드리뷰 존재하지 않음."));
+
+		if (!codeReview.getAuthor().getId().equals(authorId)) {
+			throw new IllegalArgumentException("본인이 작성한 코드리뷰만 수정할 수 있습니다");
+		}
+
+		codeReview.editReview(request.content());
+
+		return codeReviewMapper.toResponse(codeReview);
+	}
 }

--- a/backend/src/main/java/project/backend/domain/chat/codereview/dao/CodeReviewRepository.java
+++ b/backend/src/main/java/project/backend/domain/chat/codereview/dao/CodeReviewRepository.java
@@ -1,8 +1,10 @@
 package project.backend.domain.chat.codereview.dao;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import project.backend.domain.chat.codereview.entity.CodeReview;
 
 public interface CodeReviewRepository extends JpaRepository<CodeReview, Long> {
 
+	List<CodeReview> findByMessageIdOrderByLineNumberAscCreatedAtAsc(Long messageId);
 }

--- a/backend/src/main/java/project/backend/domain/chat/codereview/dao/CodeReviewRepository.java
+++ b/backend/src/main/java/project/backend/domain/chat/codereview/dao/CodeReviewRepository.java
@@ -1,0 +1,8 @@
+package project.backend.domain.chat.codereview.dao;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import project.backend.domain.chat.codereview.entity.CodeReview;
+
+public interface CodeReviewRepository extends JpaRepository<CodeReview, Long> {
+
+}

--- a/backend/src/main/java/project/backend/domain/chat/codereview/dto/CodeReviewCreateRequest.java
+++ b/backend/src/main/java/project/backend/domain/chat/codereview/dto/CodeReviewCreateRequest.java
@@ -1,0 +1,16 @@
+package project.backend.domain.chat.codereview.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record CodeReviewCreateRequest(
+	@NotNull(message = "메세지 ID는 필수입니다")
+	Long messageId,
+
+	@NotNull(message = "줄번호는 필수입니다")
+	Integer lineNumber,
+
+	@NotNull(message = "리뷰내용은 필수입니다")
+	@Size(max = 500, message = "리뷰는 500자 이하여야 합니다")
+	String content
+) {}

--- a/backend/src/main/java/project/backend/domain/chat/codereview/dto/CodeReviewEditRequest.java
+++ b/backend/src/main/java/project/backend/domain/chat/codereview/dto/CodeReviewEditRequest.java
@@ -3,13 +3,7 @@ package project.backend.domain.chat.codereview.dto;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
-public record CodeReviewRequest(
-	@NotNull(message = "메세지 ID는 필수입니다")
-	Long messageId,
-
-	@NotNull(message = "줄번호는 필수입니다")
-	Integer lineNumber,
-
+public record CodeReviewEditRequest(
 	@NotNull(message = "리뷰내용은 필수입니다")
 	@Size(max = 500, message = "리뷰는 500자 이하여야 합니다")
 	String content

--- a/backend/src/main/java/project/backend/domain/chat/codereview/dto/CodeReviewRequest.java
+++ b/backend/src/main/java/project/backend/domain/chat/codereview/dto/CodeReviewRequest.java
@@ -1,0 +1,16 @@
+package project.backend.domain.chat.codereview.dto;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record CodeReviewRequest(
+	@NotNull(message = "메세지 ID는 필수입니다")
+	Long messageId,
+
+	@NotNull(message = "줄번호는 필수입니다")
+	Integer lineNumber,
+
+	@NotNull(message = "리뷰내용은 필수입니다")
+	@Size(max = 500, message = "리뷰는 500자 이하여야 합니다")
+	String content
+) {}

--- a/backend/src/main/java/project/backend/domain/chat/codereview/dto/CodeReviewResponse.java
+++ b/backend/src/main/java/project/backend/domain/chat/codereview/dto/CodeReviewResponse.java
@@ -1,0 +1,13 @@
+package project.backend.domain.chat.codereview.dto;
+
+import java.time.LocalDateTime;
+
+public record CodeReviewResponse(
+	Long reviewId,
+	Long messageId,
+	Integer lineNumber,
+	String content,
+	LocalDateTime createAt,
+	String authorName,
+	Long authorId
+) {}

--- a/backend/src/main/java/project/backend/domain/chat/codereview/entity/CodeReview.java
+++ b/backend/src/main/java/project/backend/domain/chat/codereview/entity/CodeReview.java
@@ -24,7 +24,6 @@ import project.backend.domain.member.entity.Member;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Builder
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class CodeReview {
 
 	@Id

--- a/backend/src/main/java/project/backend/domain/chat/codereview/entity/CodeReview.java
+++ b/backend/src/main/java/project/backend/domain/chat/codereview/entity/CodeReview.java
@@ -1,0 +1,50 @@
+package project.backend.domain.chat.codereview.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import project.backend.domain.chat.chatmessage.entity.ChatMessage;
+import project.backend.domain.member.entity.Member;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Getter
+public class CodeReview {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "review_id")
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@Column(name = "message_id")
+	private ChatMessage message;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@Column(name = "member_id")
+	private Member author;
+
+	private int lineNumber;
+
+	@Column(columnDefinition = "TEXT")
+	private String content;
+
+	@CreationTimestamp
+	private LocalDateTime createdAt;
+
+	public void updateContent(String content) {
+		this.content = content;
+	}
+
+}

--- a/backend/src/main/java/project/backend/domain/chat/codereview/entity/CodeReview.java
+++ b/backend/src/main/java/project/backend/domain/chat/codereview/entity/CodeReview.java
@@ -6,10 +6,12 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
@@ -18,8 +20,9 @@ import project.backend.domain.member.entity.Member;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 @Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class CodeReview {
 
 	@Id
@@ -28,14 +31,14 @@ public class CodeReview {
 	private Long id;
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	@Column(name = "message_id")
+	@JoinColumn(name = "message_id")
 	private ChatMessage message;
 
 	@ManyToOne(fetch = FetchType.LAZY)
-	@Column(name = "member_id")
+	@JoinColumn(name = "member_id")
 	private Member author;
 
-	private int lineNumber;
+	private Integer lineNumber;
 
 	@Column(columnDefinition = "TEXT")
 	private String content;

--- a/backend/src/main/java/project/backend/domain/chat/codereview/entity/CodeReview.java
+++ b/backend/src/main/java/project/backend/domain/chat/codereview/entity/CodeReview.java
@@ -49,7 +49,7 @@ public class CodeReview {
 	@CreationTimestamp
 	private LocalDateTime createdAt;
 
-	public void updateContent(String content) {
+	public void editReview(String content) {
 		this.content = content;
 	}
 

--- a/backend/src/main/java/project/backend/domain/chat/codereview/entity/CodeReview.java
+++ b/backend/src/main/java/project/backend/domain/chat/codereview/entity/CodeReview.java
@@ -15,6 +15,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import project.backend.domain.chat.chatmessage.entity.ChatMessage;
 import project.backend.domain.member.entity.Member;
 
@@ -32,6 +34,7 @@ public class CodeReview {
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "message_id")
+	@OnDelete(action = OnDeleteAction.CASCADE)
 	private ChatMessage message;
 
 	@ManyToOne(fetch = FetchType.LAZY)

--- a/backend/src/main/java/project/backend/domain/chat/codereview/mapper/CodeReviewMapper.java
+++ b/backend/src/main/java/project/backend/domain/chat/codereview/mapper/CodeReviewMapper.java
@@ -1,0 +1,33 @@
+package project.backend.domain.chat.codereview.mapper;
+
+import org.springframework.stereotype.Component;
+import project.backend.domain.chat.chatmessage.entity.ChatMessage;
+import project.backend.domain.chat.codereview.dto.CodeReviewRequest;
+import project.backend.domain.chat.codereview.dto.CodeReviewResponse;
+import project.backend.domain.chat.codereview.entity.CodeReview;
+import project.backend.domain.member.entity.Member;
+
+@Component
+public class CodeReviewMapper {
+
+	public CodeReview toEntity(CodeReviewRequest request, ChatMessage message, Member author) {
+		return CodeReview.builder()
+			.message(message)
+			.author(author)
+			.lineNumber(request.lineNumber())
+			.content(request.content())
+			.build();
+	}
+
+	public CodeReviewResponse toResponse(CodeReview codeReview) {
+		return new CodeReviewResponse(
+			codeReview.getId(),
+			codeReview.getMessage().getId(),
+			codeReview.getLineNumber(),
+			codeReview.getContent(),
+			codeReview.getCreatedAt(),
+			codeReview.getAuthor().getNickname(),
+			codeReview.getAuthor().getId()
+		);
+	}
+}

--- a/backend/src/main/java/project/backend/domain/chat/codereview/mapper/CodeReviewMapper.java
+++ b/backend/src/main/java/project/backend/domain/chat/codereview/mapper/CodeReviewMapper.java
@@ -30,4 +30,6 @@ public class CodeReviewMapper {
 			codeReview.getAuthor().getId()
 		);
 	}
+
+
 }

--- a/backend/src/main/java/project/backend/domain/chat/codereview/mapper/CodeReviewMapper.java
+++ b/backend/src/main/java/project/backend/domain/chat/codereview/mapper/CodeReviewMapper.java
@@ -2,7 +2,7 @@ package project.backend.domain.chat.codereview.mapper;
 
 import org.springframework.stereotype.Component;
 import project.backend.domain.chat.chatmessage.entity.ChatMessage;
-import project.backend.domain.chat.codereview.dto.CodeReviewRequest;
+import project.backend.domain.chat.codereview.dto.CodeReviewCreateRequest;
 import project.backend.domain.chat.codereview.dto.CodeReviewResponse;
 import project.backend.domain.chat.codereview.entity.CodeReview;
 import project.backend.domain.member.entity.Member;
@@ -10,7 +10,7 @@ import project.backend.domain.member.entity.Member;
 @Component
 public class CodeReviewMapper {
 
-	public CodeReview toEntity(CodeReviewRequest request, ChatMessage message, Member author) {
+	public CodeReview toEntity(CodeReviewCreateRequest request, ChatMessage message, Member author) {
 		return CodeReview.builder()
 			.message(message)
 			.author(author)

--- a/backend/src/main/java/project/backend/domain/chat/github/GitHubClient.java
+++ b/backend/src/main/java/project/backend/domain/chat/github/GitHubClient.java
@@ -70,7 +70,7 @@ public class GitHubClient {
 		return true;
 	}
 
-	public void registerWebhook(String accessToken, String owner, String repo, String webhookUrl) {
+	public Long registerWebhook(String accessToken, String owner, String repo, String webhookUrl) {
 		String apiUrl = "https://api.github.com/repos/" + owner + "/" + repo + "/hooks";
 
 		Map<String, Object> requestBody = Map.of(
@@ -85,61 +85,39 @@ public class GitHubClient {
 		);
 
 		try {
-			webClientBuilder.build()
+			Map<String, Object> response = webClientBuilder.build()
 				.post()
 				.uri(apiUrl)
 				.header("Authorization", "Bearer " + accessToken)
 				.header("Accept", "application/vnd.github.v3+json")
 				.bodyValue(requestBody)
 				.retrieve()
-				.toBodilessEntity()
+				.bodyToMono(new ParameterizedTypeReference<Map<String, Object>>() {})
 				.block();
+
+			Number idNumber = (Number) response.get("id");
+			return idNumber.longValue();
 		} catch (Exception e) {
-			log.error("웹훅 등록 중 예외 예상치 못한 발생", e);
 			throw new GitHubException(GitHubErrorCode.WEBHOOK_REGISTER_FAILED);
 		}
 	}
 
-	private WebClient getWebClient(String gitHubAccessToken) {
-		return WebClient.builder()
-			.baseUrl("https://api.github.com")
-			.defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + gitHubAccessToken)
-			.defaultHeader(HttpHeaders.ACCEPT, "application/vnd.github+json")
-			.build();
-	}
+	public void deleteWebhook(String accessToken, String owner, String repo, Long webhookId) {
+		String apiUrl =
+			"https://api.github.com/repos/" + owner + "/" + repo + "/hooks/" + webhookId;
 
-	public String getPrivateEmail(String gitHubAccessToken) {
-
-		WebClient webClient = getWebClient(gitHubAccessToken);
-
-		List<Map<String, Object>> emailList = webClient.get()
-			.uri("/user/emails")
-			.retrieve()
-			.bodyToMono(new ParameterizedTypeReference<List<Map<String, Object>>>() {
-			})
-			.block();
-
-		if (emailList == null || emailList.isEmpty()) {
-			throw new IllegalStateException("GitHub 이메일 정보를 불러올 수 없습니다.");
+		try {
+			webClientBuilder.build()
+				.delete()
+				.uri(apiUrl)
+				.header("Authorization", "Bearer " + accessToken)
+				.header("Accept", "application/vnd.github.v3+json")
+				.retrieve()
+				.toBodilessEntity()
+				.block();
+		} catch (Exception e) {
+			throw new GitHubException(GitHubErrorCode.WEBHOOK_DELETE_FAILED);
 		}
-
-		String privateEmail = null;
-
-		for (Map<String, Object> email : emailList) {
-			System.out.println(email.get("email"));
-			System.out.println("primary = " + email.get("primary"));
-
-			if (Boolean.TRUE.equals(email.get("primary"))) {
-				privateEmail = (String) email.get("email");
-				break;
-			}
-		}
-
-		if (privateEmail == null) {
-			privateEmail = emailList.getFirst().get("email").toString();
-		}
-
-		return privateEmail;
-
 	}
 }
+

--- a/backend/src/main/java/project/backend/domain/chat/github/app/GitMessageService.java
+++ b/backend/src/main/java/project/backend/domain/chat/github/app/GitMessageService.java
@@ -42,7 +42,6 @@ public class GitMessageService {
 	private String githubUsername;
 	private final GitHubClient gitHubClient;
 	private final TokenRedisRepository tokenRedisRepository;
-	private final ChatParticipantRepository chatParticipantRepository;
 
 	@Transactional
 	public void handleEvent(Long roomId, String eventType, Map<String, Object> payload) {

--- a/backend/src/main/java/project/backend/domain/chat/github/app/GitMessageService.java
+++ b/backend/src/main/java/project/backend/domain/chat/github/app/GitMessageService.java
@@ -97,7 +97,7 @@ public class GitMessageService {
 		ChatRoom room = chatRoomRepository.findById(roomId)
 			.orElseThrow(() -> new ChatRoomException(ChatRoomErrorCode.CHATROOM_NOT_FOUND));
 
-		room.setWebhookId(webhookId);
+		room.updateWebhookId(webhookId);
 	}
 
 	private String makeWebhookUrl(Long roomId) {

--- a/backend/src/main/java/project/backend/domain/chat/github/app/GitMessageService.java
+++ b/backend/src/main/java/project/backend/domain/chat/github/app/GitMessageService.java
@@ -92,12 +92,36 @@ public class GitMessageService {
 			gitRepoDto.ownerName(), gitRepoDto.repoName());
 
 		//있으면 다음 단계로 넘어감
-		gitHubClient.registerWebhook(tokenRedis.getGithubAccess(),
+		Long webhookId = gitHubClient.registerWebhook(tokenRedis.getGithubAccess(),
 			gitRepoDto.ownerName(), gitRepoDto.repoName(), webhookUrl);
+
+		ChatRoom room = chatRoomRepository.findById(roomId)
+			.orElseThrow(() -> new ChatRoomException(ChatRoomErrorCode.CHATROOM_NOT_FOUND));
+
+		room.setWebhookId(webhookId);
 	}
 
 	private String makeWebhookUrl(Long roomId) {
 		return ngrokUrl + "/github/" + roomId;
+	}
+
+	public void deleteWebhook(ChatRoom room, Long ownerId) {
+		if (room.getRepositoryUrl() == null || room.getWebhookId() == null) {
+			log.info("GitHub 연동이 없는 채팅방입니다. 웹훅 삭제 스킵: roomId={}", room.getId());
+			return;
+		}
+
+		GitRepoDto gitRepoDto = GitRepoUrlUtils.validateAndParseUrl(room.getRepositoryUrl());
+
+		TokenRedis tokenRedis = tokenRedisRepository.findById(ownerId)
+			.orElseThrow(() -> new RuntimeException("토큰이 존재하지 않습니다."));
+
+		gitHubClient.deleteWebhook(
+			tokenRedis.getGithubAccess(),
+			gitRepoDto.ownerName(),
+			gitRepoDto.repoName(),
+			room.getWebhookId()
+		);
 	}
 
 }

--- a/backend/src/main/java/project/backend/global/exception/errorcode/CodeReviewErrorCode.java
+++ b/backend/src/main/java/project/backend/global/exception/errorcode/CodeReviewErrorCode.java
@@ -1,0 +1,16 @@
+package project.backend.global.exception.errorcode;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum CodeReviewErrorCode implements ErrorCode{
+	REVIEW_NOT_FOUND("CRE-001", "리뷰를 찾을 수 없습니다", HttpStatus.NOT_FOUND),
+	UNAUTHORIZED_ACCESS("CRE-002", "리뷰 작성자만 수정 및 삭제에 접근가능합니다.", HttpStatus.FORBIDDEN),
+	INVALID_MESSAGE_TYPE("CRE-003", "메세지 타입이 CODE인 경우만 리뷰작성이 가능합니다.", HttpStatus.BAD_REQUEST);
+	private final String code;
+	private final String message;
+	private final HttpStatus status;
+}

--- a/backend/src/main/java/project/backend/global/exception/errorcode/GitHubErrorCode.java
+++ b/backend/src/main/java/project/backend/global/exception/errorcode/GitHubErrorCode.java
@@ -18,6 +18,8 @@ public enum GitHubErrorCode implements ErrorCode {
     UNEXPECTED_RESPONSE("GE-006", "요청한 리포지토리의 permissions에 관한 정보가 없습니다.",
         HttpStatus.INTERNAL_SERVER_ERROR),
     WEBHOOK_REGISTER_FAILED("GE-007", "웹훅 등록 중 예상치 못한 예외가 발생했습니다.",
+        HttpStatus.INTERNAL_SERVER_ERROR),
+    WEBHOOK_DELETE_FAILED("GE-008", "웹훅 삭제 중 예상치 못한 예외가 발생했습니다.",
         HttpStatus.INTERNAL_SERVER_ERROR);
 
     private final String code;

--- a/backend/src/main/java/project/backend/global/exception/ex/CodeReviewException.java
+++ b/backend/src/main/java/project/backend/global/exception/ex/CodeReviewException.java
@@ -1,0 +1,10 @@
+package project.backend.global.exception.ex;
+
+import project.backend.global.exception.errorcode.CodeReviewErrorCode;
+
+public class CodeReviewException extends BaseException {
+
+	public CodeReviewException(CodeReviewErrorCode errorCode) {
+		super(errorCode);
+	}
+}

--- a/frontend/src/components/chatroom/MessageList.jsx
+++ b/frontend/src/components/chatroom/MessageList.jsx
@@ -6,9 +6,9 @@ import { FaCopy, FaTrashAlt, FaUserPlus, FaClock } from 'react-icons/fa';
 const formatDate = (dateString) => {
   const date = new Date(dateString);
   return date.toLocaleDateString('ko-KR', {
-      year: 'numeric',
-      month: '2-digit',
-      day: '2-digit'
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit'
   });
 };
 
@@ -41,18 +41,59 @@ const renderWithLink = (text) => {
   );
 };
 
-const HighlightedCode = ({ content, language }) => {
+const HighlightedCode = ({ content, language, onClick }) => {
   return (
-    <Highlight className={language}>{content}</Highlight>
+    <div
+      onClick={(e) => {
+        console.log('🖱️ 코드 블록 클릭됨!'); // 디버깅용
+        console.log('onClick prop:', onClick); // onClick이 제대로 전달되었는지 확인
+        if (onClick) {
+          onClick(e);
+        } else {
+          console.log('❌ onClick prop이 없음!');
+        }
+      }}
+
+
+
+      style={{
+        cursor: 'pointer',
+        position: 'relative',
+        transition: 'all 0.2s ease'
+      }}
+      onMouseEnter={(e) => {
+        e.currentTarget.style.transform = 'scale(1.01)';
+        e.currentTarget.style.boxShadow = '0 4px 12px rgba(0,0,0,0.1)';
+      }}
+      onMouseLeave={(e) => {
+        e.currentTarget.style.transform = 'scale(1)';
+        e.currentTarget.style.boxShadow = 'none';
+      }}
+    >
+      <Highlight className={language}>{content}</Highlight>
+      <div style={{
+        position: 'absolute',
+        top: '8px',
+        right: '12px',
+        background: 'rgba(0,0,0,0.7)',
+        color: 'white',
+        padding: '4px 8px',
+        borderRadius: '4px',
+        fontSize: '12px',
+        opacity: 0.8
+      }}>
+        클릭하여 자세히 보기
+      </div>
+    </div>
   );
 };
 
 // 프로필 이미지, 날짜, 수정 삭제 메뉴
-const MessageItem = ({ msg, currentUser, contextMenuId, setContextMenuId, setEditMessageId, setEditContent, handleEditMessage, handleDeleteMessage, editMessageId, editContent }) => {
+const MessageItem = ({ msg, currentUser, contextMenuId, setContextMenuId, setEditMessageId, setEditContent, handleEditMessage, handleDeleteMessage, editMessageId, editContent, onCodeClick }) => {
 
   // 이벤트 타입은 메시지만 렌더링 (원래 로직 유지)
-  if(msg.type === 'EVENT'){
-    return(
+  if (msg.type === 'EVENT') {
+    return (
       <MessageContent
         msg={msg}
         editMessageId={editMessageId}
@@ -66,7 +107,7 @@ const MessageItem = ({ msg, currentUser, contextMenuId, setContextMenuId, setEdi
 
   return (
     <div
-      id= {`message-${msg.messageId}`} // 추가
+      id={`message-${msg.messageId}`} // 추가
       style={{ marginBottom: '18px', display: 'flex', alignItems: 'flex-start' }}>
       {/* 프로필 이미지 */}
       <img
@@ -87,7 +128,7 @@ const MessageItem = ({ msg, currentUser, contextMenuId, setContextMenuId, setEdi
         }}
       />
 
-      <div style={{ flex: 1}}>
+      <div style={{ flex: 1 }}>
         <div style={{
           display: 'flex',
           marginBottom: '6px',
@@ -210,16 +251,17 @@ const MessageItem = ({ msg, currentUser, contextMenuId, setContextMenuId, setEdi
           setEditContent={setEditContent}
           handleEditMessage={handleEditMessage}
           setEditMessageId={setEditMessageId}
+          onCodeClick={onCodeClick}
         />
       </div>
     </div>
   );
 };
 
-const MessageContent = ({msg, editMessageId, editContent, setEditContent, handleEditMessage, setEditMessageId}) => {
+const MessageContent = ({ msg, editMessageId, editContent, setEditContent, handleEditMessage, setEditMessageId, onCodeClick }) => {
 
   // 수정 중인 메시지는 textarea 렌더
-  if(editMessageId === msg.messageId) {
+  if (editMessageId === msg.messageId) {
     return (
       <div style={{ display: 'flex', gap: '8px', flexDirection: 'column' }}>
         <textarea
@@ -283,7 +325,7 @@ const MessageContent = ({msg, editMessageId, editContent, setEditContent, handle
     </div>;
   }
 
-  if(msg.type === 'GIT'){
+  if (msg.type === 'GIT') {
     return (
       <div style={{
         backgroundColor: '#f6f8fa',
@@ -300,7 +342,7 @@ const MessageContent = ({msg, editMessageId, editContent, setEditContent, handle
         }} />
         <div style={{ whiteSpace: 'pre-wrap', lineHeight: '1.5', padding: '10px' }}>
           {msg.content.split('\n').map((line, i) => (
-             <div key={i}>
+            <div key={i}>
               {i === 0 ? (
                 <strong>{line}</strong>
               ) : (
@@ -313,7 +355,8 @@ const MessageContent = ({msg, editMessageId, editContent, setEditContent, handle
     );
   }
 
-  if(msg.type === 'CODE') {
+  if (msg.type === 'CODE') {
+    console.log('🔍 CODE 메시지 렌더링, onCodeClick:', onCodeClick); // 디버깅용
     return (
       <div style={{
         borderRadius: '6px',
@@ -322,7 +365,8 @@ const MessageContent = ({msg, editMessageId, editContent, setEditContent, handle
       }}>
         <HighlightedCode
           content={msg.content}
-          language={msg.language || 'java'} //java가 디폴트 언어
+          language={msg.language || 'java'}
+          onClick={() => onCodeClick && onCodeClick(msg)} // 새로 추가
         />
         {msg.status === "EDITED" && (
           <span style={{
@@ -338,8 +382,8 @@ const MessageContent = ({msg, editMessageId, editContent, setEditContent, handle
     );
   }
 
-  if(msg.type === 'IMAGE'){
-     return (
+  if (msg.type === 'IMAGE') {
+    return (
       <div style={{
         maxWidth: '30%',
         backgroundColor: '#f8fafc',
@@ -387,10 +431,10 @@ const MessageContent = ({msg, editMessageId, editContent, setEditContent, handle
         }}>
           {/* 유저 아이콘 */}
           <FaUserPlus size={12} style={{ flexShrink: 0 }} />
-          
+
           {/* 메인 메시지 */}
           <span>{msg.content}</span>
-          
+
           {/* 입장 시간 표시 (구분선과 함께) */}
           <div style={{
             display: 'flex',
@@ -403,7 +447,7 @@ const MessageContent = ({msg, editMessageId, editContent, setEditContent, handle
             marginLeft: '4px'
           }}>
             <FaClock size={10} />
-            {formatTime(msg.sendAt||msg.joinAt)}
+            {formatTime(msg.sendAt || msg.joinAt)}
           </div>
         </div>
       </div>
@@ -433,27 +477,29 @@ const MessageContent = ({msg, editMessageId, editContent, setEditContent, handle
   )
 }
 
-const MessageList = ({ messages, currentUser, contextMenuId, setContextMenuId, setEditMessageId, setEditContent, editMessageId, editContent, handleEditMessage, handleDeleteMessage }) => {
+const MessageList = ({ messages, currentUser, contextMenuId, setContextMenuId, setEditMessageId, setEditContent,
+  editMessageId, editContent, handleEditMessage, handleDeleteMessage, onCodeClick }) => {
   if (!messages.length) return null;
   const result = [];
   let currentDate = null;
 
   // 메시지를 순회하며 날짜별로 구분
   messages.forEach((msg, index) => {
-    const messageDate = formatDate(msg.sendAt||msg.joinAt);
+    const messageDate = formatDate(msg.sendAt || msg.joinAt);
 
     // 날짜가 바뀌었다면 구분선 추가
     if (messageDate !== currentDate) {
       currentDate = messageDate;
       result.push(
         <div key={`date-${index}`}
-          style={{ display: 'flex',
-              alignItems: 'center',
-              margin: '24px 0',
-              color: '#64748b',
-              fontSize: '14px',
-              fontWeight: '500'
-        }}>
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            margin: '24px 0',
+            color: '#64748b',
+            fontSize: '14px',
+            fontWeight: '500'
+          }}>
           <div style={{
             flex: '1',
             height: '1px',
@@ -472,7 +518,7 @@ const MessageList = ({ messages, currentUser, contextMenuId, setContextMenuId, s
             flex: '1',
             height: '1px',
             backgroundColor: '#e2e8f0'
-          }}/>
+          }} />
         </div>
       );
     }
@@ -480,17 +526,18 @@ const MessageList = ({ messages, currentUser, contextMenuId, setContextMenuId, s
     // 메시지 추가
     result.push(
       <MessageItem
-      key={`msg-${msg.messageId}`} // messageId가 없는 경우를 대비해 index 사용
-      msg={msg}
-      currentUser={currentUser}
-      contextMenuId={contextMenuId}
-      setContextMenuId={setContextMenuId}
-      setEditMessageId={setEditMessageId}
-      setEditContent={setEditContent}
-      handleDeleteMessage={handleDeleteMessage}
-      editMessageId={editMessageId}
-      editContent={editContent}
-      handleEditMessage={handleEditMessage}
+        key={`msg-${msg.messageId}`} // messageId가 없는 경우를 대비해 index 사용
+        msg={msg}
+        currentUser={currentUser}
+        contextMenuId={contextMenuId}
+        setContextMenuId={setContextMenuId}
+        setEditMessageId={setEditMessageId}
+        setEditContent={setEditContent}
+        handleDeleteMessage={handleDeleteMessage}
+        editMessageId={editMessageId}
+        editContent={editContent}
+        handleEditMessage={handleEditMessage}
+        onCodeClick={onCodeClick}
       />
     );
   });

--- a/frontend/src/components/modals/CodeReviewModal.jsx
+++ b/frontend/src/components/modals/CodeReviewModal.jsx
@@ -1,10 +1,20 @@
-import React, { useState } from 'react';
-import Highlight from 'react-highlight';
-import { FaTimes, FaCopy, FaExpand, FaCompress } from 'react-icons/fa';
+import React, { useState, useRef, useEffect } from 'react';
+import { FaTimes, FaCopy, FaExpand, FaCompress, FaPlus, FaCheck, FaTrash } from 'react-icons/fa';
 
 const CodeReviewModal = ({ message, onClose }) => {
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [copySuccess, setCopySuccess] = useState(false);
+  
+  // 댓글 관련 상태
+  const [comments, setComments] = useState({}); // { lineNumber: [comments] }
+  const [activeCommentLine, setActiveCommentLine] = useState(null);
+  const [commentText, setCommentText] = useState('');
+  const [hoveredLine, setHoveredLine] = useState(null);
+
+  const codeRef = useRef(null);
+
+  // 코드를 라인별로 분리
+  const codeLines = message.content.split('\n');
 
   // 코드 복사 기능
   const handleCopyCode = async () => {
@@ -18,20 +28,85 @@ const CodeReviewModal = ({ message, onClose }) => {
   };
 
   // ESC 키로 모달 닫기
-  React.useEffect(() => {
+  useEffect(() => {
     const handleEsc = (e) => {
       if (e.key === 'Escape') {
-        onClose();
+        if (activeCommentLine) {
+          handleCancelComment();
+        } else {
+          onClose();
+        }
       }
     };
     document.addEventListener('keydown', handleEsc);
     return () => document.removeEventListener('keydown', handleEsc);
-  }, [onClose]);
+  }, [onClose, activeCommentLine]);
 
   // 배경 클릭으로 모달 닫기
   const handleBackgroundClick = (e) => {
     if (e.target === e.currentTarget) {
       onClose();
+    }
+  };
+
+  // 댓글 추가 시작
+  const handleAddComment = (lineNumber) => {
+    setActiveCommentLine(lineNumber);
+    setCommentText('');
+  };
+
+  // 댓글 저장
+  const handleSaveComment = async () => {
+    if (!commentText.trim()) return;
+
+    try {
+      // 임시 API 호출 (실제로는 서버로 전송)
+      console.log('댓글 저장 API 호출:', {
+        messageId: message.messageId,
+        lineNumber: activeCommentLine,
+        content: commentText,
+        timestamp: new Date().toISOString()
+      });
+
+      // 로컬 상태에 댓글 추가
+      const newComment = {
+        id: Date.now(), // 임시 ID
+        content: commentText,
+        author: '현재 사용자', // 실제로는 currentUser.name
+        timestamp: new Date().toISOString()
+      };
+
+      setComments(prev => ({
+        ...prev,
+        [activeCommentLine]: [...(prev[activeCommentLine] || []), newComment]
+      }));
+
+      setActiveCommentLine(null);
+      setCommentText('');
+    } catch (error) {
+      console.error('댓글 저장 실패:', error);
+      alert('댓글 저장에 실패했습니다.');
+    }
+  };
+
+  // 댓글 취소
+  const handleCancelComment = () => {
+    setActiveCommentLine(null);
+    setCommentText('');
+  };
+
+  // 댓글 삭제
+  const handleDeleteComment = async (lineNumber, commentId) => {
+    try {
+      // 임시 API 호출
+      console.log('댓글 삭제 API 호출:', { commentId });
+
+      setComments(prev => ({
+        ...prev,
+        [lineNumber]: prev[lineNumber].filter(comment => comment.id !== commentId)
+      }));
+    } catch (error) {
+      console.error('댓글 삭제 실패:', error);
     }
   };
 
@@ -82,7 +157,7 @@ const CodeReviewModal = ({ message, onClose }) => {
               fontWeight: '600',
               color: '#2d3748'
             }}>
-              코드 뷰어
+              코드 리뷰
             </h3>
             <span style={{
               backgroundColor: '#4299e1',
@@ -190,17 +265,226 @@ const CodeReviewModal = ({ message, onClose }) => {
                 height: '100%',
                 overflow: 'auto',
                 fontSize: '14px',
-                lineHeight: '1.6'
+                lineHeight: '1.6',
+                fontFamily: 'Monaco, Menlo, "Ubuntu Mono", monospace'
               }}>
-                <Highlight className={message.language || 'java'}>
-                  {message.content}
-                </Highlight>
+                {/* 라인별 코드 렌더링 */}
+                <div style={{ position: 'relative' }}>
+                  {codeLines.map((line, index) => {
+                    const lineNumber = index + 1;
+                    const hasComments = comments[lineNumber] && comments[lineNumber].length > 0;
+                    
+                    return (
+                      <div key={lineNumber}>
+                        {/* 코드 라인 */}
+                        <div
+                          style={{
+                            display: 'flex',
+                            alignItems: 'flex-start',
+                            minHeight: '20px',
+                            backgroundColor: hoveredLine === lineNumber ? '#f7fafc' : 'transparent',
+                            borderLeft: hasComments ? '3px solid #4299e1' : '3px solid transparent',
+                            transition: 'all 0.1s ease'
+                          }}
+                          onMouseEnter={() => setHoveredLine(lineNumber)}
+                          onMouseLeave={() => setHoveredLine(null)}
+                        >
+                          {/* 라인 번호 */}
+                          <div style={{
+                            width: '50px',
+                            padding: '0 8px',
+                            color: '#a0aec0',
+                            fontSize: '12px',
+                            textAlign: 'right',
+                            userSelect: 'none',
+                            flexShrink: 0,
+                            lineHeight: '20px'
+                          }}>
+                            {lineNumber}
+                          </div>
+
+                          {/* + 버튼 영역 */}
+                          <div style={{
+                            width: '30px',
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                            flexShrink: 0
+                          }}>
+                            {(hoveredLine === lineNumber || hasComments) && (
+                              <button
+                                onClick={() => handleAddComment(lineNumber)}
+                                style={{
+                                  width: '20px',
+                                  height: '20px',
+                                  borderRadius: '50%',
+                                  border: 'none',
+                                  backgroundColor: hasComments ? '#4299e1' : '#e2e8f0',
+                                  color: hasComments ? 'white' : '#4a5568',
+                                  cursor: 'pointer',
+                                  display: 'flex',
+                                  alignItems: 'center',
+                                  justifyContent: 'center',
+                                  fontSize: '12px',
+                                  transition: 'all 0.2s ease'
+                                }}
+                              >
+                                <FaPlus size={8} />
+                              </button>
+                            )}
+                          </div>
+
+                          {/* 코드 내용 */}
+                          <div style={{
+                            flex: 1,
+                            padding: '0 12px 0 0',
+                            whiteSpace: 'pre',
+                            lineHeight: '20px'
+                          }}>
+                            <code>{line}</code>
+                          </div>
+                        </div>
+
+                        {/* 댓글 입력창 */}
+                        {activeCommentLine === lineNumber && (
+                          <div style={{
+                            marginLeft: '80px',
+                            marginRight: '12px',
+                            marginBottom: '12px',
+                            padding: '12px',
+                            backgroundColor: '#f8fafc',
+                            border: '1px solid #e2e8f0',
+                            borderRadius: '6px'
+                          }}>
+                            <textarea
+                              value={commentText}
+                              onChange={(e) => setCommentText(e.target.value)}
+                              placeholder="이 라인에 대한 리뷰를 작성하세요..."
+                              style={{
+                                width: '100%',
+                                minHeight: '80px',
+                                border: '1px solid #e2e8f0',
+                                borderRadius: '4px',
+                                padding: '8px',
+                                fontSize: '14px',
+                                resize: 'vertical',
+                                fontFamily: 'inherit'
+                              }}
+                              autoFocus
+                            />
+                            <div style={{
+                              display: 'flex',
+                              justifyContent: 'flex-end',
+                              gap: '8px',
+                              marginTop: '8px'
+                            }}>
+                              <button
+                                onClick={handleCancelComment}
+                                style={{
+                                  padding: '6px 12px',
+                                  backgroundColor: '#e2e8f0',
+                                  color: '#4a5568',
+                                  border: 'none',
+                                  borderRadius: '4px',
+                                  fontSize: '14px',
+                                  cursor: 'pointer'
+                                }}
+                              >
+                                취소
+                              </button>
+                              <button
+                                onClick={handleSaveComment}
+                                disabled={!commentText.trim()}
+                                style={{
+                                  display: 'flex',
+                                  alignItems: 'center',
+                                  gap: '6px',
+                                  padding: '6px 12px',
+                                  backgroundColor: commentText.trim() ? '#4299e1' : '#e2e8f0',
+                                  color: commentText.trim() ? 'white' : '#a0aec0',
+                                  border: 'none',
+                                  borderRadius: '4px',
+                                  fontSize: '14px',
+                                  cursor: commentText.trim() ? 'pointer' : 'not-allowed'
+                                }}
+                              >
+                                <FaCheck size={12} />
+                                댓글 저장
+                              </button>
+                            </div>
+                          </div>
+                        )}
+
+                        {/* 기존 댓글들 */}
+                        {comments[lineNumber] && comments[lineNumber].map((comment) => (
+                          <div
+                            key={comment.id}
+                            style={{
+                              marginLeft: '80px',
+                              marginRight: '12px',
+                              marginBottom: '8px',
+                              padding: '10px',
+                              backgroundColor: '#ffffff',
+                              border: '1px solid #e2e8f0',
+                              borderRadius: '6px',
+                              boxShadow: '0 1px 3px rgba(0,0,0,0.1)'
+                            }}
+                          >
+                            <div style={{
+                              display: 'flex',
+                              justifyContent: 'space-between',
+                              alignItems: 'center',
+                              marginBottom: '6px'
+                            }}>
+                              <div style={{
+                                fontSize: '12px',
+                                color: '#4a5568',
+                                fontWeight: '500'
+                              }}>
+                                {comment.author}
+                              </div>
+                              <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                                <span style={{
+                                  fontSize: '11px',
+                                  color: '#a0aec0'
+                                }}>
+                                  {new Date(comment.timestamp).toLocaleString('ko-KR')}
+                                </span>
+                                <button
+                                  onClick={() => handleDeleteComment(lineNumber, comment.id)}
+                                  style={{
+                                    padding: '2px',
+                                    backgroundColor: 'transparent',
+                                    border: 'none',
+                                    color: '#e53e3e',
+                                    cursor: 'pointer',
+                                    fontSize: '12px'
+                                  }}
+                                >
+                                  <FaTrash size={10} />
+                                </button>
+                              </div>
+                            </div>
+                            <div style={{
+                              fontSize: '14px',
+                              color: '#2d3748',
+                              lineHeight: '1.4',
+                              whiteSpace: 'pre-wrap'
+                            }}>
+                              {comment.content}
+                            </div>
+                          </div>
+                        ))}
+                      </div>
+                    );
+                  })}
+                </div>
               </div>
             </div>
           </div>
         </div>
 
-        {/* 푸터 (향후 API 호출 버튼들 추가 예정) */}
+        {/* 푸터 */}
         <div style={{
           padding: '16px 20px',
           backgroundColor: '#f8fafc',
@@ -213,11 +497,14 @@ const CodeReviewModal = ({ message, onClose }) => {
             fontSize: '13px',
             color: '#718096'
           }}>
-            💡 향후 AI 코드 리뷰 기능이 추가될 예정입니다
+            💬 라인별로 댓글을 달아 코드 리뷰를 진행하세요
           </div>
           
-          <div style={{ display: 'flex', gap: '8px' }}>
-            {/* 향후 AI 리뷰 버튼들이 여기에 추가될 예정 */}
+          <div style={{
+            fontSize: '12px',
+            color: '#a0aec0'
+          }}>
+            총 {Object.values(comments).flat().length}개의 댓글
           </div>
         </div>
       </div>

--- a/frontend/src/components/modals/CodeReviewModal.jsx
+++ b/frontend/src/components/modals/CodeReviewModal.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { FaTimes, FaCopy, FaExpand, FaCompress, FaPlus, FaCheck, FaTrash } from 'react-icons/fa';
+import axiosInstance from '../api/axiosInstance'; 
 
 const CodeReviewModal = ({ message, onClose }) => {
   const [isFullscreen, setIsFullscreen] = useState(false);
@@ -10,8 +11,41 @@ const CodeReviewModal = ({ message, onClose }) => {
   const [activeCommentLine, setActiveCommentLine] = useState(null);
   const [commentText, setCommentText] = useState('');
   const [hoveredLine, setHoveredLine] = useState(null);
+  const [loading, setLoading] = useState(false); // 이것도 추가
 
   const codeRef = useRef(null);
+
+  const codeReviewAPI = {
+  // 리뷰 생성
+  create: async (reviewData) => {
+    try {
+      const response = await axiosInstance.post('/code-reviews', reviewData);
+      return response.data;
+    } catch (error) {
+      throw new Error(error.response?.data?.message || '리뷰 생성 실패');
+    }
+  },
+
+  // 메시지별 리뷰 조회
+  getByMessageId: async (messageId) => {
+    try {
+      const response = await axiosInstance.get(`/code-reviews/message/${messageId}`);
+      return response.data;
+    } catch (error) {
+      throw new Error(error.response?.data?.message || '리뷰 조회 실패');
+    }
+  },
+
+  // 리뷰 삭제
+  delete: async (reviewId) => {
+    try {
+      await axiosInstance.delete(`/code-reviews/${reviewId}`);
+    } catch (error) {
+      throw new Error(error.response?.data?.message || '리뷰 삭제 실패');
+    }
+  }
+};
+ 
 
   // 코드를 라인별로 분리
   const codeLines = message.content.split('\n');
@@ -49,7 +83,7 @@ const CodeReviewModal = ({ message, onClose }) => {
     }
   };
 
-  // 댓글 추가 시작
+  // 
   const handleAddComment = (lineNumber) => {
     setActiveCommentLine(lineNumber);
     setCommentText('');
@@ -57,37 +91,41 @@ const CodeReviewModal = ({ message, onClose }) => {
 
   // 댓글 저장
   const handleSaveComment = async () => {
-    if (!commentText.trim()) return;
+  if (!commentText.trim()) return;
 
-    try {
-      // 임시 API 호출 (실제로는 서버로 전송)
-      console.log('댓글 저장 API 호출:', {
-        messageId: message.messageId,
-        lineNumber: activeCommentLine,
-        content: commentText,
-        timestamp: new Date().toISOString()
-      });
+  try {
+    setLoading(true);
 
-      // 로컬 상태에 댓글 추가
-      const newComment = {
-        id: Date.now(), // 임시 ID
-        content: commentText,
-        author: '현재 사용자', // 실제로는 currentUser.name
-        timestamp: new Date().toISOString()
-      };
+    const reviewData = {
+      messageId: message.messageId,
+      lineNumber: activeCommentLine,
+      content: commentText.trim()
+    };
 
-      setComments(prev => ({
-        ...prev,
-        [activeCommentLine]: [...(prev[activeCommentLine] || []), newComment]
-      }));
+    const createdReview = await codeReviewAPI.create(reviewData);
 
-      setActiveCommentLine(null);
-      setCommentText('');
-    } catch (error) {
-      console.error('댓글 저장 실패:', error);
-      alert('댓글 저장에 실패했습니다.');
-    }
-  };
+    const newComment = {
+      id: createdReview.reviewId,
+      content: createdReview.content,
+      author: createdReview.authorName,
+      timestamp: createdReview.createAt
+    };
+
+    setComments(prev => ({
+      ...prev,
+      [activeCommentLine]: [...(prev[activeCommentLine] || []), newComment]
+    }));
+
+    setActiveCommentLine(null);
+    setCommentText('');
+
+  } catch (error) {
+    console.error('댓글 저장 실패:', error);
+    alert(error.message);
+  } finally {
+    setLoading(false);
+  }
+};
 
   // 댓글 취소
   const handleCancelComment = () => {
@@ -359,7 +397,6 @@ const CodeReviewModal = ({ message, onClose }) => {
                             <textarea
                               value={commentText}
                               onChange={(e) => setCommentText(e.target.value)}
-                              placeholder="이 라인에 대한 리뷰를 작성하세요..."
                               style={{
                                 width: '100%',
                                 minHeight: '80px',

--- a/frontend/src/components/modals/CodeReviewModal.jsx
+++ b/frontend/src/components/modals/CodeReviewModal.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import { FaTimes, FaCopy, FaExpand, FaCompress, FaPlus, FaCheck, FaTrash } from 'react-icons/fa';
 import axiosInstance from '../api/axiosInstance';
 import Highlight from 'react-highlight';
@@ -8,13 +8,13 @@ const CodeReviewModal = ({ message, onClose }) => {
   const [copySuccess, setCopySuccess] = useState(false);
 
   // 댓글 관련 상태
-  const [comments, setComments] = useState({}); // { lineNumber: [comments] }
-  const [activeCommentLine, setActiveCommentLine] = useState(null);
-  const [commentText, setCommentText] = useState('');
+  const [reviews, setReviews] = useState({}); // { lineNumber: [reviews] }
+  const [activeReviewLine, setActiveReviewLine] = useState(null);
+  const [reviewText, setReviewText] = useState('');
   const [hoveredLine, setHoveredLine] = useState(null);
   const [loading, setLoading] = useState(false); // 이것도 추가
-  const [editingCommentId, setEditingCommentId] = useState(null);
-  const [editCommentText, setEditCommentText] = useState('');
+  const [editingReviewId, setEditingReviewsId] = useState(null);
+  const [editReviewText, setEditReviewsText] = useState('');
   const [currentUser, setCurrentUser] = useState(null);
 
   const HighlightedCode = ({ content, language }) => {
@@ -49,74 +49,12 @@ const CodeReviewModal = ({ message, onClose }) => {
   };
 
   // 수정 가능 여부 체크 함수
-  const canEdit = (comment) => {
+  const canEdit = (review) => {
     console.log('현재 사용자 ID:', currentUser);
-    console.log('댓글 작성자 ID:', comment.authorId);
-    console.log('수정 가능 여부:', currentUser && comment.authorId === currentUser);
-    return currentUser && comment.authorId === currentUser;
+    console.log('댓글 작성자 ID:', review.authorId);
+    console.log('수정 가능 여부:', currentUser && review.authorId === currentUser);
+    return currentUser && review.authorId === currentUser;
   };
-
-  // 현재 사용자 정보 로드
-  useEffect(() => {
-    fetchCurrentUser();
-  }, []);
-
-  useEffect(() => {
-    const loadExistingReviews = async () => {
-      try {
-        setLoading(true);
-
-        if (!message.messageId) {
-          return;
-        }
-        const reviews = await codeReviewAPI.getByMessageId(message.messageId);
-
-        // 서버에서 받은 리뷰 데이터를 라인별로 정리
-        const reviewsByLine = {};
-
-        if (reviews && Array.isArray(reviews)) {
-          reviews.forEach(review => {
-            const lineNumber = review.lineNumber;
-
-            if (!reviewsByLine[lineNumber]) {
-              reviewsByLine[lineNumber] = [];
-            }
-
-            reviewsByLine[lineNumber].push({
-              id: review.reviewId,
-              content: review.content,
-              author: review.authorName,
-              authorId: review.authorId, // 작성자 ID 추가
-              timestamp: review.createAt
-            });
-          });
-        }
-
-        setComments(reviewsByLine);
-
-      } catch (error) {
-        if (error.status === 404) {
-          setComments({});
-          return;
-        }
-
-        let errorMessage = '기존 댓글을 불러오는데 실패했습니다.';
-        if (error.status === 401) {
-          errorMessage = '로그인이 필요합니다.';
-        } else if (error.status === 403) {
-          errorMessage = '댓글 조회 권한이 없습니다.';
-        }
-
-        alert(errorMessage);
-
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    loadExistingReviews();
-  }, [message.messageId]);
-
 
   const codeReviewAPI = {
     // 리뷰 생성
@@ -182,6 +120,67 @@ const CodeReviewModal = ({ message, onClose }) => {
     }
   };
 
+  // 현재 사용자 정보 로드
+  useEffect(() => {
+    fetchCurrentUser();
+  }, []);
+
+  useEffect(() => {
+    const loadExistingReviews = async () => {
+      try {
+        setLoading(true);
+
+        if (!message.messageId) {
+          return;
+        }
+        const reviews = await codeReviewAPI.getByMessageId(message.messageId);
+
+        // 서버에서 받은 리뷰 데이터를 라인별로 정리
+        const reviewsByLine = {};
+
+        if (reviews && Array.isArray(reviews)) {
+          reviews.forEach(review => {
+            const lineNumber = review.lineNumber;
+
+            if (!reviewsByLine[lineNumber]) {
+              reviewsByLine[lineNumber] = [];
+            }
+
+            reviewsByLine[lineNumber].push({
+              id: review.reviewId,
+              content: review.content,
+              author: review.authorName,
+              authorId: review.authorId, // 작성자 ID 추가
+              timestamp: review.createAt
+            });
+          });
+        }
+
+        setReviews(reviewsByLine);
+
+      } catch (error) {
+        if (error.status === 404) {
+          setReviews({});
+          return;
+        }
+
+        let errorMessage = '기존 댓글을 불러오는데 실패했습니다.';
+        if (error.status === 401) {
+          errorMessage = '로그인이 필요합니다.';
+        } else if (error.status === 403) {
+          errorMessage = '댓글 조회 권한이 없습니다.';
+        }
+
+        alert(errorMessage);
+
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadExistingReviews();
+  }, [message.messageId]);
+
 
   // 코드를 라인별로 분리
   const codeLines = message.content.split('\n');
@@ -201,10 +200,10 @@ const CodeReviewModal = ({ message, onClose }) => {
   useEffect(() => {
     const handleEsc = (e) => {
       if (e.key === 'Escape') {
-        if (editingCommentId) {
+        if (editingReviewId) {
           handleCancelEdit();
-        } else if (activeCommentLine) {
-          handleCancelComment();
+        } else if (activeReviewLine) {
+          handleCancelReview();
         } else {
           onClose();
         }
@@ -212,7 +211,7 @@ const CodeReviewModal = ({ message, onClose }) => {
     };
     document.addEventListener('keydown', handleEsc);
     return () => document.removeEventListener('keydown', handleEsc);
-  }, [onClose, activeCommentLine, editingCommentId]);
+  }, [onClose, activeReviewLine, editingReviewId]);
 
   // 배경 클릭으로 모달 닫기
   const handleBackgroundClick = (e) => {
@@ -222,27 +221,27 @@ const CodeReviewModal = ({ message, onClose }) => {
   };
 
   // 댓글 추가
-  const handleAddComment = (lineNumber) => {
-    setActiveCommentLine(lineNumber);
-    setCommentText('');
+  const handleAddReview = (lineNumber) => {
+    setActiveReviewLine(lineNumber);
+    setReviewText('');
   };
 
   // 댓글 저장
-  const handleSaveComment = async () => {
-    if (!commentText.trim()) return;
+  const handleSaveReview = async () => {
+    if (!reviewText.trim()) return;
 
     try {
       setLoading(true);
 
       const reviewData = {
         messageId: message.messageId,
-        lineNumber: activeCommentLine,
-        content: commentText.trim()
+        lineNumber: activeReviewLine,
+        content: reviewText.trim()
       };
 
       const createdReview = await codeReviewAPI.create(reviewData);
 
-      const newComment = {
+      const newReview = {
         id: createdReview.reviewId,
         content: createdReview.content,
         author: createdReview.authorName,
@@ -250,13 +249,13 @@ const CodeReviewModal = ({ message, onClose }) => {
         timestamp: createdReview.createAt
       };
 
-      setComments(prev => ({
+      setReviews(prev => ({
         ...prev,
-        [activeCommentLine]: [...(prev[activeCommentLine] || []), newComment]
+        [activeReviewLine]: [...(prev[activeReviewLine] || []), newReview]
       }));
 
-      setActiveCommentLine(null);
-      setCommentText('');
+      setActiveReviewLine(null);
+      setReviewText('');
 
     } catch (error) {
       console.error('댓글 저장 실패:', error);
@@ -267,21 +266,21 @@ const CodeReviewModal = ({ message, onClose }) => {
   };
 
   // 댓글 취소(취소버튼 누르는 것)
-  const handleCancelComment = () => {
-    setActiveCommentLine(null);
-    setCommentText('');
+  const handleCancelReview = () => {
+    setActiveReviewLine(null);
+    setReviewText('');
   };
 
   // 댓글 삭제
-  const handleDeleteComment = async (lineNumber, commentId) => {
+  const handleDeleteReview = async (lineNumber, reviewId) => {
     try {
       // 실제 API 호출
-      await codeReviewAPI.delete(commentId);
+      await codeReviewAPI.delete(reviewId);
 
       // 성공 시 UI에서 제거
-      setComments(prev => ({
+      setReviews(prev => ({
         ...prev,
-        [lineNumber]: prev[lineNumber].filter(comment => comment.id !== commentId)
+        [lineNumber]: prev[lineNumber].filter(review => review.id !== reviewId)
       }));
 
     } catch (error) {
@@ -291,32 +290,32 @@ const CodeReviewModal = ({ message, onClose }) => {
   };
 
   // 댓글 수정 시작
-  const handleEditComment = (comment) => {
-    setEditingCommentId(comment.id);
-    setEditCommentText(comment.content);
+  const handleEditReview = (review) => {
+    setEditingReviewsId(review.id);
+    setEditReviewsText(review.content);
   };
 
   // 댓글 수정 저장
-  const handleSaveEdit = async (lineNumber, commentId) => {
-    if (!editCommentText.trim()) return;
+  const handleSaveEdit = async (lineNumber, reviewId) => {
+    if (!editReviewText.trim()) return;
 
     try {
       setLoading(true);
 
-      const updatedReview = await codeReviewAPI.update(commentId, editCommentText.trim());
+      const updatedReview = await codeReviewAPI.update(reviewId, editReviewText.trim());
 
       // UI 업데이트
-      setComments(prev => ({
+      setReviews(prev => ({
         ...prev,
-        [lineNumber]: prev[lineNumber].map(comment =>
-          comment.id === commentId
-            ? { ...comment, content: updatedReview.content || editCommentText.trim() }
-            : comment
+        [lineNumber]: prev[lineNumber].map(review =>
+          review.id === reviewId
+            ? { ...review, content: updatedReview.content || editReviewText.trim() }
+            : review
         )
       }));
 
-      setEditingCommentId(null);
-      setEditCommentText('');
+      setEditingReviewsId(null);
+      setEditReviewsText('');
 
     } catch (error) {
       console.error('댓글 수정 실패:', error);
@@ -328,8 +327,8 @@ const CodeReviewModal = ({ message, onClose }) => {
 
   // 댓글 수정 취소
   const handleCancelEdit = () => {
-    setEditingCommentId(null);
-    setEditCommentText('');
+    setEditingReviewsId(null);
+    setEditReviewsText('');
   };
 
   return (
@@ -494,7 +493,7 @@ const CodeReviewModal = ({ message, onClose }) => {
                 <div style={{ position: 'relative' }}>
                   {codeLines.map((line, index) => {
                     const lineNumber = index + 1;
-                    const hasComments = comments[lineNumber] && comments[lineNumber].length > 0;
+                    const hasReviews = reviews[lineNumber] && reviews[lineNumber].length > 0;
 
                     return (
                       <div key={lineNumber}>
@@ -505,7 +504,7 @@ const CodeReviewModal = ({ message, onClose }) => {
                             alignItems: 'flex-start',
                             minHeight: '20px',
                             backgroundColor: hoveredLine === lineNumber ? '#f7fafc' : 'transparent',
-                            borderLeft: hasComments ? '3px solid #4299e1' : '3px solid transparent',
+                            borderLeft: hasReviews ? '3px solid #4299e1' : '3px solid transparent',
                             transition: 'all 0.1s ease'
                           }}
                           onMouseEnter={() => setHoveredLine(lineNumber)}
@@ -533,16 +532,16 @@ const CodeReviewModal = ({ message, onClose }) => {
                             justifyContent: 'center',
                             flexShrink: 0
                           }}>
-                            {(hoveredLine === lineNumber || hasComments) && (
+                            {(hoveredLine === lineNumber || hasReviews) && (
                               <button
-                                onClick={() => handleAddComment(lineNumber)}
+                                onClick={() => handleAddReview(lineNumber)}
                                 style={{
                                   width: '20px',
                                   height: '20px',
                                   borderRadius: '50%',
                                   border: 'none',
-                                  backgroundColor: hasComments ? '#4299e1' : '#e2e8f0',
-                                  color: hasComments ? 'white' : '#4a5568',
+                                  backgroundColor: hasReviews ? '#4299e1' : '#e2e8f0',
+                                  color: hasReviews ? 'white' : '#4a5568',
                                   cursor: 'pointer',
                                   display: 'flex',
                                   alignItems: 'center',
@@ -571,7 +570,7 @@ const CodeReviewModal = ({ message, onClose }) => {
                         </div>
 
                         {/* 댓글 입력창 */}
-                        {activeCommentLine === lineNumber && (
+                        {activeReviewLine === lineNumber && (
                           <div style={{
                             marginLeft: '80px',
                             marginRight: '12px',
@@ -582,9 +581,9 @@ const CodeReviewModal = ({ message, onClose }) => {
                             borderRadius: '6px'
                           }}>
                             <textarea
-                              value={commentText}
-                              onChange={(e) => setCommentText(e.target.value)}
-                              placeholder='Leave a comment...'
+                              value={reviewText}
+                              onChange={(e) => setReviewText(e.target.value)}
+                              placeholder='Leave a review...'
                               style={{
                                 width: '100%',
                                 minHeight: '80px',
@@ -604,7 +603,7 @@ const CodeReviewModal = ({ message, onClose }) => {
                               marginTop: '8px'
                             }}>
                               <button
-                                onClick={handleCancelComment}
+                                onClick={handleCancelReview}
                                 style={{
                                   padding: '6px 12px',
                                   backgroundColor: '#e2e8f0',
@@ -618,19 +617,19 @@ const CodeReviewModal = ({ message, onClose }) => {
                                 취소
                               </button>
                               <button
-                                onClick={handleSaveComment}
-                                disabled={!commentText.trim()}
+                                onClick={handleSaveReview}
+                                disabled={!reviewText.trim()}
                                 style={{
                                   display: 'flex',
                                   alignItems: 'center',
                                   gap: '6px',
                                   padding: '6px 12px',
-                                  backgroundColor: commentText.trim() ? '#4299e1' : '#e2e8f0',
-                                  color: commentText.trim() ? 'white' : '#a0aec0',
+                                  backgroundColor: reviewText.trim() ? '#4299e1' : '#e2e8f0',
+                                  color: reviewText.trim() ? 'white' : '#a0aec0',
                                   border: 'none',
                                   borderRadius: '4px',
                                   fontSize: '14px',
-                                  cursor: commentText.trim() ? 'pointer' : 'not-allowed'
+                                  cursor: reviewText.trim() ? 'pointer' : 'not-allowed'
                                 }}
                               >
                                 <FaCheck size={12} />
@@ -641,9 +640,9 @@ const CodeReviewModal = ({ message, onClose }) => {
                         )}
 
                         {/* 기존 댓글들 */}
-                        {comments[lineNumber] && comments[lineNumber].map((comment) => (
+                        {reviews[lineNumber] && reviews[lineNumber].map((review) => (
                           <div
-                            key={comment.id}
+                            key={review.id}
                             style={{
                               marginLeft: '80px',
                               marginRight: '12px',
@@ -653,22 +652,22 @@ const CodeReviewModal = ({ message, onClose }) => {
                               border: '1px solid #e2e8f0',
                               borderRadius: '6px',
                               boxShadow: '0 1px 3px rgba(0,0,0,0.1)',
-                              cursor: canEdit(comment) && editingCommentId !== comment.id ? 'pointer' : 'default',
+                              cursor: canEdit(review) && editingReviewId !== review.id ? 'pointer' : 'default',
                               transition: 'all 0.2s ease'
                             }}
                             onClick={() => {
-                              if (canEdit(comment) && editingCommentId !== comment.id) {
-                                handleEditComment(comment);
+                              if (canEdit(review) && editingReviewId !== review.id) {
+                                handleEditReview(review);
                               }
                             }}
                             onMouseEnter={(e) => {
-                              if (canEdit(comment) && editingCommentId !== comment.id) {
+                              if (canEdit(review) && editingReviewId !== review.id) {
                                 e.currentTarget.style.backgroundColor = '#f8fafc';
                                 e.currentTarget.style.borderColor = '#4299e1';
                               }
                             }}
                             onMouseLeave={(e) => {
-                              if (canEdit(comment) && editingCommentId !== comment.id) {
+                              if (canEdit(review) && editingReviewId !== review.id) {
                                 e.currentTarget.style.backgroundColor = '#ffffff';
                                 e.currentTarget.style.borderColor = '#e2e8f0';
                               }
@@ -690,9 +689,9 @@ const CodeReviewModal = ({ message, onClose }) => {
                                   color: '#4a5568',
                                   fontWeight: '500'
                                 }}>
-                                  {comment.author}
+                                  {review.author}
                                 </span>
-                                {canEdit(comment) && editingCommentId !== comment.id && (
+                                {canEdit(review) && editingReviewId !== review.id && (
                                   <span style={{
                                     fontSize: '10px',
                                     color: '#4299e1',
@@ -708,13 +707,13 @@ const CodeReviewModal = ({ message, onClose }) => {
                                   fontSize: '11px',
                                   color: '#a0aec0'
                                 }}>
-                                  {new Date(comment.timestamp).toLocaleString('ko-KR')}
+                                  {new Date(review.timestamp).toLocaleString('ko-KR')}
                                 </span>
-                                {canEdit(comment) && (
+                                {canEdit(review) && (
                                   <button
                                     onClick={(e) => {
                                       e.stopPropagation();
-                                      handleDeleteComment(lineNumber, comment.id);
+                                      handleDeleteReview(lineNumber, review.id);
                                     }}
                                     style={{
                                       padding: '2px',
@@ -732,11 +731,11 @@ const CodeReviewModal = ({ message, onClose }) => {
                             </div>
 
                             {/* 댓글 내용 또는 수정 입력창 */}
-                            {editingCommentId === comment.id ? (
+                            {editingReviewId === review.id ? (
                               <div>
                                 <textarea
-                                  value={editCommentText}
-                                  onChange={(e) => setEditCommentText(e.target.value)}
+                                  value={editReviewText}
+                                  onChange={(e) => setEditReviewsText(e.target.value)}
                                   style={{
                                     width: '100%',
                                     minHeight: '60px',
@@ -770,19 +769,19 @@ const CodeReviewModal = ({ message, onClose }) => {
                                     취소
                                   </button>
                                   <button
-                                    onClick={() => handleSaveEdit(lineNumber, comment.id)}
-                                    disabled={!editCommentText.trim() || loading}
+                                    onClick={() => handleSaveEdit(lineNumber, review.id)}
+                                    disabled={!editReviewText.trim() || loading}
                                     style={{
                                       display: 'flex',
                                       alignItems: 'center',
                                       gap: '4px',
                                       padding: '4px 8px',
-                                      backgroundColor: editCommentText.trim() ? '#4299e1' : '#e2e8f0',
-                                      color: editCommentText.trim() ? 'white' : '#a0aec0',
+                                      backgroundColor: editReviewText.trim() ? '#4299e1' : '#e2e8f0',
+                                      color: editReviewText.trim() ? 'white' : '#a0aec0',
                                       border: 'none',
                                       borderRadius: '4px',
                                       fontSize: '12px',
-                                      cursor: editCommentText.trim() ? 'pointer' : 'not-allowed'
+                                      cursor: editReviewText.trim() ? 'pointer' : 'not-allowed'
                                     }}
                                   >
                                     <FaCheck size={10} />
@@ -797,7 +796,7 @@ const CodeReviewModal = ({ message, onClose }) => {
                                 lineHeight: '1.4',
                                 whiteSpace: 'pre-wrap'
                               }}>
-                                {comment.content}
+                                {review.content}
                               </div>
                             )}
                           </div>
@@ -831,7 +830,7 @@ const CodeReviewModal = ({ message, onClose }) => {
             fontSize: '12px',
             color: '#a0aec0'
           }}>
-            총 {Object.values(comments).flat().length}개의 댓글
+            총 {Object.values(reviews).flat().length}개의 댓글
           </div>
         </div>
       </div>

--- a/frontend/src/components/modals/CodeReviewModal.jsx
+++ b/frontend/src/components/modals/CodeReviewModal.jsx
@@ -50,6 +50,9 @@ const CodeReviewModal = ({ message, onClose }) => {
 
   // 수정 가능 여부 체크 함수
   const canEdit = (comment) => {
+    console.log('현재 사용자 ID:', currentUser);
+    console.log('댓글 작성자 ID:', comment.authorId);
+    console.log('수정 가능 여부:', currentUser && comment.authorId === currentUser);
     return currentUser && comment.authorId === currentUser;
   };
 
@@ -92,15 +95,15 @@ const CodeReviewModal = ({ message, onClose }) => {
         setComments(reviewsByLine);
 
       } catch (error) {
-        if (error.message.includes('404')) {
+        if (error.status === 404) {
           setComments({});
           return;
         }
 
         let errorMessage = '기존 댓글을 불러오는데 실패했습니다.';
-        if (error.message.includes('401')) {
+        if (error.status === 401) {
           errorMessage = '로그인이 필요합니다.';
-        } else if (error.message.includes('403')) {
+        } else if (error.status === 403) {
           errorMessage = '댓글 조회 권한이 없습니다.';
         }
 
@@ -122,7 +125,12 @@ const CodeReviewModal = ({ message, onClose }) => {
         const response = await axiosInstance.post('/code-reviews', reviewData);
         return response.data;
       } catch (error) {
-        throw new Error(error.response?.data?.message || '리뷰 생성 실패');
+        // 상태코드와 메시지를 함께 전달
+        const status = error.response?.status;
+        const message = error.response?.data?.message || '리뷰 생성 실패';
+        const customError = new Error(message);
+        customError.status = status;
+        throw customError;
       }
     },
 
@@ -130,16 +138,17 @@ const CodeReviewModal = ({ message, onClose }) => {
     getByMessageId: async (messageId) => {
       try {
         const response = await axiosInstance.get(`/code-reviews/${messageId}`);
-
-        // 응답 데이터 구조에 따라 수정 필요
         return response.data.reviews || response.data;
-
       } catch (error) {
         if (error.response?.status === 404) {
           return [];
         }
-
-        throw new Error(error.response?.data?.message || '리뷰 조회 실패');
+        
+        const status = error.response?.status;
+        const message = error.response?.data?.message || '리뷰 조회 실패';
+        const customError = new Error(message);
+        customError.status = status;
+        throw customError;
       }
     },
 
@@ -148,7 +157,11 @@ const CodeReviewModal = ({ message, onClose }) => {
       try {
         await axiosInstance.delete(`/code-reviews/${reviewId}`);
       } catch (error) {
-        throw new Error(error.response?.data?.message || '리뷰 삭제 실패');
+        const status = error.response?.status;
+        const message = error.response?.data?.message || '리뷰 삭제 실패';
+        const customError = new Error(message);
+        customError.status = status;
+        throw customError;
       }
     },
 
@@ -160,7 +173,11 @@ const CodeReviewModal = ({ message, onClose }) => {
         });
         return response.data;
       } catch (error) {
-        throw new Error(error.response?.data?.message || '리뷰 수정 실패');
+        const status = error.response?.status;
+        const message = error.response?.data?.message || '리뷰 수정 실패';
+        const customError = new Error(message);
+        customError.status = status;
+        throw customError;
       }
     }
   };

--- a/frontend/src/components/modals/CodeReviewModal.jsx
+++ b/frontend/src/components/modals/CodeReviewModal.jsx
@@ -1,0 +1,228 @@
+import React, { useState } from 'react';
+import Highlight from 'react-highlight';
+import { FaTimes, FaCopy, FaExpand, FaCompress } from 'react-icons/fa';
+
+const CodeReviewModal = ({ message, onClose }) => {
+  const [isFullscreen, setIsFullscreen] = useState(false);
+  const [copySuccess, setCopySuccess] = useState(false);
+
+  // 코드 복사 기능
+  const handleCopyCode = async () => {
+    try {
+      await navigator.clipboard.writeText(message.content);
+      setCopySuccess(true);
+      setTimeout(() => setCopySuccess(false), 2000);
+    } catch (err) {
+      console.error('복사 실패:', err);
+    }
+  };
+
+  // ESC 키로 모달 닫기
+  React.useEffect(() => {
+    const handleEsc = (e) => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    };
+    document.addEventListener('keydown', handleEsc);
+    return () => document.removeEventListener('keydown', handleEsc);
+  }, [onClose]);
+
+  // 배경 클릭으로 모달 닫기
+  const handleBackgroundClick = (e) => {
+    if (e.target === e.currentTarget) {
+      onClose();
+    }
+  };
+
+  return (
+    <div 
+      style={{
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        backgroundColor: 'rgba(0, 0, 0, 0.7)',
+        zIndex: 9999,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: isFullscreen ? '0' : '20px'
+      }}
+      onClick={handleBackgroundClick}
+    >
+      <div 
+        style={{
+          backgroundColor: '#ffffff',
+          borderRadius: isFullscreen ? '0' : '12px',
+          width: isFullscreen ? '100vw' : '90%',
+          height: isFullscreen ? '100vh' : '85vh',
+          maxWidth: isFullscreen ? 'none' : '1200px',
+          display: 'flex',
+          flexDirection: 'column',
+          boxShadow: isFullscreen ? 'none' : '0 20px 60px rgba(0, 0, 0, 0.3)',
+          overflow: 'hidden'
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* 헤더 */}
+        <div style={{
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          padding: '16px 20px',
+          borderBottom: '1px solid #e2e8f0',
+          backgroundColor: '#f8fafc'
+        }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
+            <h3 style={{
+              margin: 0,
+              fontSize: '18px',
+              fontWeight: '600',
+              color: '#2d3748'
+            }}>
+              코드 뷰어
+            </h3>
+            <span style={{
+              backgroundColor: '#4299e1',
+              color: 'white',
+              padding: '2px 8px',
+              borderRadius: '12px',
+              fontSize: '12px',
+              fontWeight: '500'
+            }}>
+              {message.language || 'java'}
+            </span>
+          </div>
+          
+          <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+            {/* 복사 버튼 */}
+            <button
+              onClick={handleCopyCode}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: '6px',
+                padding: '8px 12px',
+                backgroundColor: copySuccess ? '#48bb78' : '#f7fafc',
+                color: copySuccess ? 'white' : '#4a5568',
+                border: '1px solid #e2e8f0',
+                borderRadius: '6px',
+                fontSize: '14px',
+                cursor: 'pointer',
+                transition: 'all 0.2s ease'
+              }}
+            >
+              <FaCopy size={12} />
+              {copySuccess ? '복사됨!' : '복사'}
+            </button>
+
+            {/* 전체화면 버튼 */}
+            <button
+              onClick={() => setIsFullscreen(!isFullscreen)}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                padding: '8px',
+                backgroundColor: '#f7fafc',
+                color: '#4a5568',
+                border: '1px solid #e2e8f0',
+                borderRadius: '6px',
+                cursor: 'pointer',
+                transition: 'all 0.2s ease'
+              }}
+            >
+              {isFullscreen ? <FaCompress size={14} /> : <FaExpand size={14} />}
+            </button>
+
+            {/* 닫기 버튼 */}
+            <button
+              onClick={onClose}
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                padding: '8px',
+                backgroundColor: '#fed7d7',
+                color: '#c53030',
+                border: '1px solid #feb2b2',
+                borderRadius: '6px',
+                cursor: 'pointer',
+                transition: 'all 0.2s ease'
+              }}
+            >
+              <FaTimes size={14} />
+            </button>
+          </div>
+        </div>
+
+        {/* 메시지 정보 */}
+        <div style={{
+          padding: '12px 20px',
+          backgroundColor: '#f8fafc',
+          borderBottom: '1px solid #e2e8f0',
+          fontSize: '14px',
+          color: '#4a5568'
+        }}>
+          <span style={{ fontWeight: '500' }}>{message.senderName}</span>
+          <span style={{ margin: '0 8px', color: '#a0aec0' }}>•</span>
+          <span>{new Date(message.sendAt).toLocaleString('ko-KR')}</span>
+        </div>
+
+        {/* 코드 영역 */}
+        <div style={{
+          flex: 1,
+          overflow: 'auto',
+          backgroundColor: '#fafafa'
+        }}>
+          <div style={{
+            padding: '20px',
+            height: '100%'
+          }}>
+            <div style={{
+              backgroundColor: '#ffffff',
+              borderRadius: '8px',
+              border: '1px solid #e2e8f0',
+              overflow: 'hidden',
+              height: '100%'
+            }}>
+              <div style={{
+                height: '100%',
+                overflow: 'auto',
+                fontSize: '14px',
+                lineHeight: '1.6'
+              }}>
+                <Highlight className={message.language || 'java'}>
+                  {message.content}
+                </Highlight>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* 푸터 (향후 API 호출 버튼들 추가 예정) */}
+        <div style={{
+          padding: '16px 20px',
+          backgroundColor: '#f8fafc',
+          borderTop: '1px solid #e2e8f0',
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center'
+        }}>
+          <div style={{
+            fontSize: '13px',
+            color: '#718096'
+          }}>
+            💡 향후 AI 코드 리뷰 기능이 추가될 예정입니다
+          </div>
+          
+          <div style={{ display: 'flex', gap: '8px' }}>
+            {/* 향후 AI 리뷰 버튼들이 여기에 추가될 예정 */}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CodeReviewModal;

--- a/frontend/src/components/modals/CodeReviewModal.jsx
+++ b/frontend/src/components/modals/CodeReviewModal.jsx
@@ -13,8 +13,8 @@ const CodeReviewModal = ({ message, onClose }) => {
   const [reviewText, setReviewText] = useState('');
   const [hoveredLine, setHoveredLine] = useState(null);
   const [loading, setLoading] = useState(false); // 이것도 추가
-  const [editingReviewId, setEditingReviewsId] = useState(null);
-  const [editReviewText, setEditReviewsText] = useState('');
+  const [editingReviewId, setEditingReviewId] = useState(null);
+  const [editReviewText, setEditReviewText] = useState('');
   const [currentUser, setCurrentUser] = useState(null);
 
   const HighlightedCode = ({ content, language }) => {
@@ -291,8 +291,8 @@ const CodeReviewModal = ({ message, onClose }) => {
 
   // 댓글 수정 시작
   const handleEditReview = (review) => {
-    setEditingReviewsId(review.id);
-    setEditReviewsText(review.content);
+    setEditingReviewId(review.id);
+    setEditReviewText(review.content);
   };
 
   // 댓글 수정 저장
@@ -314,8 +314,8 @@ const CodeReviewModal = ({ message, onClose }) => {
         )
       }));
 
-      setEditingReviewsId(null);
-      setEditReviewsText('');
+      setEditingReviewId(null);
+      setEditReviewText('');
 
     } catch (error) {
       console.error('댓글 수정 실패:', error);
@@ -327,8 +327,8 @@ const CodeReviewModal = ({ message, onClose }) => {
 
   // 댓글 수정 취소
   const handleCancelEdit = () => {
-    setEditingReviewsId(null);
-    setEditReviewsText('');
+    setEditingReviewId(null);
+    setEditReviewText('');
   };
 
   return (
@@ -735,7 +735,7 @@ const CodeReviewModal = ({ message, onClose }) => {
                               <div>
                                 <textarea
                                   value={editReviewText}
-                                  onChange={(e) => setEditReviewsText(e.target.value)}
+                                  onChange={(e) => setEditReviewText(e.target.value)}
                                   style={{
                                     width: '100%',
                                     minHeight: '60px',

--- a/frontend/src/components/modals/CodeReviewModal.jsx
+++ b/frontend/src/components/modals/CodeReviewModal.jsx
@@ -1,11 +1,12 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { FaTimes, FaCopy, FaExpand, FaCompress, FaPlus, FaCheck, FaTrash } from 'react-icons/fa';
-import axiosInstance from '../api/axiosInstance'; 
+import axiosInstance from '../api/axiosInstance';
+import Highlight from 'react-highlight';
 
 const CodeReviewModal = ({ message, onClose }) => {
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [copySuccess, setCopySuccess] = useState(false);
-  
+
   // 댓글 관련 상태
   const [comments, setComments] = useState({}); // { lineNumber: [comments] }
   const [activeCommentLine, setActiveCommentLine] = useState(null);
@@ -16,100 +17,100 @@ const CodeReviewModal = ({ message, onClose }) => {
   const codeRef = useRef(null);
 
   useEffect(() => {
-  const loadExistingReviews = async () => {
-    try {
-      setLoading(true);
-      
-      if (!message.messageId) {
-        return;
-      }
+    const loadExistingReviews = async () => {
+      try {
+        setLoading(true);
 
-      const reviews = await codeReviewAPI.getByMessageId(message.messageId);
-      
-      // 서버에서 받은 리뷰 데이터를 라인별로 정리
-      const reviewsByLine = {};
-      
-      if (reviews && Array.isArray(reviews)) {
-        reviews.forEach(review => {
-          const lineNumber = review.lineNumber;
-          
-          if (!reviewsByLine[lineNumber]) {
-            reviewsByLine[lineNumber] = [];
-          }
-          
-          reviewsByLine[lineNumber].push({
-            id: review.reviewId,
-            content: review.content,
-            author: review.authorName,
-            timestamp: review.createAt
+        if (!message.messageId) {
+          return;
+        }
+
+        const reviews = await codeReviewAPI.getByMessageId(message.messageId);
+
+        // 서버에서 받은 리뷰 데이터를 라인별로 정리
+        const reviewsByLine = {};
+
+        if (reviews && Array.isArray(reviews)) {
+          reviews.forEach(review => {
+            const lineNumber = review.lineNumber;
+
+            if (!reviewsByLine[lineNumber]) {
+              reviewsByLine[lineNumber] = [];
+            }
+
+            reviewsByLine[lineNumber].push({
+              id: review.reviewId,
+              content: review.content,
+              author: review.authorName,
+              timestamp: review.createAt
+            });
           });
-        });
-      }
-      
-      setComments(reviewsByLine);
-      
-    } catch (error) {
-      if (error.message.includes('404')) {
-        setComments({});
-        return;
-      }
-      
-      let errorMessage = '기존 댓글을 불러오는데 실패했습니다.';
-      if (error.message.includes('401')) {
-        errorMessage = '로그인이 필요합니다.';
-      } else if (error.message.includes('403')) {
-        errorMessage = '댓글 조회 권한이 없습니다.';
-      }
-      
-      alert(errorMessage);
-      
-    } finally {
-      setLoading(false);
-    }
-  };
+        }
 
-  loadExistingReviews();
-}, [message.messageId]);
+        setComments(reviewsByLine);
+
+      } catch (error) {
+        if (error.message.includes('404')) {
+          setComments({});
+          return;
+        }
+
+        let errorMessage = '기존 댓글을 불러오는데 실패했습니다.';
+        if (error.message.includes('401')) {
+          errorMessage = '로그인이 필요합니다.';
+        } else if (error.message.includes('403')) {
+          errorMessage = '댓글 조회 권한이 없습니다.';
+        }
+
+        alert(errorMessage);
+
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadExistingReviews();
+  }, [message.messageId]);
 
 
   const codeReviewAPI = {
-  // 리뷰 생성
-  create: async (reviewData) => {
-    try {
-      const response = await axiosInstance.post('/code-reviews', reviewData);
-      return response.data;
-    } catch (error) {
-      throw new Error(error.response?.data?.message || '리뷰 생성 실패');
-    }
-  },
-
-  // 메시지별 리뷰 조회
-  getByMessageId: async (messageId) => {
-    try {
-      const response = await axiosInstance.get(`/code-reviews/${messageId}`);
-      
-      // 응답 데이터 구조에 따라 수정 필요
-      return response.data.reviews || response.data;
-      
-    } catch (error) {
-      if (error.response?.status === 404) {
-        return [];
+    // 리뷰 생성
+    create: async (reviewData) => {
+      try {
+        const response = await axiosInstance.post('/code-reviews', reviewData);
+        return response.data;
+      } catch (error) {
+        throw new Error(error.response?.data?.message || '리뷰 생성 실패');
       }
-      
-      throw new Error(error.response?.data?.message || '리뷰 조회 실패');
-    }
-  },
+    },
 
-  // 리뷰 삭제
-  delete: async (reviewId) => {
-    try {
-      await axiosInstance.delete(`/code-reviews/${reviewId}`);
-    } catch (error) {
-      throw new Error(error.response?.data?.message || '리뷰 삭제 실패');
+    // 메시지별 리뷰 조회
+    getByMessageId: async (messageId) => {
+      try {
+        const response = await axiosInstance.get(`/code-reviews/${messageId}`);
+
+        // 응답 데이터 구조에 따라 수정 필요
+        return response.data.reviews || response.data;
+
+      } catch (error) {
+        if (error.response?.status === 404) {
+          return [];
+        }
+
+        throw new Error(error.response?.data?.message || '리뷰 조회 실패');
+      }
+    },
+
+    // 리뷰 삭제
+    delete: async (reviewId) => {
+      try {
+        await axiosInstance.delete(`/code-reviews/${reviewId}`);
+      } catch (error) {
+        throw new Error(error.response?.data?.message || '리뷰 삭제 실패');
+      }
     }
-  }
-};
- 
+  };
+
 
   // 코드를 라인별로 분리
   const codeLines = message.content.split('\n');
@@ -155,41 +156,41 @@ const CodeReviewModal = ({ message, onClose }) => {
 
   // 댓글 저장
   const handleSaveComment = async () => {
-  if (!commentText.trim()) return;
+    if (!commentText.trim()) return;
 
-  try {
-    setLoading(true);
+    try {
+      setLoading(true);
 
-    const reviewData = {
-      messageId: message.messageId,
-      lineNumber: activeCommentLine,
-      content: commentText.trim()
-    };
+      const reviewData = {
+        messageId: message.messageId,
+        lineNumber: activeCommentLine,
+        content: commentText.trim()
+      };
 
-    const createdReview = await codeReviewAPI.create(reviewData);
+      const createdReview = await codeReviewAPI.create(reviewData);
 
-    const newComment = {
-      id: createdReview.reviewId,
-      content: createdReview.content,
-      author: createdReview.authorName,
-      timestamp: createdReview.createAt
-    };
+      const newComment = {
+        id: createdReview.reviewId,
+        content: createdReview.content,
+        author: createdReview.authorName,
+        timestamp: createdReview.createAt
+      };
 
-    setComments(prev => ({
-      ...prev,
-      [activeCommentLine]: [...(prev[activeCommentLine] || []), newComment]
-    }));
+      setComments(prev => ({
+        ...prev,
+        [activeCommentLine]: [...(prev[activeCommentLine] || []), newComment]
+      }));
 
-    setActiveCommentLine(null);
-    setCommentText('');
+      setActiveCommentLine(null);
+      setCommentText('');
 
-  } catch (error) {
-    console.error('댓글 저장 실패:', error);
-    alert(error.message);
-  } finally {
-    setLoading(false);
-  }
-};
+    } catch (error) {
+      console.error('댓글 저장 실패:', error);
+      alert(error.message);
+    } finally {
+      setLoading(false);
+    }
+  };
 
   // 댓글 취소(취소버튼 누르는 것)
   const handleCancelComment = () => {
@@ -215,7 +216,7 @@ const CodeReviewModal = ({ message, onClose }) => {
 
 
   return (
-    <div 
+    <div
       style={{
         position: 'fixed',
         top: 0,
@@ -231,7 +232,7 @@ const CodeReviewModal = ({ message, onClose }) => {
       }}
       onClick={handleBackgroundClick}
     >
-      <div 
+      <div
         style={{
           backgroundColor: '#ffffff',
           borderRadius: isFullscreen ? '0' : '12px',
@@ -274,7 +275,7 @@ const CodeReviewModal = ({ message, onClose }) => {
               {message.language || 'java'}
             </span>
           </div>
-          
+
           <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
             {/* 복사 버튼 */}
             <button
@@ -377,7 +378,7 @@ const CodeReviewModal = ({ message, onClose }) => {
                   {codeLines.map((line, index) => {
                     const lineNumber = index + 1;
                     const hasComments = comments[lineNumber] && comments[lineNumber].length > 0;
-                    
+
                     return (
                       <div key={lineNumber}>
                         {/* 코드 라인 */}
@@ -602,7 +603,7 @@ const CodeReviewModal = ({ message, onClose }) => {
           }}>
             💬 라인별로 댓글을 달아 코드 리뷰를 진행하세요
           </div>
-          
+
           <div style={{
             fontSize: '12px',
             color: '#a0aec0'

--- a/frontend/src/components/modals/CodeReviewModal.jsx
+++ b/frontend/src/components/modals/CodeReviewModal.jsx
@@ -16,6 +16,25 @@ const CodeReviewModal = ({ message, onClose }) => {
 
   const codeRef = useRef(null);
 
+const HighlightedCode = ({ content, language }) => {
+  return (
+    <>
+      <Highlight className={language}>{content}</Highlight>
+      <style>{`
+        .hljs {
+          margin: 0 !important;
+          padding: 0 !important;
+          background: transparent !important;
+          line-height: 22px !important;
+          font-size: 16px !important;
+          font-family: inherit !important;
+          display: inline !important;
+        }
+      `}</style>
+    </>
+  );
+};
+
   useEffect(() => {
     const loadExistingReviews = async () => {
       try {
@@ -446,7 +465,10 @@ const CodeReviewModal = ({ message, onClose }) => {
                             whiteSpace: 'pre',
                             lineHeight: '20px'
                           }}>
-                            <code>{line}</code>
+                            <HighlightedCode
+                              content={line}
+                              language={message.language || 'java'}
+                            />
                           </div>
                         </div>
 

--- a/frontend/src/components/modals/CodeReviewModal.jsx
+++ b/frontend/src/components/modals/CodeReviewModal.jsx
@@ -16,11 +16,11 @@ const CodeReviewModal = ({ message, onClose }) => {
 
   const codeRef = useRef(null);
 
-const HighlightedCode = ({ content, language }) => {
-  return (
-    <>
-      <Highlight className={language}>{content}</Highlight>
-      <style>{`
+  const HighlightedCode = ({ content, language }) => {
+    return (
+      <>
+        <Highlight className={language}>{content}</Highlight>
+        <style>{`
         .hljs {
           margin: 0 !important;
           padding: 0 !important;
@@ -31,9 +31,9 @@ const HighlightedCode = ({ content, language }) => {
           display: inline !important;
         }
       `}</style>
-    </>
-  );
-};
+      </>
+    );
+  };
 
   useEffect(() => {
     const loadExistingReviews = async () => {
@@ -220,15 +220,18 @@ const HighlightedCode = ({ content, language }) => {
   // 댓글 삭제
   const handleDeleteComment = async (lineNumber, commentId) => {
     try {
-      // 임시 API 호출
-      console.log('댓글 삭제 API 호출:', { commentId });
+      // 실제 API 호출
+      await codeReviewAPI.delete(commentId);
 
+      // 성공 시 UI에서 제거
       setComments(prev => ({
         ...prev,
         [lineNumber]: prev[lineNumber].filter(comment => comment.id !== commentId)
       }));
+
     } catch (error) {
       console.error('댓글 삭제 실패:', error);
+      alert(error.message || '댓글 삭제에 실패했습니다.');
     }
   };
 

--- a/frontend/src/components/modals/CodeReviewModal.jsx
+++ b/frontend/src/components/modals/CodeReviewModal.jsx
@@ -15,6 +15,63 @@ const CodeReviewModal = ({ message, onClose }) => {
 
   const codeRef = useRef(null);
 
+  useEffect(() => {
+  const loadExistingReviews = async () => {
+    try {
+      setLoading(true);
+      
+      if (!message.messageId) {
+        return;
+      }
+
+      const reviews = await codeReviewAPI.getByMessageId(message.messageId);
+      
+      // 서버에서 받은 리뷰 데이터를 라인별로 정리
+      const reviewsByLine = {};
+      
+      if (reviews && Array.isArray(reviews)) {
+        reviews.forEach(review => {
+          const lineNumber = review.lineNumber;
+          
+          if (!reviewsByLine[lineNumber]) {
+            reviewsByLine[lineNumber] = [];
+          }
+          
+          reviewsByLine[lineNumber].push({
+            id: review.reviewId,
+            content: review.content,
+            author: review.authorName,
+            timestamp: review.createAt
+          });
+        });
+      }
+      
+      setComments(reviewsByLine);
+      
+    } catch (error) {
+      if (error.message.includes('404')) {
+        setComments({});
+        return;
+      }
+      
+      let errorMessage = '기존 댓글을 불러오는데 실패했습니다.';
+      if (error.message.includes('401')) {
+        errorMessage = '로그인이 필요합니다.';
+      } else if (error.message.includes('403')) {
+        errorMessage = '댓글 조회 권한이 없습니다.';
+      }
+      
+      alert(errorMessage);
+      
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  loadExistingReviews();
+}, [message.messageId]);
+
+
   const codeReviewAPI = {
   // 리뷰 생성
   create: async (reviewData) => {
@@ -29,9 +86,16 @@ const CodeReviewModal = ({ message, onClose }) => {
   // 메시지별 리뷰 조회
   getByMessageId: async (messageId) => {
     try {
-      const response = await axiosInstance.get(`/code-reviews/message/${messageId}`);
-      return response.data;
+      const response = await axiosInstance.get(`/code-reviews/${messageId}`);
+      
+      // 응답 데이터 구조에 따라 수정 필요
+      return response.data.reviews || response.data;
+      
     } catch (error) {
+      if (error.response?.status === 404) {
+        return [];
+      }
+      
       throw new Error(error.response?.data?.message || '리뷰 조회 실패');
     }
   },
@@ -127,7 +191,7 @@ const CodeReviewModal = ({ message, onClose }) => {
   }
 };
 
-  // 댓글 취소
+  // 댓글 취소(취소버튼 누르는 것)
   const handleCancelComment = () => {
     setActiveCommentLine(null);
     setCommentText('');
@@ -147,6 +211,8 @@ const CodeReviewModal = ({ message, onClose }) => {
       console.error('댓글 삭제 실패:', error);
     }
   };
+
+
 
   return (
     <div 
@@ -195,7 +261,7 @@ const CodeReviewModal = ({ message, onClose }) => {
               fontWeight: '600',
               color: '#2d3748'
             }}>
-              코드 리뷰
+              Code Review
             </h3>
             <span style={{
               backgroundColor: '#4299e1',

--- a/frontend/src/components/modals/CodeReviewModal.jsx
+++ b/frontend/src/components/modals/CodeReviewModal.jsx
@@ -464,6 +464,7 @@ const CodeReviewModal = ({ message, onClose }) => {
                             <textarea
                               value={commentText}
                               onChange={(e) => setCommentText(e.target.value)}
+                              placeholder='Leave a comment...'
                               style={{
                                 width: '100%',
                                 minHeight: '80px',
@@ -513,7 +514,7 @@ const CodeReviewModal = ({ message, onClose }) => {
                                 }}
                               >
                                 <FaCheck size={12} />
-                                댓글 저장
+                                리뷰 저장
                               </button>
                             </div>
                           </div>

--- a/frontend/src/components/modals/CodeReviewModal.jsx
+++ b/frontend/src/components/modals/CodeReviewModal.jsx
@@ -13,8 +13,9 @@ const CodeReviewModal = ({ message, onClose }) => {
   const [commentText, setCommentText] = useState('');
   const [hoveredLine, setHoveredLine] = useState(null);
   const [loading, setLoading] = useState(false); // 이것도 추가
-
-  const codeRef = useRef(null);
+  const [editingCommentId, setEditingCommentId] = useState(null);
+  const [editCommentText, setEditCommentText] = useState('');
+  const [currentUser, setCurrentUser] = useState(null);
 
   const HighlightedCode = ({ content, language }) => {
     return (
@@ -35,6 +36,28 @@ const CodeReviewModal = ({ message, onClose }) => {
     );
   };
 
+  // 현재 사용자 정보 가져오기
+  const fetchCurrentUser = async () => {
+    try {
+      const response = await axiosInstance.get('/user/details');
+      setCurrentUser(response.data.id); // username 대신 id 사용
+      console.log('현재 사용자 ID:', response.data.id);
+    } catch (error) {
+      console.error('사용자 정보 조회 실패:', error);
+      setCurrentUser(null);
+    }
+  };
+
+  // 수정 가능 여부 체크 함수
+  const canEdit = (comment) => {
+    return currentUser && comment.authorId === currentUser;
+  };
+
+  // 현재 사용자 정보 로드
+  useEffect(() => {
+    fetchCurrentUser();
+  }, []);
+
   useEffect(() => {
     const loadExistingReviews = async () => {
       try {
@@ -43,7 +66,6 @@ const CodeReviewModal = ({ message, onClose }) => {
         if (!message.messageId) {
           return;
         }
-
         const reviews = await codeReviewAPI.getByMessageId(message.messageId);
 
         // 서버에서 받은 리뷰 데이터를 라인별로 정리
@@ -61,6 +83,7 @@ const CodeReviewModal = ({ message, onClose }) => {
               id: review.reviewId,
               content: review.content,
               author: review.authorName,
+              authorId: review.authorId, // 작성자 ID 추가
               timestamp: review.createAt
             });
           });
@@ -127,6 +150,18 @@ const CodeReviewModal = ({ message, onClose }) => {
       } catch (error) {
         throw new Error(error.response?.data?.message || '리뷰 삭제 실패');
       }
+    },
+
+    // 리뷰 수정
+    update: async (reviewId, content) => {
+      try {
+        const response = await axiosInstance.put(`/code-reviews/${reviewId}`, {
+          content: content
+        });
+        return response.data;
+      } catch (error) {
+        throw new Error(error.response?.data?.message || '리뷰 수정 실패');
+      }
     }
   };
 
@@ -149,7 +184,9 @@ const CodeReviewModal = ({ message, onClose }) => {
   useEffect(() => {
     const handleEsc = (e) => {
       if (e.key === 'Escape') {
-        if (activeCommentLine) {
+        if (editingCommentId) {
+          handleCancelEdit();
+        } else if (activeCommentLine) {
           handleCancelComment();
         } else {
           onClose();
@@ -158,7 +195,7 @@ const CodeReviewModal = ({ message, onClose }) => {
     };
     document.addEventListener('keydown', handleEsc);
     return () => document.removeEventListener('keydown', handleEsc);
-  }, [onClose, activeCommentLine]);
+  }, [onClose, activeCommentLine, editingCommentId]);
 
   // 배경 클릭으로 모달 닫기
   const handleBackgroundClick = (e) => {
@@ -167,7 +204,7 @@ const CodeReviewModal = ({ message, onClose }) => {
     }
   };
 
-  // 
+  // 댓글 추가
   const handleAddComment = (lineNumber) => {
     setActiveCommentLine(lineNumber);
     setCommentText('');
@@ -192,6 +229,7 @@ const CodeReviewModal = ({ message, onClose }) => {
         id: createdReview.reviewId,
         content: createdReview.content,
         author: createdReview.authorName,
+        authorId: createdReview.authorId, // 작성자 ID 추가
         timestamp: createdReview.createAt
       };
 
@@ -235,7 +273,47 @@ const CodeReviewModal = ({ message, onClose }) => {
     }
   };
 
+  // 댓글 수정 시작
+  const handleEditComment = (comment) => {
+    setEditingCommentId(comment.id);
+    setEditCommentText(comment.content);
+  };
 
+  // 댓글 수정 저장
+  const handleSaveEdit = async (lineNumber, commentId) => {
+    if (!editCommentText.trim()) return;
+
+    try {
+      setLoading(true);
+
+      const updatedReview = await codeReviewAPI.update(commentId, editCommentText.trim());
+
+      // UI 업데이트
+      setComments(prev => ({
+        ...prev,
+        [lineNumber]: prev[lineNumber].map(comment =>
+          comment.id === commentId
+            ? { ...comment, content: updatedReview.content || editCommentText.trim() }
+            : comment
+        )
+      }));
+
+      setEditingCommentId(null);
+      setEditCommentText('');
+
+    } catch (error) {
+      console.error('댓글 수정 실패:', error);
+      alert(error.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // 댓글 수정 취소
+  const handleCancelEdit = () => {
+    setEditingCommentId(null);
+    setEditCommentText('');
+  };
 
   return (
     <div
@@ -557,7 +635,26 @@ const CodeReviewModal = ({ message, onClose }) => {
                               backgroundColor: '#ffffff',
                               border: '1px solid #e2e8f0',
                               borderRadius: '6px',
-                              boxShadow: '0 1px 3px rgba(0,0,0,0.1)'
+                              boxShadow: '0 1px 3px rgba(0,0,0,0.1)',
+                              cursor: canEdit(comment) && editingCommentId !== comment.id ? 'pointer' : 'default',
+                              transition: 'all 0.2s ease'
+                            }}
+                            onClick={() => {
+                              if (canEdit(comment) && editingCommentId !== comment.id) {
+                                handleEditComment(comment);
+                              }
+                            }}
+                            onMouseEnter={(e) => {
+                              if (canEdit(comment) && editingCommentId !== comment.id) {
+                                e.currentTarget.style.backgroundColor = '#f8fafc';
+                                e.currentTarget.style.borderColor = '#4299e1';
+                              }
+                            }}
+                            onMouseLeave={(e) => {
+                              if (canEdit(comment) && editingCommentId !== comment.id) {
+                                e.currentTarget.style.backgroundColor = '#ffffff';
+                                e.currentTarget.style.borderColor = '#e2e8f0';
+                              }
                             }}
                           >
                             <div style={{
@@ -567,11 +664,27 @@ const CodeReviewModal = ({ message, onClose }) => {
                               marginBottom: '6px'
                             }}>
                               <div style={{
-                                fontSize: '12px',
-                                color: '#4a5568',
-                                fontWeight: '500'
+                                display: 'flex',
+                                alignItems: 'center',
+                                gap: '6px'
                               }}>
-                                {comment.author}
+                                <span style={{
+                                  fontSize: '12px',
+                                  color: '#4a5568',
+                                  fontWeight: '500'
+                                }}>
+                                  {comment.author}
+                                </span>
+                                {canEdit(comment) && editingCommentId !== comment.id && (
+                                  <span style={{
+                                    fontSize: '10px',
+                                    color: '#4299e1',
+                                    backgroundColor: '#ebf8ff',
+                                    padding: '1px 4px',
+                                    borderRadius: '2px'
+                                  }}>
+                                  </span>
+                                )}
                               </div>
                               <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
                                 <span style={{
@@ -580,29 +693,96 @@ const CodeReviewModal = ({ message, onClose }) => {
                                 }}>
                                   {new Date(comment.timestamp).toLocaleString('ko-KR')}
                                 </span>
-                                <button
-                                  onClick={() => handleDeleteComment(lineNumber, comment.id)}
-                                  style={{
-                                    padding: '2px',
-                                    backgroundColor: 'transparent',
-                                    border: 'none',
-                                    color: '#e53e3e',
-                                    cursor: 'pointer',
-                                    fontSize: '12px'
-                                  }}
-                                >
-                                  <FaTrash size={10} />
-                                </button>
+                                {canEdit(comment) && (
+                                  <button
+                                    onClick={(e) => {
+                                      e.stopPropagation();
+                                      handleDeleteComment(lineNumber, comment.id);
+                                    }}
+                                    style={{
+                                      padding: '2px',
+                                      backgroundColor: 'transparent',
+                                      border: 'none',
+                                      color: '#e53e3e',
+                                      cursor: 'pointer',
+                                      fontSize: '12px'
+                                    }}
+                                  >
+                                    <FaTrash size={10} />
+                                  </button>
+                                )}
                               </div>
                             </div>
-                            <div style={{
-                              fontSize: '14px',
-                              color: '#2d3748',
-                              lineHeight: '1.4',
-                              whiteSpace: 'pre-wrap'
-                            }}>
-                              {comment.content}
-                            </div>
+
+                            {/* 댓글 내용 또는 수정 입력창 */}
+                            {editingCommentId === comment.id ? (
+                              <div>
+                                <textarea
+                                  value={editCommentText}
+                                  onChange={(e) => setEditCommentText(e.target.value)}
+                                  style={{
+                                    width: '100%',
+                                    minHeight: '60px',
+                                    border: '1px solid #4299e1',
+                                    borderRadius: '4px',
+                                    padding: '8px',
+                                    fontSize: '14px',
+                                    resize: 'vertical',
+                                    fontFamily: 'inherit',
+                                    marginBottom: '8px'
+                                  }}
+                                  autoFocus
+                                />
+                                <div style={{
+                                  display: 'flex',
+                                  justifyContent: 'flex-end',
+                                  gap: '8px'
+                                }}>
+                                  <button
+                                    onClick={handleCancelEdit}
+                                    style={{
+                                      padding: '4px 8px',
+                                      backgroundColor: '#e2e8f0',
+                                      color: '#4a5568',
+                                      border: 'none',
+                                      borderRadius: '4px',
+                                      fontSize: '12px',
+                                      cursor: 'pointer'
+                                    }}
+                                  >
+                                    취소
+                                  </button>
+                                  <button
+                                    onClick={() => handleSaveEdit(lineNumber, comment.id)}
+                                    disabled={!editCommentText.trim() || loading}
+                                    style={{
+                                      display: 'flex',
+                                      alignItems: 'center',
+                                      gap: '4px',
+                                      padding: '4px 8px',
+                                      backgroundColor: editCommentText.trim() ? '#4299e1' : '#e2e8f0',
+                                      color: editCommentText.trim() ? 'white' : '#a0aec0',
+                                      border: 'none',
+                                      borderRadius: '4px',
+                                      fontSize: '12px',
+                                      cursor: editCommentText.trim() ? 'pointer' : 'not-allowed'
+                                    }}
+                                  >
+                                    <FaCheck size={10} />
+                                    저장
+                                  </button>
+                                </div>
+                              </div>
+                            ) : (
+                              <div style={{
+                                fontSize: '14px',
+                                color: '#2d3748',
+                                lineHeight: '1.4',
+                                whiteSpace: 'pre-wrap'
+                              }}>
+                                {comment.content}
+                              </div>
+                            )}
                           </div>
                         ))}
                       </div>

--- a/frontend/src/pages/ChatRoom.jsx
+++ b/frontend/src/pages/ChatRoom.jsx
@@ -43,10 +43,8 @@ const ChatRoom = () => {
   const [selectedCodeMessage, setSelectedCodeMessage] = useState(null);
 
   const handleCodeClick = (message) => {
-     console.log('🎯 handleCodeClick 호출됨!', message);
-  setSelectedCodeMessage(message);
-  setShowCodeModal(true);
-  console.log('📊 상태 업데이트 완료, showCodeModal:', true);
+    setSelectedCodeMessage(message);
+    setShowCodeModal(true);
   };
 
   // 초기화 상태를 하나로 통합하고 단계별로 관리

--- a/frontend/src/pages/ChatRoom.jsx
+++ b/frontend/src/pages/ChatRoom.jsx
@@ -7,6 +7,7 @@ import MessageList from '../components/chatroom/MessageList';
 import useWebSocket from '../components/common/useWebSocket';
 import RoomHeader from '../components/chatroom/RoomHeader';
 import RoomDeletedModal from '../components/modals/RoomDeletedModal';
+import CodeReviewModal from '../components/modals/CodeReviewModal.jsx';
 
 const ChatRoom = () => {
   const { inviteCode } = useParams();
@@ -38,6 +39,15 @@ const ChatRoom = () => {
   const [isOwner, setIsOwner] = useState(false);
   const [roomData, setRoomData] = useState(null);
   const [deleteNotification, setDeleteNotification] = useState(null);
+  const [showCodeModal, setShowCodeModal] = useState(false);
+  const [selectedCodeMessage, setSelectedCodeMessage] = useState(null);
+
+  const handleCodeClick = (message) => {
+     console.log('🎯 handleCodeClick 호출됨!', message);
+  setSelectedCodeMessage(message);
+  setShowCodeModal(true);
+  console.log('📊 상태 업데이트 완료, showCodeModal:', true);
+  };
 
   // 초기화 상태를 하나로 통합하고 단계별로 관리
   const [initState, setInitState] = useState({
@@ -74,7 +84,7 @@ const ChatRoom = () => {
       setRoomId(roomData.roomId);
       setRoomName(roomData.roomName);
       setRoomData(roomData);
-      
+
       // 한 번에 상태 업데이트
       setInitState(prev => ({
         ...prev,
@@ -676,7 +686,7 @@ const ChatRoom = () => {
           <RoomHeader
             roomName={roomName}
             inviteCode={inviteCode}
-            onSearch={handleSearch} 
+            onSearch={handleSearch}
             onLeaveRoom={handleLeaveRoom}
             onDeleteRoom={handleDeleteRoom}
             isOwner={isOwner}
@@ -768,6 +778,7 @@ const ChatRoom = () => {
               editMessageId={editMessageId}
               editContent={editContent}
               handleEditMessage={handleEditMessage}
+              onCodeClick={handleCodeClick}
             />
             <div ref={messagesEndRef} />
           </div>
@@ -810,6 +821,19 @@ const ChatRoom = () => {
             onClose={() => setShowSearchSidebar(false)}
             onPageChange={(page) => handleSearch(searchKeyword, page)}
             onMessageClick={scrollToMessage}
+          />
+        )}
+
+        {/* 코드 리뷰 모달 */}
+        {showCodeModal && selectedCodeMessage && (
+          <CodeReviewModal
+            message={selectedCodeMessage}
+            roomId={roomId}
+            currentUser={currentUser}
+            onClose={() => {
+              setShowCodeModal(false);
+              setSelectedCodeMessage(null);
+            }}
           />
         )}
 


### PR DESCRIPTION
## 🛰️ Issue Number
#156 #160 

## 🪐 작업 내용
### 인라인 코드 구현
---
### 프론트
- 코드는 클릭하여 큰 모달창으로 볼 수 있다.
- 큰 모달창(코드리뷰 모달) 에서는 전체복사, 전체화면으로 보기가 가능. 
- 큰 모달창(코드리뷰 모달) 에서는 한줄한줄 +버튼을 눌러서 해당 라인에 리뷰를 남길 수 있다.
<img width="1285" alt="image" src="https://github.com/user-attachments/assets/3897498f-feb1-4dfe-a5e3-2b23ecd9e203" />
<img width="1142" alt="image" src="https://github.com/user-attachments/assets/a6d8c1a6-8652-45b5-aaf2-0228f0ea8f8c" />
<img width="1149" alt="image" src="https://github.com/user-attachments/assets/b2e99582-105f-4228-8043-bd4678d2e8e7" />
<img width="1125" alt="image" src="https://github.com/user-attachments/assets/7b618555-486d-490f-89b4-33992fa5f275" />

- 본인이 작성한 리뷰에 한해서 수정, 삭제가 가능.(타인이 작성한 리뷰는 수정,삭제 기능 비활성화)
- 수정 방법 : 본인이 작성한 리뷰 클릭하면 편집상태로 변함
- 삭제 방법 : 맨 오른쪽 쓰레기통 버튼 누르면 삭제

---
### 백엔드
<img width="1287" alt="image" src="https://github.com/user-attachments/assets/f243c61e-175d-4844-82f1-9f4f36c1551f" />

- 코드리뷰 테이블 추가(메세지id와 회원id 참조)
<img width="237" alt="image" src="https://github.com/user-attachments/assets/b71d656a-dc37-4d7c-9af8-2d89785d391c" />

- 코드리뷰 도메인 추가
- 코드리뷰 crud 구현

---
### 웹훅 자동 삭제

- ChatRoom 엔티티에 webhookId 필드를 추가하였고, 웹훅 자동 생성 시 id를 저장하도록 하여 관리.
- 채팅방 삭제 시 웹훅 자동 삭제.
- GitHubClient의 안 쓰이는 메서드 2개 삭제

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?