### PR TITLE
Refactor: offset 방식의 페이지네이션을 cursor 방식의 페이지네이션으로 변경

### DIFF
--- a/backend/src/main/java/project/backend/domain/chat/chatmessage/api/ChatMessageController.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatmessage/api/ChatMessageController.java
@@ -1,8 +1,10 @@
 package project.backend.domain.chat.chatmessage.api;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.security.Principal;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Slice;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
@@ -29,71 +31,74 @@ import project.backend.domain.imagefile.ImageFileService;
 @RequiredArgsConstructor
 public class ChatMessageController {
 
-	private final ChatMessageService chatMessageService;
-	private final ImageFileService imageFileService;
-	private final SimpMessagingTemplate messagingTemplate;
+    private final ChatMessageService chatMessageService;
+    private final ImageFileService imageFileService;
+    private final SimpMessagingTemplate messagingTemplate;
 
-	@MessageMapping("/send-message/{roomId}") //클라이언트가 메세지를 보낼 경로
-	public ChatMessageResponse sendMessage(@DestinationVariable Long roomId,
-		@Payload ChatMessageRequest request, Principal principal) {
-		ChatMessageResponse response = chatMessageService.save(roomId, request,
-			principal.getName());
+    @MessageMapping("/send-message/{roomId}") //클라이언트가 메세지를 보낼 경로
+    public ChatMessageResponse sendMessage(@DestinationVariable Long roomId,
+        @Payload ChatMessageRequest request, Principal principal) {
+        ChatMessageResponse response = chatMessageService.save(roomId, request,
+            principal.getName());
 
-		messagingTemplate.convertAndSend("/topic/chat/" + roomId, response);
+        messagingTemplate.convertAndSend("/topic/chat/" + roomId, response);
 
-		return response;
-	}
+        return response;
+    }
 
-	@MessageMapping("/edit-message/{roomId}")
-	public ChatMessageResponse editMessage(@DestinationVariable Long roomId, @Payload
-	ChatMessageEditRequest request, Principal principal) {
-		ChatMessageResponse response = chatMessageService.editMessage(roomId, request,
-			principal.getName());
+    @MessageMapping("/edit-message/{roomId}")
+    public ChatMessageResponse editMessage(@DestinationVariable Long roomId, @Payload
+    ChatMessageEditRequest request, Principal principal) {
+        ChatMessageResponse response = chatMessageService.editMessage(roomId, request,
+            principal.getName());
 
-		messagingTemplate.convertAndSend("/topic/chat/" + roomId, response);
+        messagingTemplate.convertAndSend("/topic/chat/" + roomId, response);
 
-		return response;
-	}
+        return response;
+    }
 
-	@GetMapping("/chat/search/{roomId}")
-	public Page<ChatMessageSearchResponse> searchMessages(
-		@AuthenticationPrincipal MemberDetails memberDetails,
-		@PathVariable("roomId") Long roomId,
-		@RequestParam("keyword") String keyword,
-		@RequestParam(defaultValue = "0") int page,
-		@RequestParam(defaultValue = "10") int size
-	) {
-		ChatMessageSearchRequest request = ChatMessageSearchRequest.of(keyword, page, size);
+    @GetMapping("/chat/search/{roomId}")
+    public Slice<ChatMessageSearchResponse> searchMessages(
+        @AuthenticationPrincipal MemberDetails memberDetails,
+        @PathVariable("roomId") Long roomId,
+        @RequestParam("keyword") String keyword,
+        @RequestParam(required = false) Long lastMessageId,
+        @RequestParam(defaultValue = "10") int size
+    ) throws JsonProcessingException {  // writeValueAsString 때문에 예외 선언 필요
+        ChatMessageSearchRequest request = ChatMessageSearchRequest.of(keyword, lastMessageId,
+            size);
+        Slice<ChatMessageSearchResponse> result = chatMessageService.searchMessages(
+            memberDetails.getId(), roomId, request);
 
-		return chatMessageService.searchMessages(memberDetails.getId(), roomId, request);
-	}
+        return result;
+    }
 
-	@GetMapping("/{roomId}/messages")
-	public ChatScrollResponse getMessages(
-		@AuthenticationPrincipal MemberDetails memberDetails,
-		@PathVariable Long roomId,
-		@RequestParam(required = false) Long cursor,
-		@RequestParam(defaultValue = "30") int size
-	) {
-		return chatMessageService.getMessagesByRoomId(memberDetails.getId(), roomId, cursor, size);
-	}
+    @GetMapping("/{roomId}/messages")
+    public ChatScrollResponse getMessages(
+        @AuthenticationPrincipal MemberDetails memberDetails,
+        @PathVariable Long roomId,
+        @RequestParam(required = false) Long cursor,
+        @RequestParam(defaultValue = "30") int size
+    ) {
+        return chatMessageService.getMessagesByRoomId(memberDetails.getId(), roomId, cursor, size);
+    }
 
-	@MessageMapping("/delete-message/{roomId}")
-	public ChatMessageResponse deleteMessage(@DestinationVariable Long roomId,
-		@Payload Long messageId,
-		Principal principal) {
-		ChatMessageResponse response = chatMessageService.deleteMessage(roomId, messageId,
-			principal.getName());
+    @MessageMapping("/delete-message/{roomId}")
+    public ChatMessageResponse deleteMessage(@DestinationVariable Long roomId,
+        @Payload Long messageId,
+        Principal principal) {
+        ChatMessageResponse response = chatMessageService.deleteMessage(roomId, messageId,
+            principal.getName());
 
-		messagingTemplate.convertAndSend("/topic/chat/" + roomId, response);
+        messagingTemplate.convertAndSend("/topic/chat/" + roomId, response);
 
-		return response;
-	}
+        return response;
+    }
 
-	@PostMapping("/send-image")
-	public Long uploadImage(@RequestParam MultipartFile image) {
-		ImageFile imageFile = imageFileService.saveChatImage(image);
-		return imageFile.getImageId();
-	}
+    @PostMapping("/send-image")
+    public Long uploadImage(@RequestParam MultipartFile image) {
+        ImageFile imageFile = imageFileService.saveChatImage(image);
+        return imageFile.getImageId();
+    }
 
 }

