### PR TITLE
Refactor: 검색 색인 비동기 분리 및 배치 재처리 도입

### DIFF
--- a/backend/src/main/java/project/backend/BackendApplication.java
+++ b/backend/src/main/java/project/backend/BackendApplication.java
@@ -2,17 +2,15 @@ package project.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.scheduling.annotation.EnableAsync;
 
-@EnableAsync
 @SpringBootApplication
 public class BackendApplication {
 
-	public static void main(String[] args) {
+    public static void main(String[] args) {
 
-		SpringApplication.run(BackendApplication.class, args);
+        SpringApplication.run(BackendApplication.class, args);
 
-	}
+    }
 
 
 }

--- a/backend/src/main/java/project/backend/domain/chat/chatmessage/app/ChatMessageSearchBatch.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatmessage/app/ChatMessageSearchBatch.java
@@ -1,0 +1,50 @@
+package project.backend.domain.chat.chatmessage.app;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import project.backend.domain.chat.chatmessage.dao.ChatMessageRepository;
+import project.backend.domain.chat.chatmessage.entity.ChatMessage;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ChatMessageSearchBatch {
+
+    private final JdbcTemplate jdbcTemplate;
+    private final ChatMessageRepository chatMessageRepository;
+    private final MeterRegistry meterRegistry;
+
+    @Scheduled(fixedDelay = 300000)  // 5분
+    public void reindexFailedMessages() {
+        List<ChatMessage> missing = chatMessageRepository
+            .findMissingSearchIndex(
+                LocalDateTime.now().minusMinutes(5),
+                PageRequest.of(0, 100)
+            );
+
+        if (missing.isEmpty()) {
+            return;
+        }
+
+        for (ChatMessage message : missing) {
+            try {
+                jdbcTemplate.update(
+                    "INSERT INTO chat_message_search (id, room_id, content) VALUES (?, ?, ?)",
+                    message.getId(),
+                    message.getChatRoomId(),
+                    message.getContent()
+                );
+            } catch (Exception e) {
+                log.error("[배치색인실패] messageId: {}", message.getId());
+                meterRegistry.counter("chat.search.index.fail").increment();
+            }
+        }
+    }
+}

--- a/backend/src/main/java/project/backend/domain/chat/chatmessage/app/ChatMessageService.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatmessage/app/ChatMessageService.java
@@ -4,6 +4,7 @@ import jakarta.validation.Valid;
 import java.util.Comparator;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -17,6 +18,7 @@ import project.backend.domain.chat.chatmessage.dto.ChatMessageSearchRequest;
 import project.backend.domain.chat.chatmessage.dto.ChatMessageSearchResponse;
 import project.backend.domain.chat.chatmessage.dto.ChatMessageSearchSlice;
 import project.backend.domain.chat.chatmessage.dto.ChatScrollResponse;
+import project.backend.domain.chat.chatmessage.dto.event.ChatMessageSavedEvent;
 import project.backend.domain.chat.chatmessage.entity.ChatMessage;
 import project.backend.domain.chat.chatmessage.entity.ChatMessageSearch;
 import project.backend.domain.chat.chatmessage.entity.MessageType;
