### PR TITLE
Feat: 채팅 안읽은 메시지 수 관리 기능 구현

### DIFF
--- a/backend/src/main/java/project/backend/domain/chat/chatmessage/app/ChatMessageService.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatmessage/app/ChatMessageService.java
@@ -41,10 +41,12 @@ import project.backend.global.metric.TimeTrace;
 public class ChatMessageService {
 
     private final ChatMessageRepository chatMessageRepository;
+    private final ChatMessageSearchRepository chatMessageSearchRepository;
+
     private final ChatRoomService chatRoomService;
     private final MemberService memberService;
     private final ImageFileService imageFileService;
-    private final ChatMessageSearchRepository chatMessageSearchRepository;
+
     private final ApplicationEventPublisher eventPublisher;
 
     private final ChatMessageMapper messageMapper;
@@ -71,6 +73,8 @@ public class ChatMessageService {
         }
 
         chatMessageRepository.save(message);
+
+        chatRoomService.incrementUnreadCountForOfflineMembers(roomId, sender.getId());
 
         if (isSearchable(message)) {
             eventPublisher.publishEvent(ChatMessageSavedEvent.from(message));

--- a/backend/src/main/java/project/backend/domain/chat/chatmessage/dao/ChatMessageRepository.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatmessage/dao/ChatMessageRepository.java
@@ -2,6 +2,7 @@ package project.backend.domain.chat.chatmessage.dao;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -26,4 +27,6 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> 
         AND cms.id IS NULL
         """)
     List<ChatMessage> findMissingSearchIndex(@Param("from") LocalDateTime from, Pageable pageable);
+
+    Optional<ChatMessage> findTopByChatRoom_IdOrderByIdDesc(Long roomId);
 }

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/api/ChatRoomController.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/api/ChatRoomController.java
@@ -38,93 +38,101 @@ import project.backend.domain.chat.chatroom.dto.RoomInfoResponse;
 @RequestMapping("/chat-rooms")
 public class ChatRoomController {
 
-	private final ChatRoomService chatRoomService;
+    private final ChatRoomService chatRoomService;
 
-	@PostMapping
-	@ResponseStatus(HttpStatus.CREATED)
-	public ChatRoomSimpleResponse createChatRoom(@Valid @RequestBody ChatRoomRequest request,
-		@AuthenticationPrincipal MemberDetails memberDetails) {
-		Long ownerId = memberDetails.getId();
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public ChatRoomSimpleResponse createChatRoom(@Valid @RequestBody ChatRoomRequest request,
+        @AuthenticationPrincipal MemberDetails memberDetails) {
+        Long ownerId = memberDetails.getId();
 
-		return chatRoomService.createChatRoom(request, ownerId);
-	}
+        return chatRoomService.createChatRoom(request, ownerId);
+    }
 
-	@PostMapping("/join")
-	public InviteJoinResponse joinChatRoom(@RequestBody InviteJoinRequest request,
-		@AuthenticationPrincipal MemberDetails memberDetails
-	) {
-		return chatRoomService.joinChatRoom(request.getInviteCode(), memberDetails.getId());
-	}
+    @PostMapping("/join")
+    public InviteJoinResponse joinChatRoom(@RequestBody InviteJoinRequest request,
+        @AuthenticationPrincipal MemberDetails memberDetails
+    ) {
+        return chatRoomService.joinChatRoom(request.getInviteCode(), memberDetails.getId());
+    }
 
-	@GetMapping("/recent")
-	public RecentChatRoomResponse getRecentRoomInviteCode(
-		@AuthenticationPrincipal MemberDetails memberDetails) {
-		String inviteCode = chatRoomService.getRecentRoomInviteCode(
-			memberDetails.getId());
-		return new RecentChatRoomResponse(inviteCode);
-	}
+    @GetMapping("/recent")
+    public RecentChatRoomResponse getRecentRoomInviteCode(
+        @AuthenticationPrincipal MemberDetails memberDetails) {
+        String inviteCode = chatRoomService.getRecentRoomInviteCode(
+            memberDetails.getId());
+        return new RecentChatRoomResponse(inviteCode);
+    }
 
-	@GetMapping
-	public Page<RoomInfoResponse> getChatRooms(
-		@AuthenticationPrincipal MemberDetails memberDetails,
-		@PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+    @GetMapping
+    public Page<RoomInfoResponse> getChatRooms(
+        @AuthenticationPrincipal MemberDetails memberDetails,
+        @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
 
-		Long memberId = memberDetails.getId();
-		return chatRoomService.findChatRoomsByMemberId(memberId, pageable);
-	}
+        Long memberId = memberDetails.getId();
+        return chatRoomService.findChatRoomsByMemberId(memberId, pageable);
+    }
 
-	@GetMapping("/{roomId}/participants")
-	public List<ChatParticipantResponse> getParticipants(
-		@PathVariable Long roomId,
-		@AuthenticationPrincipal MemberDetails memberDetails) {
+    @GetMapping("/{roomId}/participants")
+    public List<ChatParticipantResponse> getParticipants(
+        @PathVariable Long roomId,
+        @AuthenticationPrincipal MemberDetails memberDetails) {
 
-		return chatRoomService.getParticipants(memberDetails.getId(), roomId);
-	}
+        return chatRoomService.getParticipants(memberDetails.getId(), roomId);
+    }
 
-	// 자신이 만든 채팅방 가져오기 -> 주후 인증객체 id로 조회가능 할듯(Authentication)
-	@GetMapping("/mine/{memberId}")
-	public Page<MyChatRoomResponse> findMyAllChatRooms(@PathVariable Long memberId,
-		@PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
-		log.info("자신이 만든 채팅방 요청: memberId = {}", memberId);
-		return chatRoomService.findAllRoomsByOwnerId(memberId, pageable);
-	}
+    // 자신이 만든 채팅방 가져오기 -> 주후 인증객체 id로 조회가능 할듯(Authentication)
+    @GetMapping("/mine/{memberId}")
+    public Page<MyChatRoomResponse> findMyAllChatRooms(@PathVariable Long memberId,
+        @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
+        log.info("자신이 만든 채팅방 요청: memberId = {}", memberId);
+        return chatRoomService.findAllRoomsByOwnerId(memberId, pageable);
+    }
 
-	@DeleteMapping("/{roomId}/leave")
-	@ResponseStatus(HttpStatus.NO_CONTENT)
-	public void leaveChatRoom(@PathVariable Long roomId,
-		@AuthenticationPrincipal MemberDetails memberDetails) {
-		chatRoomService.leaveChatRoom(roomId, memberDetails.getId());
-	}
+    @DeleteMapping("/{roomId}/leave")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void leaveChatRoom(@PathVariable Long roomId,
+        @AuthenticationPrincipal MemberDetails memberDetails) {
+        chatRoomService.leaveChatRoom(roomId, memberDetails.getId());
+    }
 
-	//채팅방 입장
-	@GetMapping("/{inviteCode}")
-	public EntryRoomResponse entryChatRoom(@PathVariable String inviteCode,
-		@AuthenticationPrincipal MemberDetails memberDetails) {
-		return chatRoomService.getEntryInfo(inviteCode, memberDetails.getId());
-	}
+    //채팅방 입장
+    @GetMapping("/{inviteCode}")
+    public EntryRoomResponse entryChatRoom(@PathVariable String inviteCode,
+        @AuthenticationPrincipal MemberDetails memberDetails) {
+        return chatRoomService.getEntryInfo(inviteCode, memberDetails.getId());
+    }
 
 
-	@GetMapping("/info/{inviteCode}")
-	public RoomInfoResponse getChatRoomDetails(@PathVariable String inviteCode,
-		@AuthenticationPrincipal MemberDetails memberDetails) {
-		return chatRoomService.getRoomInfo(inviteCode, memberDetails.getId());
-	}
+    @GetMapping("/info/{inviteCode}")
+    public RoomInfoResponse getChatRoomDetails(@PathVariable String inviteCode,
+        @AuthenticationPrincipal MemberDetails memberDetails) {
+        return chatRoomService.getRoomInfo(inviteCode, memberDetails.getId());
+    }
 
-	@DeleteMapping("/{roomId}")
-	public void deleteChatRoom(@PathVariable Long roomId,
-		@AuthenticationPrincipal MemberDetails memberDetails) {
-		chatRoomService.deleteChatRoom(roomId, memberDetails.getId());
-	}
+    @DeleteMapping("/{roomId}")
+    public void deleteChatRoom(@PathVariable Long roomId,
+        @AuthenticationPrincipal MemberDetails memberDetails) {
+        chatRoomService.deleteChatRoom(roomId, memberDetails.getId());
+    }
 
-	@PostMapping("/alarm/toggle/{roomId}")
-	public boolean toggleAlarm(@PathVariable Long roomId,
-		@AuthenticationPrincipal MemberDetails memberDetails) {
-		return chatRoomService.toggleAlarm(roomId, memberDetails.getId());
-	}
+    @PostMapping("/alarm/toggle/{roomId}")
+    public boolean toggleAlarm(@PathVariable Long roomId,
+        @AuthenticationPrincipal MemberDetails memberDetails) {
+        return chatRoomService.toggleAlarm(roomId, memberDetails.getId());
+    }
 
-	@GetMapping("/all")
-	public List<AllRoomsResponse> getAllRooms(
-		@AuthenticationPrincipal MemberDetails memberDetails) {
-		return chatRoomService.findAllRoomsByMemberId(memberDetails.getId());
-	}
+    @GetMapping("/all")
+    public List<AllRoomsResponse> getAllRooms(
+        @AuthenticationPrincipal MemberDetails memberDetails) {
+        return chatRoomService.findAllRoomsByMemberId(memberDetails.getId());
+    }
+
+    @PostMapping("/{roomId}/read")
+    public void markAsRead(
+        @PathVariable Long roomId,
+        @AuthenticationPrincipal MemberDetails memberDetails
+    ) {
+        chatRoomService.markAsRead(roomId, memberDetails.getId());
+    }
 }

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomService.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomService.java
@@ -12,6 +12,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import project.backend.domain.chat.chatmessage.dao.ChatMessageRepository;
@@ -48,274 +49,315 @@ import project.backend.global.metric.TimeTrace;
 @RequiredArgsConstructor
 public class ChatRoomService {
 
-	private final ChatRoomRepository chatRoomRepository;
-	private final ChatParticipantRepository chatParticipantRepository;
-	private final ChatRoomMapper chatRoomMapper;
-	private final ChatMessageMapper chatMessageMapper;
-	private final MemberService memberService;
-	private final GitMessageService gitMessageService;
-	private final ApplicationEventPublisher eventPublisher;
-	private final ChatMessageRepository chatMessageRepository;
-	private final ChatRoomAlarmRepository chatRoomAlarmRepository;
-
-
-	@Value("${github.username}")
-	private String githubUsername;
-
-	@Transactional
-	public ChatRoomSimpleResponse createChatRoom(ChatRoomRequest request, Long ownerId) {
-		Member owner = memberService.getMemberById(ownerId);
-
-		ChatRoom chatRoom = chatRoomMapper.toEntity(request);
-
-		ChatParticipant chatParticipant = ChatParticipant.createOwner(owner, chatRoom);
-		chatRoom.addParticipant(chatParticipant);
-
-		ChatRoom savedRoom = chatRoomRepository.save(chatRoom);
-
-		createAlarm(ownerId, chatRoom.getId());
-
-		if (!request.getRepositoryUrl().isBlank()) {
-			gitMessageService.registerWebhook(request.getRepositoryUrl(),
-				savedRoom.getId(), owner.getId()); //웹훅 자동 등록
-			joinGitHubBot(savedRoom); //깃허브봇 채팅 참가
-		}
+    private final ChatRoomRepository chatRoomRepository;
+    private final ChatParticipantRepository chatParticipantRepository;
+    private final ChatRoomMapper chatRoomMapper;
+    private final ChatMessageMapper chatMessageMapper;
+    private final MemberService memberService;
+    private final GitMessageService gitMessageService;
+    private final ApplicationEventPublisher eventPublisher;
+    private final ChatMessageRepository chatMessageRepository;
+    private final ChatRoomAlarmRepository chatRoomAlarmRepository;
+
+    @Value("${github.username}")
+    private String githubUsername;
+
+    @Transactional
+    public ChatRoomSimpleResponse createChatRoom(ChatRoomRequest request, Long ownerId) {
+        Member owner = memberService.getMemberById(ownerId);
+
+        ChatRoom chatRoom = chatRoomMapper.toEntity(request);
+
+        ChatParticipant chatParticipant = ChatParticipant.createOwner(owner, chatRoom);
+        chatRoom.addParticipant(chatParticipant);
+
+        ChatRoom savedRoom = chatRoomRepository.save(chatRoom);
+
+        createAlarm(ownerId, chatRoom.getId());
+
+        if (!request.getRepositoryUrl().isBlank()) {
+            gitMessageService.registerWebhook(request.getRepositoryUrl(),
+                savedRoom.getId(), owner.getId()); //웹훅 자동 등록
+            joinGitHubBot(savedRoom); //깃허브봇 채팅 참가
+        }
+
+        return chatRoomMapper.toSimpleResponse(savedRoom, owner);
+    }
+
+    private void createAlarm(Long memberId, Long roomId) {
+        ChatRoomAlarm alarm = new ChatRoomAlarm(memberId, roomId);
+        chatRoomAlarmRepository.save(alarm);
+    }
+
+    private void joinGitHubBot(ChatRoom room) {
+        Member githubBot = memberService.getMemberByUsername(githubUsername);
+        ChatParticipant gitParticipant = ChatParticipant.of(githubBot, room);
+        room.addParticipant(gitParticipant);
+    }
+
+    @TimeTrace
+    @Transactional
+    public InviteJoinResponse joinChatRoom(String inviteCode, Long memberId) {
+        log.info("timetrace 적용");
+        ChatRoom room = getByInviteCode(inviteCode);
+        Member member = memberService.getMemberById(memberId);
 
-		return chatRoomMapper.toSimpleResponse(savedRoom, owner);
-	}
-
-	private void createAlarm(Long memberId, Long roomId) {
-		ChatRoomAlarm alarm = new ChatRoomAlarm(memberId, roomId);
-		chatRoomAlarmRepository.save(alarm);
-	}
+        handleParticipantJoin(room, member);
+        createAlarm(memberId, room.getId());
 
-	private void joinGitHubBot(ChatRoom room) {
-		Member githubBot = memberService.getMemberByUsername(githubUsername);
-		ChatParticipant gitParticipant = ChatParticipant.of(githubBot, room);
-		room.addParticipant(gitParticipant);
-	}
+        ChatMessage message = chatMessageMapper.toEntityWithJoinEvent(room, member,
+            LocalDateTime.now());
+        ChatMessage savedMessage = chatMessageRepository.save(message);
 
-	@TimeTrace
-	@Transactional
-	public InviteJoinResponse joinChatRoom(String inviteCode, Long memberId) {
-		log.info("timetrace 적용");
-		ChatRoom room = getByInviteCode(inviteCode);
-		Member member = memberService.getMemberById(memberId);
+        eventPublisher.publishEvent(
+            new JoinChatRoomEvent(room.getId(), memberId, member.getNickname(),
+                savedMessage.getId(), savedMessage.getSendAt()));
 
-		handleParticipantJoin(room, member);
-		createAlarm(memberId, room.getId());
+        return ChatRoomMapper.toInviteJoinResponse(room.getId(), room.getInviteCode(),
+            room.getName());
+    }
 
-		ChatMessage message = chatMessageMapper.toEntityWithJoinEvent(room, member,
-			LocalDateTime.now());
-		ChatMessage savedMessage = chatMessageRepository.save(message);
+    private void handleParticipantJoin(ChatRoom room, Member member) {
+        //참여중 여부와 관계없이 기존 참가 기록들을 확인
+        Optional<ChatParticipant> existingParticipant =
+            chatParticipantRepository.findByChatRoomIdAndParticipantId(
+                room.getId(), member.getId());
+
+        if (existingParticipant.isPresent()) {
+            ChatParticipant participant = existingParticipant.get();
+            if (participant.isActive()) {
+                throw new ChatRoomException(ChatRoomErrorCode.ALREADY_PARTICIPANT);
+            }
+            participant.rejoin();
+        } else {
+            ChatParticipant chatParticipant = ChatParticipant.of(member, room);
+            room.addParticipant(chatParticipant);
+        }
+    }
+
+
+    @Transactional(readOnly = true)
+    public String getRecentRoomInviteCode(Long memberId) {
+        Long roomId = memberService.getMemberById(memberId).getRecentRoomId();
+
+        // 아무 채팅방에도 참여한 적이 없음 → 예외 던지기
+        if (roomId == null) {
+            throw new ChatRoomException(ChatRoomErrorCode.CHATROOM_NOT_EXIST);
+        }
+
+        return getRoomById(roomId).getInviteCode();
+    }
+
+    @Transactional(readOnly = true)
+    public Page<MyChatRoomResponse> findAllRoomsByOwnerId(Long memberId, Pageable pageable) {
+        Page<ChatRoom> allRoomsByOwnerId = chatRoomRepository.findAllRoomsByOwnerId(memberId,
+            pageable);
 
-		eventPublisher.publishEvent(
-			new JoinChatRoomEvent(room.getId(), memberId, member.getNickname(),
-				savedMessage.getId(), savedMessage.getSendAt()));
+        return allRoomsByOwnerId.map(ChatRoomMapper::toProfileResponse);
+    }
 
-		return ChatRoomMapper.toInviteJoinResponse(room.getId(), room.getInviteCode(),
-			room.getName());
-	}
 
-	private void handleParticipantJoin(ChatRoom room, Member member) {
-		//참여중 여부와 관계없이 기존 참가 기록들을 확인
-		Optional<ChatParticipant> existingParticipant =
-			chatParticipantRepository.findByChatRoomIdAndParticipantId(
-				room.getId(), member.getId());
+    @Transactional(readOnly = true)
+    public Page<RoomInfoResponse> findChatRoomsByMemberId(Long memberId, Pageable pageable) {
 
-		if (existingParticipant.isPresent()) {
-			ChatParticipant participant = existingParticipant.get();
-			if (participant.isActive()) {
-				throw new ChatRoomException(ChatRoomErrorCode.ALREADY_PARTICIPANT);
-			}
-			participant.rejoin();
-		} else {
-			ChatParticipant chatParticipant = ChatParticipant.of(member, room);
-			room.addParticipant(chatParticipant);
-		}
-	}
+        Page<ChatRoom> chatRooms = chatRoomRepository.findChatRoomsByParticipantId(
+            memberId, pageable);
 
+        return chatRooms.map(ChatRoomMapper::toListResponse);
+    }
 
-	@Transactional(readOnly = true)
-	public String getRecentRoomInviteCode(Long memberId) {
-		Long roomId = memberService.getMemberById(memberId).getRecentRoomId();
+    // 채팅방의 참가자 목록 조회
+    @Transactional(readOnly = true)
+    public List<ChatParticipantResponse> getParticipants(Long memberId, Long roomId) {
+        ChatRoom chatRoom = chatRoomRepository.findById(roomId)
+            .orElseThrow(() -> new ChatRoomException(ChatRoomErrorCode.CHATROOM_NOT_FOUND));
 
-		// 아무 채팅방에도 참여한 적이 없음 → 예외 던지기
-		if (roomId == null) {
-			throw new ChatRoomException(ChatRoomErrorCode.CHATROOM_NOT_EXIST);
-		}
+        validateParticipant(memberId, roomId);
 
-		return getRoomById(roomId).getInviteCode();
-	}
+        List<ChatParticipant> participants = chatParticipantRepository.findByChatRoom(chatRoom);
 
-	@Transactional(readOnly = true)
-	public Page<MyChatRoomResponse> findAllRoomsByOwnerId(Long memberId, Pageable pageable) {
-		Page<ChatRoom> allRoomsByOwnerId = chatRoomRepository.findAllRoomsByOwnerId(memberId,
-			pageable);
+        return participants.stream()
+            .map(ChatRoomMapper::toParticipantResponse).collect(Collectors.toList());
+    }
 
-		return allRoomsByOwnerId.map(ChatRoomMapper::toProfileResponse);
-	}
+    //임창인
+    @Transactional
+    public void leaveChatRoom(Long roomId, Long memberId) {
 
+        ChatParticipant participant = chatParticipantRepository.findByChatRoomIdAndParticipantIdAndIsActiveTrue(
+                roomId, memberId)
+            .orElseThrow(() -> new ChatRoomException(ChatRoomErrorCode.NOT_PARTICIPANT));
 
-	@Transactional(readOnly = true)
-	public Page<RoomInfoResponse> findChatRoomsByMemberId(Long memberId, Pageable pageable) {
+        if (participant.isOwner()) {
+            throw new ChatRoomException(ChatRoomErrorCode.OWNER_CANNOT_LEAVE);
+        }
 
-		Page<ChatRoom> chatRooms = chatRoomRepository.findChatRoomsByParticipantId(
-			memberId, pageable);
+        participant.leave();
 
-		return chatRooms.map(ChatRoomMapper::toListResponse);
-	}
+        Member member = memberService.getMemberById(memberId);
 
-	// 채팅방의 참가자 목록 조회
-	@Transactional(readOnly = true)
-	public List<ChatParticipantResponse> getParticipants(Long memberId, Long roomId) {
-		ChatRoom chatRoom = chatRoomRepository.findById(roomId)
-			.orElseThrow(() -> new ChatRoomException(ChatRoomErrorCode.CHATROOM_NOT_FOUND));
+        eventPublisher.publishEvent(
+            new LeaveChatRoomEvent(roomId, memberId, member.getNickname(),
+                LocalDateTime.now()));
 
-		validateParticipant(memberId, roomId);
+        updateRecentRoomAfterLeaving(memberId);
+    }
 
-		List<ChatParticipant> participants = chatParticipantRepository.findByChatRoom(chatRoom);
+    private void updateRecentRoomAfterLeaving(Long memberId) {
+        Member member = memberService.getMemberById(memberId);
 
-		return participants.stream()
-			.map(ChatRoomMapper::toParticipantResponse).collect(Collectors.toList());
-	}
+        Optional<ChatParticipant> mostRecentActiveRoom =
+            chatParticipantRepository.findTopByParticipantIdAndIsActiveTrueOrderByJoinAtDesc(
+                memberId);
 
-	//임창인
-	@Transactional
-	public void leaveChatRoom(Long roomId, Long memberId) {
+        if (mostRecentActiveRoom.isPresent()) {
+            member.setRecentRoomId(mostRecentActiveRoom.get().getChatRoom().getId());
+        } else {
+            member.setRecentRoomId(null);
+        }
 
-		ChatParticipant participant = chatParticipantRepository.findByChatRoomIdAndParticipantIdAndIsActiveTrue(
-				roomId, memberId)
-			.orElseThrow(() -> new ChatRoomException(ChatRoomErrorCode.NOT_PARTICIPANT));
+    }
 
-		if (participant.isOwner()) {
-			throw new ChatRoomException(ChatRoomErrorCode.OWNER_CANNOT_LEAVE);
-		}
+    private ChatRoom getByInviteCode(String inviteCode) {
+        return chatRoomRepository.findByInviteCode(inviteCode)
+            .orElseThrow(() -> new ChatRoomException(ChatRoomErrorCode.CHATROOM_NOT_FOUND));
+    }
 
-		participant.leave();
+    @Transactional(readOnly = true)
+    public ChatRoom getRoomById(Long roomId) {
+        return chatRoomRepository.findById(roomId)
+            .orElseThrow(() -> new ChatRoomException(ChatRoomErrorCode.CHATROOM_NOT_FOUND));
+    }
 
-		Member member = memberService.getMemberById(memberId);
-
-		eventPublisher.publishEvent(
-			new LeaveChatRoomEvent(roomId, memberId, member.getNickname(),
-				LocalDateTime.now()));
-
-		updateRecentRoomAfterLeaving(memberId);
-	}
-
-	private void updateRecentRoomAfterLeaving(Long memberId) {
-		Member member = memberService.getMemberById(memberId);
-
-		Optional<ChatParticipant> mostRecentActiveRoom =
-			chatParticipantRepository.findTopByParticipantIdAndIsActiveTrueOrderByJoinAtDesc(
-				memberId);
-
-		if (mostRecentActiveRoom.isPresent()) {
-			member.setRecentRoomId(mostRecentActiveRoom.get().getChatRoom().getId());
-		} else {
-			member.setRecentRoomId(null);
-		}
-
-	}
-
-	private ChatRoom getByInviteCode(String inviteCode) {
-		return chatRoomRepository.findByInviteCode(inviteCode)
-			.orElseThrow(() -> new ChatRoomException(ChatRoomErrorCode.CHATROOM_NOT_FOUND));
-	}
-
-	@Transactional(readOnly = true)
-	public ChatRoom getRoomById(Long roomId) {
-		return chatRoomRepository.findById(roomId)
-			.orElseThrow(() -> new ChatRoomException(ChatRoomErrorCode.CHATROOM_NOT_FOUND));
-	}
-
-	@Transactional
-	public EntryRoomResponse getEntryInfo(String inviteCode, Long memberId) {
-		ChatRoom room = getByInviteCode(inviteCode);
-		validateParticipant(memberId, room.getId());
-
-		memberService.getMemberById(memberId).setRecentRoomId(room.getId()); //recentRoomId 업데이트
-
-		Long ownerId = findOwnerId(room.getId());
-
-		boolean alarmEnable = chatRoomAlarmRepository.findEnabledByMemberIdAndRoomId(
-			memberId, room.getId());
-
-		return new EntryRoomResponse(room.getId(), room.getName(), ownerId, alarmEnable);
-	}
-
-	private Long findOwnerId(Long roomId) {
-		ChatParticipant owner = chatParticipantRepository.findByChatRoomIdAndIsOwnerTrue(roomId)
-			.orElseThrow(() -> new ChatRoomException(ChatRoomErrorCode.OWNER_NOT_FOUND));
-		return owner.getParticipant().getId();
-	}
-
-	@Transactional(readOnly = true)
-	public RoomInfoResponse getRoomInfo(String inviteCode, Long memberId) {
-		ChatRoom room = getByInviteCode(inviteCode);
-		return ChatRoomMapper.toListResponse(room);
-	}
-
-	public void validateParticipant(Long memberId, Long roomId) {
-		if (!chatParticipantRepository.
-			existsByParticipantIdAndChatRoomIdAndIsActiveTrue(memberId, roomId)) {
-			throw new ChatRoomException(ChatRoomErrorCode.NOT_PARTICIPANT);
-		}
-	}
-
-	@Transactional
-	public void deleteChatRoom(Long roomId, Long memberId) {
-		ChatRoom room = getRoomById(roomId);
-
-		ChatParticipant participant = chatParticipantRepository.findByChatRoomIdAndParticipantIdAndIsActiveTrue(
-				roomId, memberId)
-			.orElseThrow(() -> new ChatRoomException(ChatRoomErrorCode.NOT_PARTICIPANT));
-
-		if (!participant.isOwner()) {
-			throw new ChatRoomException(ChatRoomErrorCode.OWNER_PERMISSION_REQUIRED);
-		}
-
-		gitMessageService.deleteWebhook(room, memberId);
-
-		eventPublisher.publishEvent(
-			new DeleteChatRoomEvent(roomId, room.getName())
-		);
-
-		chatRoomRepository.delete(room);
-	}
-
-	@Transactional
-	public boolean toggleAlarm(Long roomId, Long memberId) {
-		ChatRoomAlarm alarm = chatRoomAlarmRepository.findByIdMemberIdAndIdRoomId(memberId, roomId)
-			.orElseThrow(() -> new ChatRoomException(ChatRoomErrorCode.ALARM_NOT_FOUND));
-
-		System.out.println("Before toggle: " + alarm.isEnabled());
-		alarm.setEnabled(!alarm.isEnabled());
-		System.out.println("After toggle: " + alarm.isEnabled());
-
-		return alarm.isEnabled();
-	}
-
-	@Transactional(readOnly = true)
-	public List<AllRoomsResponse> findAllRoomsByMemberId(Long memberId) {
-		//참여 중인 방 id 목록 조회
-		List<ChatRoom> chatRooms = chatRoomRepository.findAllRoomsByParticipantId(
-			memberId);
-
-		List<Long> roomIds = chatRooms.stream()
-			.map(ChatRoom::getId)
-			.toList();
-
-		//알림 상태 map
-		Map<Long, Boolean> alarmEnabledMap = chatRoomAlarmRepository.findEnabledMap(memberId,
-			roomIds);
-
-		return chatRooms.stream()
-			.map(room -> {
-				boolean alarmEnabled = alarmEnabledMap.getOrDefault(room.getId(), true); // 기본값 true
-				return new AllRoomsResponse(room.getId(), room.getInviteCode(), room.getName(),
-					alarmEnabled);
-			}).toList();
-	}
+    @Transactional
+    public EntryRoomResponse getEntryInfo(String inviteCode, Long memberId) {
+        ChatRoom room = getByInviteCode(inviteCode);
+        validateParticipant(memberId, room.getId());
+
+        chatParticipantRepository.findByChatRoomIdAndParticipantIdAndIsActiveTrue(room.getId(),
+                memberId)
+            .ifPresent(p -> {
+                Long latestMessageId = chatMessageRepository
+                    .findTopByChatRoom_IdOrderByIdDesc(room.getId())
+                    .map(ChatMessage::getId)
+                    .orElse(null);
+                p.resetUnreadCount(latestMessageId);
+            });
+
+        memberService.getMemberById(memberId).setRecentRoomId(room.getId()); //recentRoomId 업데이트
+
+        Long ownerId = findOwnerId(room.getId());
+
+        boolean alarmEnable = chatRoomAlarmRepository.findEnabledByMemberIdAndRoomId(
+            memberId, room.getId());
+
+        return new EntryRoomResponse(room.getId(), room.getName(), ownerId, alarmEnable);
+    }
+
+    private Long findOwnerId(Long roomId) {
+        ChatParticipant owner = chatParticipantRepository.findByChatRoomIdAndIsOwnerTrue(roomId)
+            .orElseThrow(() -> new ChatRoomException(ChatRoomErrorCode.OWNER_NOT_FOUND));
+        return owner.getParticipant().getId();
+    }
+
+    @Transactional(readOnly = true)
+    public RoomInfoResponse getRoomInfo(String inviteCode, Long memberId) {
+        ChatRoom room = getByInviteCode(inviteCode);
+        return ChatRoomMapper.toListResponse(room);
+    }
+
+    public void validateParticipant(Long memberId, Long roomId) {
+        if (!chatParticipantRepository.
+            existsByParticipantIdAndChatRoomIdAndIsActiveTrue(memberId, roomId)) {
+            throw new ChatRoomException(ChatRoomErrorCode.NOT_PARTICIPANT);
+        }
+    }
+
+    @Transactional
+    public void deleteChatRoom(Long roomId, Long memberId) {
+        ChatRoom room = getRoomById(roomId);
+
+        ChatParticipant participant = chatParticipantRepository.findByChatRoomIdAndParticipantIdAndIsActiveTrue(
+                roomId, memberId)
+            .orElseThrow(() -> new ChatRoomException(ChatRoomErrorCode.NOT_PARTICIPANT));
+
+        if (!participant.isOwner()) {
+            throw new ChatRoomException(ChatRoomErrorCode.OWNER_PERMISSION_REQUIRED);
+        }
+
+        gitMessageService.deleteWebhook(room, memberId);
+
+        eventPublisher.publishEvent(
+            new DeleteChatRoomEvent(roomId, room.getName())
+        );
+
+        chatRoomRepository.delete(room);
+    }
+
+    @Transactional
+    public boolean toggleAlarm(Long roomId, Long memberId) {
+        ChatRoomAlarm alarm = chatRoomAlarmRepository.findByIdMemberIdAndIdRoomId(memberId, roomId)
+            .orElseThrow(() -> new ChatRoomException(ChatRoomErrorCode.ALARM_NOT_FOUND));
+
+        System.out.println("Before toggle: " + alarm.isEnabled());
+        alarm.setEnabled(!alarm.isEnabled());
+        System.out.println("After toggle: " + alarm.isEnabled());
+
+        return alarm.isEnabled();
+    }
+
+    @Transactional(readOnly = true)
+    public List<AllRoomsResponse> findAllRoomsByMemberId(Long memberId) {
+        //참여 중인 방 id 목록 조회
+        List<ChatRoom> chatRooms = chatRoomRepository.findAllRoomsByParticipantId(
+            memberId);
+
+        List<Long> roomIds = chatRooms.stream()
+            .map(ChatRoom::getId)
+            .toList();
+
+        //알림 상태 map
+        Map<Long, Boolean> alarmEnabledMap = chatRoomAlarmRepository.findEnabledMap(memberId,
+            roomIds);
+
+        Map<Long, Long> unreadCountMap = chatParticipantRepository
+            .findAllByParticipantIdAndIsActiveTrue(memberId)
+            .stream()
+            .collect(Collectors.toMap(
+                cp -> cp.getChatRoom().getId(),
+                ChatParticipant::getUnreadCount
+            ));
+
+        return chatRooms.stream()
+            .map(room -> {
+                boolean alarmEnabled = alarmEnabledMap.getOrDefault(room.getId(), true);
+                long unreadCount = unreadCountMap.getOrDefault(room.getId(), 0L);
+                return new AllRoomsResponse(room.getId(), room.getInviteCode(), room.getName(),
+                    alarmEnabled, unreadCount);
+            }).toList();
+    }
+
+    @Transactional
+    public void incrementUnreadCountForOfflineMembers(Long roomId, Long senderId) {
+        ChatRoom room = getRoomById(roomId);
+        List<ChatParticipant> participants = chatParticipantRepository.findByChatRoom(room);
+
+        participants.stream()
+            .filter(p -> !p.getParticipant().getId().equals(senderId))
+            .forEach(ChatParticipant::incrementUnreadCount);
+    }
+
+    @Transactional
+    public void markAsRead(Long roomId, Long memberId) {
+        chatParticipantRepository
+            .findByChatRoomIdAndParticipantIdAndIsActiveTrue(roomId, memberId)
+            .ifPresent(p -> {
+                Long latestMessageId = chatMessageRepository
+                    .findTopByChatRoom_IdOrderByIdDesc(roomId)
+                    .map(ChatMessage::getId)
+                    .orElse(null);
+                p.resetUnreadCount(latestMessageId);
+            });
+        log.info("Marked as read: {}", memberId);
+    }
 }
-

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/dao/ChatParticipantRepository.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/dao/ChatParticipantRepository.java
@@ -11,25 +11,34 @@ import project.backend.domain.chat.chatroom.entity.ChatRoom;
 
 public interface ChatParticipantRepository extends JpaRepository<ChatParticipant, Long> {
 
-	@EntityGraph(attributePaths = {"participant"})
-	@Query("""
-    SELECT cp 
-    FROM ChatParticipant cp 
-    WHERE cp.chatRoom = :chatRoom 
-      AND cp.isActive = true
-    """)
-	List<ChatParticipant> findByChatRoom(@Param("chatRoom") ChatRoom chatRoom);
+    @EntityGraph(attributePaths = {"participant"})
+    @Query("""
+        SELECT cp 
+        FROM ChatParticipant cp 
+        WHERE cp.chatRoom = :chatRoom 
+          AND cp.isActive = true
+        """)
+    List<ChatParticipant> findByChatRoom(@Param("chatRoom") ChatRoom chatRoom);
 
-	Optional<ChatParticipant> findByChatRoomIdAndParticipantIdAndIsActiveTrue(Long chatRoomId,
-		Long participantId);
+    Optional<ChatParticipant> findByChatRoomIdAndParticipantIdAndIsActiveTrue(Long chatRoomId,
+        Long participantId);
 
-	Optional<ChatParticipant> findByChatRoomIdAndParticipantId(Long chatRoomId, Long participantId);
+    Optional<ChatParticipant> findByChatRoomIdAndParticipantId(Long chatRoomId, Long participantId);
 
-	Optional<ChatParticipant> findTopByParticipantIdAndIsActiveTrueOrderByJoinAtDesc(
-		Long participantId);
+    Optional<ChatParticipant> findTopByParticipantIdAndIsActiveTrueOrderByJoinAtDesc(
+        Long participantId);
 
-	Optional<ChatParticipant> findByChatRoomIdAndIsOwnerTrue(Long roomId);
+    Optional<ChatParticipant> findByChatRoomIdAndIsOwnerTrue(Long roomId);
 
-	boolean existsByParticipantIdAndChatRoomIdAndIsActiveTrue(Long participantId, Long chatRoomId);
+    boolean existsByParticipantIdAndChatRoomIdAndIsActiveTrue(Long participantId, Long chatRoomId);
+
+    @Query("""
+        SELECT cp 
+        FROM ChatParticipant cp 
+        JOIN FETCH cp.chatRoom 
+        WHERE cp.participant.id = :memberId 
+          AND cp.isActive = true
+        """)
+    List<ChatParticipant> findAllByParticipantIdAndIsActiveTrue(@Param("memberId") Long memberId);
 }
 

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/dto/AllRoomsResponse.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/dto/AllRoomsResponse.java
@@ -7,9 +7,10 @@ import lombok.Getter;
 @AllArgsConstructor
 public class AllRoomsResponse {
 
-	private Long roomId;
-	private String inviteCode;
-	private String roomName;
-	private boolean alarmEnabled;
+    private Long roomId;
+    private String inviteCode;
+    private String roomName;
+    private boolean alarmEnabled;
+    private long unreadCount;
 
 }

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/entity/ChatParticipant.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/entity/ChatParticipant.java
@@ -21,59 +21,74 @@ import project.backend.domain.member.entity.Member;
 @Getter
 public class ChatParticipant {
 
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "chat_participant_id")
-	private Long id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "chat_participant_id")
+    private Long id;
 
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "member_id")
-	private Member participant;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member participant;
 
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "room_id")
-	private ChatRoom chatRoom;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "room_id")
+    private ChatRoom chatRoom;
 
-	private boolean isOwner;
+    private boolean isOwner;
 
-	private boolean isActive = true;
+    private boolean isActive = true;
 
-	private LocalDateTime joinAt;
+    private LocalDateTime joinAt;
 
-	@Builder
-	public ChatParticipant(Long id, Member participant, ChatRoom chatRoom, boolean isOwner,
-		LocalDateTime joinAt) {
-		this.id = id;
-		this.participant = participant;
-		this.chatRoom = chatRoom;
-		this.isOwner = isOwner;
-		this.joinAt = joinAt;
-	}
+    @Column(name = "unread_count", nullable = false)
+    private long unreadCount = 0;
 
-	public static ChatParticipant of(Member participant, ChatRoom chatRoom) {
-		return ChatParticipant.builder()
-			.participant(participant)
-			.chatRoom(chatRoom)
-			.joinAt(LocalDateTime.now())
-			.build();
-	}
+    @Column(name = "last_read_message_id")
+    private Long lastReadMessageId;
 
-	public static ChatParticipant createOwner(Member participant, ChatRoom chatRoom) {
-		return ChatParticipant.builder()
-			.participant(participant)
-			.chatRoom(chatRoom)
-			.isOwner(true)
-			.joinAt(LocalDateTime.now())
-			.build();
-	}
+    @Builder
+    public ChatParticipant(Long id, Member participant, ChatRoom chatRoom, boolean isOwner,
+        LocalDateTime joinAt) {
+        this.id = id;
+        this.participant = participant;
+        this.chatRoom = chatRoom;
+        this.isOwner = isOwner;
+        this.joinAt = joinAt;
+    }
 
-	public void leave() {
-		this.isActive = false;
-	}
+    public static ChatParticipant of(Member participant, ChatRoom chatRoom) {
+        return ChatParticipant.builder()
+            .participant(participant)
+            .chatRoom(chatRoom)
+            .joinAt(LocalDateTime.now())
+            .build();
+    }
 
-	public void rejoin() {
-		this.isActive = true;
-	}
+    public static ChatParticipant createOwner(Member participant, ChatRoom chatRoom) {
+        return ChatParticipant.builder()
+            .participant(participant)
+            .chatRoom(chatRoom)
+            .isOwner(true)
+            .joinAt(LocalDateTime.now())
+            .build();
+    }
+
+    public void incrementUnreadCount() {
+        this.unreadCount++;
+    }
+
+    public void resetUnreadCount(Long messageId) {
+        this.unreadCount = 0;
+        this.lastReadMessageId = messageId;
+    }
+
+    public void leave() {
+        this.isActive = false;
+    }
+
+    public void rejoin() {
+        this.isActive = true;
+    }
 
 }
 

--- a/backend/src/main/java/project/backend/global/redisConfig/RedisRepositoryConfig.java
+++ b/backend/src/main/java/project/backend/global/redisConfig/RedisRepositoryConfig.java
@@ -6,23 +6,36 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 public class RedisRepositoryConfig {
 
-	@Value("${spring.data.redis.host}")
-	private String host;
+    @Value("${spring.data.redis.host}")
+    private String host;
 
-	@Value("${spring.data.redis.port}")
-	private int port;
+    @Value("${spring.data.redis.port}")
+    private int port;
 
-	@Bean
-	public RedisConnectionFactory redisConnectionFactory() {
-		RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
-		redisStandaloneConfiguration.setHostName(host);
-		redisStandaloneConfiguration.setPort(port);
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration redisStandaloneConfiguration = new RedisStandaloneConfiguration();
+        redisStandaloneConfiguration.setHostName(host);
+        redisStandaloneConfiguration.setPort(port);
 
-		return new LettuceConnectionFactory(redisStandaloneConfiguration);
-	}
+        return new LettuceConnectionFactory(redisStandaloneConfiguration);
+    }
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
+        template.setHashKeySerializer(new StringRedisSerializer());
+        template.setHashValueSerializer(new StringRedisSerializer());
+        return template;
+    }
 
 }

--- a/backend/src/main/java/project/backend/global/webconfig/WebSocketEventListener.java
+++ b/backend/src/main/java/project/backend/global/webconfig/WebSocketEventListener.java
@@ -1,0 +1,82 @@
+package project.backend.global.webconfig;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.SessionDisconnectEvent;
+import org.springframework.web.socket.messaging.SessionSubscribeEvent;
+import org.springframework.web.socket.messaging.SessionUnsubscribeEvent;
+import project.backend.auth.dto.MemberDetails;
+import java.security.Principal;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class WebSocketEventListener {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    @EventListener
+    public void handleSubscribe(SessionSubscribeEvent event) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
+        String destination = accessor.getDestination();
+
+        if (destination == null || !destination.startsWith("/topic/chat/")) {
+            return;
+        }
+
+        String roomId = destination.replace("/topic/chat/", "");
+        String sessionId = accessor.getSessionId();
+        Long memberId = getMemberId(accessor);
+
+        if (memberId == null) {
+            return;
+        }
+
+        // 온라인 등록
+        redisTemplate.opsForSet().add("online:" + roomId, memberId.toString());
+        // 세션 매핑 저장
+        redisTemplate.opsForHash().put("session:" + sessionId, "roomId", roomId);
+        redisTemplate.opsForHash().put("session:" + sessionId, "memberId", memberId.toString());
+        redisTemplate.expire("session:" + sessionId, 24, TimeUnit.HOURS);
+
+        log.info("온라인 등록 - roomId: {}, memberId: {}", roomId, memberId);
+    }
+
+    @EventListener
+    public void handleUnsubscribe(SessionUnsubscribeEvent event) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(event.getMessage());
+        removeSession(accessor.getSessionId());
+    }
+
+    @EventListener
+    public void handleDisconnect(SessionDisconnectEvent event) {
+        removeSession(event.getSessionId());
+    }
+
+    private void removeSession(String sessionId) {
+        String roomId = (String) redisTemplate.opsForHash().get("session:" + sessionId, "roomId");
+        String memberId = (String) redisTemplate.opsForHash()
+            .get("session:" + sessionId, "memberId");
+
+        if (roomId != null && memberId != null) {
+            redisTemplate.opsForSet().remove("online:" + roomId, memberId);
+            redisTemplate.delete("session:" + sessionId);
+            log.info("온라인 해제 - roomId: {}, memberId: {}", roomId, memberId);
+        }
+    }
+
+    private Long getMemberId(StompHeaderAccessor accessor) {
+        Principal principal = accessor.getUser();
+        if (principal instanceof Authentication auth) {
+            MemberDetails memberDetails = (MemberDetails) auth.getPrincipal();
+            return memberDetails.getId();
+        }
+        return null;
+    }
+}

--- a/frontend/src/components/SideBar.jsx
+++ b/frontend/src/components/SideBar.jsx
@@ -35,8 +35,6 @@ const Sidebar = ({ onStartChat }) => {
   // 현재 사용자 정보
   const [currentUser, setCurrentUser] = useState(null)
 
-  // 읽지 않은 메시지 상태 (roomId: boolean)
-  const [unreadMessages, setUnreadMessages] = useState({})
   const [roomId, setRoomId] = useState(null)
 
   const { getAlarmStatus, alarmStatusMap={} } = useAlarm(); // 전역 알림 상태 접근
@@ -44,33 +42,29 @@ const Sidebar = ({ onStartChat }) => {
 
   // 사이드바 메시지 처리 콜백
   const handleSidebarMessage = (roomUniqueId, message) => {
-
-    // 현재 있는 채팅방이 아닌 경우에만 알림 표시
     if (Number(roomId) !== Number(roomUniqueId)) {
-      setUnreadMessages((prev) => ({
-        ...prev,
-        [roomUniqueId]: true
-      }));
+      // unreadCount 증가
+      setAlarmRooms(prev => prev.map(r =>
+        Number(r.uniqueId) === Number(roomUniqueId)
+          ? { ...r, unreadCount: (r.unreadCount ?? 0) + 1 }
+          : r
+      ));
 
-      const room=alarmRooms.find(r=> r.uniqueId===roomUniqueId);
+      const room = alarmRooms.find(r => r.uniqueId === roomUniqueId);
 
-      // ✅ 알림 채팅방 최상단으로 올리기
       if (room) {
         setAlarmRooms(prev => {
           const updated = prev.filter(r => r.uniqueId !== roomUniqueId);
-          return [room, ...updated];
+          const updatedRoom = prev.find(r => r.uniqueId === roomUniqueId);
+          return [updatedRoom, ...updated];
         });
       }
 
-      // 알림 허용 상태 체크
       const isAlarmEnabled = getAlarmStatus(roomUniqueId);
       if (isAlarmEnabled === false) {
         console.log(`🔕 알림 비활성화된 방(${roomUniqueId}) → 브라우저 알림 생략`);
         return;
       }
-
-      // header.jsx에게 "브라우저 알림 요청" 전역 이벤트 발행
-      console.log(`chat_message 전역 이벤트 발행`);
 
       window.dispatchEvent(
         new CustomEvent("chat:notify", {
@@ -78,14 +72,13 @@ const Sidebar = ({ onStartChat }) => {
             senderNickname: message.senderName,
             body: message.content,
             senderImg: message.profileImageUrl,
-            url: room?.inviteCode ? `/chat/${room.inviteCode}` : undefined, // 클릭 시 해당 채팅방으로 이동
-            tag: `room-${Date.now()}`, // 고유 태그 부여(사용 안함)
-            silent: false, // 소리 재생 여부 (true면 소리 재생 x)
+            url: room?.inviteCode ? `/chat/${room.inviteCode}` : undefined,
+            tag: `room-${Date.now()}`,
+            silent: false,
             roomName: room?.roomName || `Room ${roomUniqueId}`
           },
         })
       );
-
     }
   };
 
@@ -105,17 +98,6 @@ const Sidebar = ({ onStartChat }) => {
       fetchCurrentUser()
     }
   }, [inviteCode, activeTab, alarmStatusMap]) // Add activeTab to dependencies
-
-  // 현재 채팅방이 변경될 때 해당 방의 읽지 않은 메시지 상태 제거
-  useEffect(() => {
-    if (roomId) {
-      setUnreadMessages((prev) => {
-        const updated = { ...prev }
-        delete updated[roomId]
-        return updated
-      })
-    }
-  }, [roomId, alarmStatusMap]);
 
   useEffect(() => {
     if (!inviteCode) {
@@ -152,6 +134,7 @@ const Sidebar = ({ onStartChat }) => {
         alarmEnabled: room.alarmEnabled ?? true,
         roomName: room.roomName || `Room ${room.roomId || room.id}`,
         inviteCode: room.inviteCode,
+        unreadCount: room.unreadCount ?? 0,
       })).filter(room => room.uniqueId);
 
       setAlarmRooms(rooms);
@@ -162,17 +145,21 @@ const Sidebar = ({ onStartChat }) => {
     }
   }
 
-  const navigateToRoom = (id, inviteCode) => {
+ const navigateToRoom = async (id, inviteCode) => {
     if (id) {
-      // 해당 방의 읽지 않은 메시지 상태 제거
-      setUnreadMessages((prev) => {
-        const updated = { ...prev }
-        delete updated[id]
-        return updated
-      })
-      navigate(`/chat/${inviteCode}`)
+        console.log("현재 roomId:", roomId);  // ← 여기 확인
+        console.log("이동할 id:", id);
+        if (roomId) {
+            await axiosInstance.post(`/chat-rooms/${roomId}/read`).catch((e) => {
+                console.error("read API 실패:", e);  // ← API 실패 여부 확인
+            });
+        }
+        setAlarmRooms(prev => prev.map(r =>
+            Number(r.uniqueId) === Number(roomId) ? {...r, unreadCount: 0} : r
+        ));
+        navigate(`/chat/${inviteCode}`);
     }
-  };
+};
 
   // 방 상세 정보 가져오기
   const fetchRoomDetails = async (roomId) => {
@@ -377,7 +364,8 @@ const Sidebar = ({ onStartChat }) => {
               const isCurrentRoom = roomId && Number(roomId) === Number(roomUniqueId);
               const isSelectedForModal = selectedRoom && Number(selectedRoom.uniqueId) === Number(roomUniqueId) && showMembersModal;
               const roomInviteCode = room.inviteCode;
-              const hasUnreadMessage = unreadMessages[roomUniqueId] && !isCurrentRoom;
+              const unreadCount = room.unreadCount ?? 0;
+              const hasUnread = unreadCount > 0 && !isCurrentRoom;
 
               return (
                 <div key={`room-${roomUniqueId}`} style={{ padding: "5px 10px" }}>
@@ -431,29 +419,35 @@ const Sidebar = ({ onStartChat }) => {
                       >
                         <FaRegCommentDots size={14} />
                         {/* 읽지 않은 메시지 알림 점 (빨간점)*/}
-                        {hasUnreadMessage && (
-                          <div
-                            style={{
-                              position: "absolute",
-                              top: "-3px",
-                              right: "-3px",
-                              width: "12px",
-                              height: "12px",
-                              backgroundColor: "#ff4757",
-                              borderRadius: "50%",
-                              border: "2px solid #2588F1",
-                              animation: "pulse 2s infinite",
-                            }}
-                          />
+                        {hasUnread && (
+                          <div style={{
+                            position: "absolute",
+                            top: "-3px",
+                            right: "-3px",
+                            minWidth: "16px",
+                            height: "16px",
+                            backgroundColor: "#ff4757",
+                            borderRadius: "8px",
+                            border: "2px solid #2588F1",
+                            fontSize: "9px",
+                            color: "white",
+                            display: "flex",
+                            alignItems: "center",
+                            justifyContent: "center",
+                            padding: "0 2px",
+                            animation: "pulse 2s infinite",
+                          }}>
+                            {unreadCount > 99 ? "99+" : unreadCount}
+                          </div>
                         )}
                       </div>
                       <span
                         style={{
-                          fontWeight: isCurrentRoom ? "bold" : hasUnreadMessage ? "600" : "normal",
+                          fontWeight: isCurrentRoom ? "bold" : hasUnread ? "600" : "normal",
                           whiteSpace: "nowrap",
                           overflow: "hidden",
                           textOverflow: "ellipsis",
-                          color: hasUnreadMessage ? "#fff" : "inherit",
+                          color: hasUnread ? "#fff" : "inherit",
                         }}
                       >
                         {room.name || room.roomName || `Room ${roomUniqueId}`}


### PR DESCRIPTION
## 🛰️ Issue Number
close #181 

## 🪐 작업 내용
채팅방별 안읽은 메시지 수를 DB에서 관리하고 클라이언트에 실시간으로 반영

### Backend
- ChatParticipant에 unread_count, last_read_message_id 컬럼 추가
- 메시지 전송 시 발신자 제외 전체 참가자 unread_count +1
- 채팅방 입장/이동 시 unread_count 초기화 및 last_read_message_id 업데이트
- GET /chat-rooms/all 응답에 unreadCount 포함
- POST /chat-rooms/{roomId}/read API 추가
- Redis WebSocket 세션 기반 온라인 상태 관리 (WebSocketEventListener)

### Frontend
- 사이드바 채팅방 목록에 안읽은 메시지 수 뱃지 표시
- 방 이동 시 이전 방 읽음 처리 API 호출
- 실시간 메시지 수신 시 unreadCount 증가

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?