--- a/backend/src/main/java/project/backend/domain/chat/chatmessage/app/ChatMessageService.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatmessage/app/ChatMessageService.java
@@ -1,15 +1,11 @@
 package project.backend.domain.chat.chatmessage.app;
 
 import jakarta.validation.Valid;
+import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import project.backend.domain.chat.chatmessage.dao.ChatMessageRepository;
@@ -19,14 +15,13 @@ import project.backend.domain.chat.chatmessage.dto.ChatMessageRequest;
 import project.backend.domain.chat.chatmessage.dto.ChatMessageResponse;
 import project.backend.domain.chat.chatmessage.dto.ChatMessageSearchRequest;
 import project.backend.domain.chat.chatmessage.dto.ChatMessageSearchResponse;
+import project.backend.domain.chat.chatmessage.dto.ChatMessageSearchSlice;
 import project.backend.domain.chat.chatmessage.dto.ChatScrollResponse;
 import project.backend.domain.chat.chatmessage.entity.ChatMessage;
 import project.backend.domain.chat.chatmessage.entity.ChatMessageSearch;
 import project.backend.domain.chat.chatmessage.entity.MessageType;
 import project.backend.domain.chat.chatmessage.mapper.ChatMessageMapper;
 import project.backend.domain.chat.chatroom.app.ChatRoomService;
-import project.backend.domain.chat.chatroom.dao.ChatParticipantRepository;
-import project.backend.domain.chat.chatroom.dao.ChatRoomRepository;
 import project.backend.domain.chat.chatroom.entity.ChatRoom;
 import project.backend.domain.imagefile.ImageFile;
 import project.backend.domain.imagefile.ImageFileService;