@@ -43,6 +45,7 @@ public class ChatMessageService {
     private final MemberService memberService;
     private final ImageFileService imageFileService;
     private final ChatMessageSearchRepository chatMessageSearchRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     private final ChatMessageMapper messageMapper;
 
@@ -70,8 +73,7 @@ public class ChatMessageService {
         chatMessageRepository.save(message);
 
         if (isSearchable(message)) {
-            ChatMessageSearch searchMessage = messageMapper.toSearchEntity(message);
-            chatMessageSearchRepository.save(searchMessage);
+            eventPublisher.publishEvent(ChatMessageSavedEvent.from(message));
         }
 
         return messageMapper.toResponse(message);
@@ -99,7 +101,6 @@ public class ChatMessageService {
             messageIds.remove(messageIds.size() - 1);
         }
 
-        // 첫 요청일 때만 totalCount 계산
         Long totalCount = null;
         if (request.getLastMessageId() == null) {
             totalCount = chatMessageSearchRepository.countByKeywordAndRoomId(

--- a/backend/src/main/java/project/backend/domain/chat/chatmessage/dao/ChatMessageRepository.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatmessage/dao/ChatMessageRepository.java
@@ -1,19 +1,29 @@
 package project.backend.domain.chat.chatmessage.dao;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import project.backend.domain.chat.chatmessage.entity.ChatMessage;
 
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
 
-	List<ChatMessage> findByIdIn(List<Long> ids);
+    List<ChatMessage> findByIdIn(List<Long> ids);
 
-	// 채팅방 입장 시, cursor가 null값이므로, 초반 메시지를 가져올 메서드
-	List<ChatMessage> findByChatRoom_IdOrderByIdDesc(Long roomId, Pageable pageable);
+    // 채팅방 입장 시, cursor가 null값이므로, 초반 메시지를 가져올 메서드
+    List<ChatMessage> findByChatRoom_IdOrderByIdDesc(Long roomId, Pageable pageable);
 
-	// 커서기반 무한스크롤 메서드
-	List<ChatMessage> findByChatRoom_IdAndIdLessThanOrderByIdDesc(Long roomId, Long cursor,
-		Pageable pageable);
+    // 커서기반 무한스크롤 메서드
+    List<ChatMessage> findByChatRoom_IdAndIdLessThanOrderByIdDesc(Long roomId, Long cursor,
+        Pageable pageable);
 
+    @Query("""
+        SELECT cm FROM ChatMessage cm
+        LEFT JOIN ChatMessageSearch cms ON cm.id = cms.id
+        WHERE cm.sendAt > :from
+        AND cms.id IS NULL
+        """)
+    List<ChatMessage> findMissingSearchIndex(@Param("from") LocalDateTime from, Pageable pageable);
 }

--- a/backend/src/main/java/project/backend/domain/chat/chatmessage/dto/event/ChatMessageSavedEvent.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatmessage/dto/event/ChatMessageSavedEvent.java
@@ -1,0 +1,18 @@
+package project.backend.domain.chat.chatmessage.dto.event;
+
+import project.backend.domain.chat.chatmessage.entity.ChatMessage;
+
+public record ChatMessageSavedEvent(
+    Long messageId,
+    Long roomId,
+    String content
+) {
+
+    public static ChatMessageSavedEvent from(ChatMessage message) {
+        return new ChatMessageSavedEvent(
+            message.getId(),
+            message.getChatRoomId(),
+            message.getContent()
+        );
+    }
+}

--- a/backend/src/main/java/project/backend/domain/chat/chatmessage/entity/ChatMessage.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatmessage/entity/ChatMessage.java
@@ -29,53 +29,57 @@ import project.backend.domain.member.entity.Member;
 @Builder
 public class ChatMessage {
 
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "message_id")
-	private Long id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "message_id")
+    private Long id;
 
-	@ManyToOne
-	@JoinColumn(name = "member_id")
-	private Member sender;
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member sender;
 
-	@ManyToOne
-	@JoinColumn(name = "room_id")
-	private ChatRoom chatRoom;
+    @ManyToOne
+    @JoinColumn(name = "room_id")
+    private ChatRoom chatRoom;
 
-	@Lob
-	@Column(columnDefinition = "TEXT")
-	private String content;
+    @Lob
+    @Column(columnDefinition = "TEXT")
+    private String content;
 
-	private LocalDateTime sendAt;
+    private LocalDateTime sendAt;
 
-	@Enumerated(EnumType.STRING)
-	private MessageType type;
+    @Enumerated(EnumType.STRING)
+    private MessageType type;
 
-	private String codeLanguage; //추가, 문법마다 다르게 하이라이팅을 하기 위함
+    private String codeLanguage;
 
-	@OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
-	@JoinColumn(name = "chat_image_id")
-	private ImageFile chatImage;
+    @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name = "chat_image_id")
+    private ImageFile chatImage;
 
-	@Builder.Default
-	@Enumerated(EnumType.STRING)
-	private MessageStatus status = MessageStatus.NO_CHANGE;
+    @Builder.Default
+    @Enumerated(EnumType.STRING)
+    private MessageStatus status = MessageStatus.NO_CHANGE;
 
-	public void updateContent(String newContent) {
-		if (newContent != null) {
-			content = newContent;
-			status = MessageStatus.EDITED;
-		}
-	}
+    public Long getChatRoomId() {
+        return chatRoom.getId();
+    }
 
-	public void updateLanguage(String language) {
-		if (language != null) {
-			codeLanguage = language;
-			status = MessageStatus.EDITED;
-		}
-	}
+    public void updateContent(String newContent) {
+        if (newContent != null) {
+            content = newContent;
+            status = MessageStatus.EDITED;
+        }
+    }
 
-	public void delete() {
-		status = MessageStatus.DELETED;
-	}
+    public void updateLanguage(String language) {
+        if (language != null) {
+            codeLanguage = language;
+            status = MessageStatus.EDITED;
+        }
+    }
+
+    public void delete() {
+        status = MessageStatus.DELETED;
+    }
 }