@@ -47,9 +42,7 @@ public class ChatMessageService {
     private final ChatRoomService chatRoomService;
     private final MemberService memberService;
     private final ImageFileService imageFileService;
-    private final ChatRoomRepository chatRoomRepository;
     private final ChatMessageSearchRepository chatMessageSearchRepository;
-    private final ChatParticipantRepository chatParticipantRepository;
 
     private final ChatMessageMapper messageMapper;
 
@@ -76,7 +69,6 @@ public class ChatMessageService {
 
         chatMessageRepository.save(message);
 
-        // 검색용 테이블에도 저장된 메시지의 id(pk), roomId, content를 다시 뽑아서 저장
         if (isSearchable(message)) {
             ChatMessageSearch searchMessage = messageMapper.toSearchEntity(message);
             chatMessageSearchRepository.save(searchMessage);
@@ -90,38 +82,38 @@ public class ChatMessageService {
     }
 
     @Transactional(readOnly = true)
-    public Page<ChatMessageSearchResponse> searchMessages(Long memberId, Long roomId,
+    public Slice<ChatMessageSearchResponse> searchMessages(Long memberId, Long roomId,
         @Valid ChatMessageSearchRequest request) {
 
-        String keyword = request.getKeyword();
-        int page = request.getPage();
-        int size = request.getPageSize();
-        int offset = page * size;
-
         chatRoomService.validateParticipant(memberId, roomId);
-        // messageIds는 DESC 정렬 보장
-        List<Long> messageIds = chatMessageSearchRepository.searchIdsByKeywordAndRoomId(keyword,
-            roomId, size, offset);
 
-        long totalCount = chatMessageSearchRepository.countByKeywordAndRoomId(keyword, roomId);
+        List<Long> messageIds = chatMessageSearchRepository.searchIdsByKeywordAndRoomIdWithCursor(
+            request.getKeyword(),
+            roomId,
+            request.getLastMessageId(),
+            request.getPageSize() + 1
+        );
 
-        // findByIdIn은 정렬 보장이 안되므로, chatMessages에 대한 정렬 필요
-        List<ChatMessage> chatMessages = chatMessageRepository.findByIdIn(
-            messageIds);
+        boolean hasNext = messageIds.size() > request.getPageSize();
+        if (hasNext) {
+            messageIds.remove(messageIds.size() - 1);
+        }
 
-        // chatMessage의 빠른 정렬 수행을 위해 Map으로 변환
-        Map<Long, ChatMessage> messageMap = chatMessages.stream()
-            .collect(Collectors.toMap(ChatMessage::getId, Function.identity()));
+        // 첫 요청일 때만 totalCount 계산
+        Long totalCount = null;
+        if (request.getLastMessageId() == null) {
+            totalCount = chatMessageSearchRepository.countByKeywordAndRoomId(
+                request.getKeyword(), roomId);
+        }
 
-        // messageIds의 정렬순서에 맞춰서 chatMessages 정렬 수행
-        List<ChatMessageSearchResponse> resultList = messageIds.stream()
-            .map(messageMap::get)
-            .filter(Objects::nonNull)
+        List<ChatMessageSearchResponse> resultList = chatMessageRepository.findByIdIn(messageIds)
+            .stream()
+            .sorted(Comparator.comparingInt(cm -> messageIds.indexOf(cm.getId())))
             .map(messageMapper::toSearchResponse)
-            .collect(Collectors.toList());
+            .toList();
 
-        // PageImpl 구체 클래스로 담아서 반환
-        return new PageImpl<>(resultList, PageRequest.of(page, size), totalCount);
+        return new ChatMessageSearchSlice(resultList,
+            PageRequest.of(0, request.getPageSize()), hasNext, totalCount);
     }
 
     @Transactional

--- a/backend/src/main/java/project/backend/domain/chat/chatmessage/dao/ChatMessageSearchRepository.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatmessage/dao/ChatMessageSearchRepository.java
@@ -9,25 +9,26 @@ import project.backend.domain.chat.chatmessage.entity.ChatMessageSearch;
 public interface ChatMessageSearchRepository extends JpaRepository<ChatMessageSearch, Long> {
 
     @Query(value = """
-        SELECT id FROM chat_message_search
+        SELECT id
+        FROM chat_message_search
         WHERE room_id = :roomId
-        AND MATCH(content) AGAINST (:keyword IN NATURAL LANGUAGE MODE)
+          AND MATCH(content) AGAINST (:keyword IN NATURAL LANGUAGE MODE)
+          AND (:lastMessageId IS NULL OR id < :lastMessageId)
         ORDER BY id DESC
-        LIMIT :limit OFFSET :offset
+        LIMIT :limit
         """, nativeQuery = true)
-        // 페이지 하나를 어떻게 구성할것인지 limit: 한 페이지에 담을 결과 개수, offset: 시작 위치
-    List<Long> searchIdsByKeywordAndRoomId(
+    List<Long> searchIdsByKeywordAndRoomIdWithCursor(
         @Param("keyword") String keyword,
         @Param("roomId") Long roomId,
-        @Param("limit") int limit,
-        @Param("offset") int offset
+        @Param("lastMessageId") Long lastMessageId,
+        @Param("limit") int limit
     );
 
     @Query(value = """
         SELECT COUNT(*)
         FROM chat_message_search
         WHERE room_id = :roomId
-        AND MATCH(content) AGAINST (:keyword IN BOOLEAN MODE)
+        AND MATCH(content) AGAINST (:keyword IN NATURAL LANGUAGE MODE)
         """, nativeQuery = true)
     long countByKeywordAndRoomId(@Param("keyword") String keyword, @Param("roomId") Long roomId);
 }

--- a/backend/src/main/java/project/backend/domain/chat/chatmessage/dto/ChatMessageSearchRequest.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatmessage/dto/ChatMessageSearchRequest.java
@@ -1,24 +1,21 @@
 package project.backend.domain.chat.chatmessage.dto;
 
-import lombok.Builder;
 import lombok.Getter;
 
 @Getter
-@Builder
 public class ChatMessageSearchRequest {
 
-	private String keyword;
+    private String keyword;
+    private Long lastMessageId;
+    private int pageSize;
 
-	private int page = 0;
+    public static ChatMessageSearchRequest of(String keyword, Long lastMessageId, int pageSize) {
+        ChatMessageSearchRequest request = new ChatMessageSearchRequest();
+        request.keyword = keyword;
+        request.lastMessageId = lastMessageId;
+        request.pageSize = pageSize;
+        return request;
+    }
 
-	private int pageSize = 10;
-
-	public static ChatMessageSearchRequest of(String keyword, int page, int pageSize) {
-		return ChatMessageSearchRequest.builder()
-			.keyword(keyword)
-			.page(page)
-			.pageSize(pageSize)
-			.build();
-	}
 }
 

--- a/backend/src/main/java/project/backend/domain/chat/chatmessage/dto/ChatMessageSearchResponse.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatmessage/dto/ChatMessageSearchResponse.java
@@ -4,22 +4,21 @@ import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
 import project.backend.domain.chat.chatmessage.entity.MessageType;
-import project.backend.domain.imagefile.ImageFile;
 
 @Getter
 @Builder
 public class ChatMessageSearchResponse {
 
-	private Long messageId;
+    private Long messageId;
 
-	private String content;
+    private String content;
 
-	private MessageType type;
+    private MessageType type;
 
-	private String senderName;
+    private String senderName;
 
-	private String profileImageUrl;
+    private String profileImageUrl;
 
-	private LocalDateTime sendAt;
+    private LocalDateTime sendAt;
 }
 

--- a/backend/src/main/java/project/backend/domain/chat/chatmessage/dto/ChatMessageSearchSlice.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatmessage/dto/ChatMessageSearchSlice.java
@@ -1,0 +1,20 @@
+package project.backend.domain.chat.chatmessage.dto;
+
+import java.util.List;
+import lombok.Getter;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.SliceImpl;
+
+@Getter
+public class ChatMessageSearchSlice extends SliceImpl<ChatMessageSearchResponse> {
+
+    private final Long totalCount;
+
+    public ChatMessageSearchSlice(List<ChatMessageSearchResponse> content,
+        Pageable pageable,
+        boolean hasNext,
+        Long totalCount) {
+        super(content, pageable, hasNext);
+        this.totalCount = totalCount;
+    }
+}

--- a/frontend/src/components/SearchSideBar.jsx
+++ b/frontend/src/components/SearchSideBar.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import 'highlight.js/styles/github.css';
 
 const SearchSidebar = ({ 
@@ -6,20 +6,57 @@ const SearchSidebar = ({
   searchResults,
   isSearching,
   errorMessage,
-  currentPage,
-  totalPages,
-  totalElements,
+  hasNext,
+  totalCount,
   onClose,
-  onPageChange,
+  onSearch,
   onMessageClick
 }) => {
   const [hoveredIndex, setHoveredIndex] = useState(null);
   
-  // 페이지당 10개씩 표시
-  const itemsPerPage = 10;
+  // 커서 스택: 각 페이지의 마지막 메시지 ID를 저장
+  const [cursorStack, setCursorStack] = useState([null]); // [null, cursor1, cursor2, ...]
+  const [currentPageIndex, setCurrentPageIndex] = useState(0);
   
-  // 총 페이지 수 계산 (10개씩 끊어서)
-  const calculatedTotalPages = Math.ceil(totalElements / itemsPerPage);
+  // 총 페이지 수 계산 (예상치)
+  const estimatedTotalPages = totalCount ? Math.ceil(totalCount / 10) : '?';
+  
+  // 검색어 변경 시 커서 스택 초기화
+  useEffect(() => {
+    setCursorStack([null]);
+    setCurrentPageIndex(0);
+  }, [searchKeyword]);
+  
+  // 다음 페이지로 이동
+  const handleNextPage = () => {
+    if (!hasNext || searchResults.length === 0) return;
+    
+    // 현재 페이지의 마지막 메시지 ID를 커서로 저장
+    const lastMessageId = searchResults[searchResults.length - 1].messageId;
+    
+    // 새로운 커서를 스택에 추가
+    const newStack = [...cursorStack.slice(0, currentPageIndex + 1), lastMessageId];
+    setCursorStack(newStack);
+    setCurrentPageIndex(currentPageIndex + 1);
+    
+    // 다음 페이지 검색
+    onSearch(searchKeyword, lastMessageId);
+  };
+  
+  // 이전 페이지로 이동
+  const handlePrevPage = () => {
+    if (currentPageIndex === 0) return;
+    
+    const prevPageIndex = currentPageIndex - 1;
+    setCurrentPageIndex(prevPageIndex);
+    
+    // 이전 페이지의 커서로 검색 (0번째 페이지는 null)
+    const prevCursor = cursorStack[prevPageIndex];
+    onSearch(searchKeyword, prevCursor);
+  };
+  
+  // 현재 페이지 번호 (1부터 시작)
+  const currentPageNumber = currentPageIndex + 1;
   
   return (
     <div className="search-sidebar" style={{ 
@@ -62,7 +99,7 @@ const SearchSidebar = ({
         padding: '10px 15px 5px',
         borderBottom: '1px solid #f0f0f0'
       }}>
-        최신순으로 정렬됨 • 전체 {totalElements}개의 결과
+        최신순으로 정렬됨 • {totalCount ? `전체 ${totalCount}개의 결과` : '검색 중...'}
       </div>
 
       <div style={{ 
@@ -84,13 +121,13 @@ const SearchSidebar = ({
         }}>
           {errorMessage}
         </div>
-      ) : totalElements === 0 ? (
+      ) : !searchResults || searchResults.length === 0 ? (
         <div style={{ textAlign: 'center', padding: '20px' }}>검색 결과가 없습니다.</div>
       ) : (
         <>
           {searchResults.map((msg, index) => (
             <div 
-              key={index} 
+              key={msg.messageId} 
               onClick={() => onMessageClick && onMessageClick(msg.messageId)}
               onMouseEnter={() => setHoveredIndex(index)}
               onMouseLeave={() => setHoveredIndex(null)}
@@ -183,50 +220,55 @@ const SearchSidebar = ({
       )}
       </div>
 
-      {calculatedTotalPages > 1 && (
+      {/* 페이지네이션 버튼 - 결과가 있을 때만 표시 */}
+      {searchResults && searchResults.length > 0 && (
         <div style={{ 
           display: 'flex', 
           justifyContent: 'center', 
+          alignItems: 'center',
           padding: '15px',
-          borderTop: '1px solid #f0f0f0'
+          borderTop: '1px solid #f0f0f0',
+          gap: '10px'
         }}>
           <button
-            onClick={() => onPageChange(currentPage - 1)}
-            disabled={currentPage === 0}
+            onClick={handlePrevPage}
+            disabled={currentPageIndex === 0}
             style={{ 
-              margin: '0 5px', 
               padding: '8px 15px',
-              cursor: currentPage === 0 ? 'default' : 'pointer', 
-              opacity: currentPage === 0 ? 0.5 : 1,
+              cursor: currentPageIndex === 0 ? 'not-allowed' : 'pointer', 
+              opacity: currentPageIndex === 0 ? 0.5 : 1,
               border: '1px solid #ccc',
               borderRadius: '4px',
-              backgroundColor: 'white'
+              backgroundColor: 'white',
+              fontWeight: '500'
             }}
           >
-            이전
+            ← 이전
           </button>
+          
           <span style={{ 
-            margin: '0 10px', 
-            display: 'flex', 
-            alignItems: 'center',
-            fontSize: '14px'
+            fontSize: '14px',
+            color: '#333',
+            minWidth: '80px',
+            textAlign: 'center'
           }}>
-            {currentPage + 1} / {calculatedTotalPages}
+            {currentPageNumber} / {estimatedTotalPages}
           </span>
+          
           <button
-            onClick={() => onPageChange(currentPage + 1)}
-            disabled={currentPage === calculatedTotalPages - 1}
+            onClick={handleNextPage}
+            disabled={!hasNext}
             style={{ 
-              margin: '0 5px', 
               padding: '8px 15px',
-              cursor: currentPage === calculatedTotalPages - 1 ? 'default' : 'pointer', 
-              opacity: currentPage === calculatedTotalPages - 1 ? 0.5 : 1,
+              cursor: !hasNext ? 'not-allowed' : 'pointer', 
+              opacity: !hasNext ? 0.5 : 1,
               border: '1px solid #ccc',
               borderRadius: '4px',
-              backgroundColor: 'white'
+              backgroundColor: 'white',
+              fontWeight: '500'
             }}
           >
-            다음
+            다음 →
           </button>
         </div>
       )}

--- a/frontend/src/pages/ChatRoom.jsx
+++ b/frontend/src/pages/ChatRoom.jsx
@@ -440,12 +440,12 @@ const ChatRoom = () => {
   const [searchKeyword, setSearchKeyword] = useState('');
   const [searchResults, setSearchResults] = useState([]);
   const [isSearching, setIsSearching] = useState(false);
-  const [currentPage, setCurrentPage] = useState(0);
-  const [totalPages, setTotalPages] = useState(0);
-  const [totalElements, setTotalElements] = useState(0);
+  const [searchHasNext, setSearchHasNext] = useState(false);
+  const [searchTotalCount, setSearchTotalCount] = useState(null);
   const [errorMessage, setErrorMessage] = useState(null);
+  
 
-  const handleSearch = async (keyword, page = 0) => {
+  const handleSearch = async (keyword, lastMessageId = null) => {
     if (!roomId || !initState.isRoomValidated) {
       setErrorMessage('채팅방이 아직 로딩 중입니다. 잠시 후 다시 시도해주세요.');
       return;
@@ -453,12 +453,24 @@ const ChatRoom = () => {
 
     setIsSearching(true);
     setShowSearchSidebar(true);
-    setSearchKeyword(keyword);
+    if (keyword !== searchKeyword) {
+      setSearchKeyword(keyword);
+      setSearchTotalCount(null);
+    }
     setErrorMessage(null);
 
     try {
+      const params = {
+        keyword: keyword,
+        pageSize: 10
+      };
+
+      if (lastMessageId) {
+        params.lastMessageId = lastMessageId;
+      }
+
       const response = await axiosInstance.get(`/chat/search/${roomId}`, {
-        params: { keyword, page, size: 10 }
+        params: params
       });
 
       const data = response.data;
@@ -471,12 +483,16 @@ const ChatRoom = () => {
       });
 
       setSearchResults(validatedResults);
-      setCurrentPage(data.pageable?.pageNumber || 0);
-      setTotalPages(data.totalPages || 0);
-      setTotalElements(data.totalElements || 0);
+      setSearchHasNext(!data.last);
+
+      if (lastMessageId === null && data.totalCount !== undefined) {
+        setSearchTotalCount(data.totalCount);
+      }
+
     } catch (err) {
       console.error('Search error:', err);
       setErrorMessage(err.response?.data?.message || '검색 중 오류가 발생했습니다.');
+      setSearchResults([]);
     } finally {
       setIsSearching(false);
     }
@@ -817,15 +833,14 @@ const ChatRoom = () => {
         {/* 검색 사이드바 */}
         {showSearchSidebar && (
           <SearchSidebar
+            totalCount={searchTotalCount}
+            onSearch={handleSearch} 
             searchKeyword={searchKeyword}
             searchResults={searchResults}
             isSearching={isSearching}
             errorMessage={errorMessage}
-            currentPage={currentPage}
-            totalPages={totalPages}
-            totalElements={totalElements}
+            hasNext={searchHasNext}
             onClose={() => setShowSearchSidebar(false)}
-            onPageChange={(page) => handleSearch(searchKeyword, page)}
             onMessageClick={scrollToMessage}
           />
         )}


### PR DESCRIPTION
- 이전페이지는 메모리의 cursorStack으로 관리

## 🛰️ Issue Number
close #170 

## 🪐 작업 내용
- 기존 offset 기반 검색 페이지네이션을 cursor 기반으로 변경
  - 최신 메시지 기준으로 lastMessageId를 커서로 사용
  - 다음 페이지 요청 시, 마지막 메시지 ID보다 작은 메시지를 조회
- 이전 페이지 조회 지원
  - 클라이언트에서 cursorStack으로 각 페이지의 마지막 메시지 ID 관리
  - 이전 페이지 클릭 시, 스택에서 이전 페이지 커서를 꺼내 서버에 요청
- ChatMessageSearchRequest 구조 변경
  - lastMessageId, pageSize 필드 추가
- ChatMessageService.searchMessages 로직 변경
  - findByIdIn 정렬 유지
  - 첫 요청 시에만 totalCount 계산

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [ ] Label을 지정했나요?