--- a/backend/src/main/java/project/backend/domain/chat/chatmessage/entity/ChatMessageSearch.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatmessage/entity/ChatMessageSearch.java
@@ -14,29 +14,28 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ChatMessageSearch {
 
-	@Id
-	// chat_message의 id를 그대로 넣어줌
-	private Long id;
+    @Id
+    private Long id;
 
-	@Column(name = "room_id", nullable = false)
-	private Long roomId;
-	
-	@Lob
-	@Column(columnDefinition = "TEXT", nullable = false)
-	private String content;
+    @Column(name = "room_id", nullable = false)
+    private Long roomId;
 
-	@Builder
-	public ChatMessageSearch(Long id, Long roomId, String content) {
-		this.id = id;
-		this.roomId = roomId;
-		this.content = content;
-	}
+    @Lob
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String content;
 
-	public void updateContent(String content) {
-		this.content = content;
-	}
+    @Builder
+    public ChatMessageSearch(Long id, Long roomId, String content) {
+        this.id = id;
+        this.roomId = roomId;
+        this.content = content;
+    }
 
-	public void deleteContent() {
-		this.content = "";
-	}
+    public void updateContent(String content) {
+        this.content = content;
+    }
+
+    public void deleteContent() {
+        this.content = "";
+    }
 }

--- a/backend/src/main/java/project/backend/domain/chat/chatmessage/listener/ChatMessageSearchEventListener.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatmessage/listener/ChatMessageSearchEventListener.java
@@ -1,0 +1,38 @@
+package project.backend.domain.chat.chatmessage.listener;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+import project.backend.domain.chat.chatmessage.dao.ChatMessageSearchRepository;
+import project.backend.domain.chat.chatmessage.dto.event.ChatMessageSavedEvent;
+import project.backend.domain.chat.chatmessage.entity.ChatMessageSearch;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ChatMessageSearchEventListener {
+
+    private final ChatMessageSearchRepository chatMessageSearchRepository;
+    private final MeterRegistry meterRegistry;
+
+    @Async("chatSearchEventExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleSearchIndex(ChatMessageSavedEvent event) {
+        try {
+            chatMessageSearchRepository.save(
+                ChatMessageSearch.builder()
+                    .id(event.messageId())
+                    .roomId(event.roomId())
+                    .content(event.content())
+                    .build()
+            );
+        } catch (Exception e) {
+            log.error("[검색색인실패] messageId: {}", event.messageId());
+            meterRegistry.counter("chat.search.index.fail").increment();
+        }
+    }
+}

--- a/backend/src/main/java/project/backend/global/asyncConfig/AsyncConfig.java
+++ b/backend/src/main/java/project/backend/global/asyncConfig/AsyncConfig.java
@@ -1,4 +1,4 @@
-package project.backend.global.AsyncConfig;
+package project.backend.global.asyncConfig;
 
 import java.util.concurrent.Executor;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +21,18 @@ public class AsyncConfig {
         executor.setMaxPoolSize(20); // 최대 스레드 수
         executor.setQueueCapacity(100); // 작업 대기열
         executor.setThreadNamePrefix("ChatRoomEvent-");
+        executor.setRejectedExecutionHandler(rejectExecutionHandler);
+        executor.initialize();
+        return executor;
+    }
+
+    @Bean(name = "chatSearchEventExecutor")
+    public Executor getChatSearchEventExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(5);
+        executor.setQueueCapacity(50);
+        executor.setThreadNamePrefix("ChatSearchEvent-");
         executor.setRejectedExecutionHandler(rejectExecutionHandler);
         executor.initialize();
         return executor;

--- a/backend/src/main/java/project/backend/global/asyncConfig/RejectExecutionHandler.java
+++ b/backend/src/main/java/project/backend/global/asyncConfig/RejectExecutionHandler.java
@@ -1,4 +1,4 @@
-package project.backend.global.AsyncConfig;
+package project.backend.global.asyncConfig;
 
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;


### PR DESCRIPTION
## 🛰️ Issue Number
close #179

## 🪐 작업 내용
- 채팅 메시지 저장 시 검색 색인을 메인 트랜잭션에서 분리
- AFTER_COMMIT 이벤트 리스너 + @Async로 비동기 색인 처리
- 색인 실패 시 5분 주기 배치가 LEFT JOIN으로 누락 탐지 후 재처리
- 검색 색인 전용 스레드 풀(chatSearchEventExecutor) 추가
- 색인 실패 메트릭 수집 (chat.search.index.listener.fail / batch.fail)

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?