### PR TITLE
feat: Redis INCR 기반 unread_count 관리 및 DB 동기화 스케줄러 추가

### DIFF
--- a/backend/src/main/java/project/backend/BackendApplication.java
+++ b/backend/src/main/java/project/backend/BackendApplication.java
@@ -2,7 +2,9 @@ package project.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class BackendApplication {
 

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomService.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomService.java
@@ -5,6 +5,8 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -83,6 +85,7 @@ public class ChatRoomService {
             joinGitHubBot(savedRoom); //깃허브봇 채팅 참가
         }
 
+        updateRoomMembersCache(savedRoom.getId());
         return chatRoomMapper.toSimpleResponse(savedRoom, owner);
     }
 
@@ -115,6 +118,7 @@ public class ChatRoomService {
             new JoinChatRoomEvent(room.getId(), memberId, member.getNickname(),
                 savedMessage.getId(), savedMessage.getSendAt()));
 
+        updateRoomMembersCache(room.getId());
         return ChatRoomMapper.toInviteJoinResponse(room.getId(), room.getInviteCode(),
             room.getName());
     }
@@ -202,6 +206,7 @@ public class ChatRoomService {
             new LeaveChatRoomEvent(roomId, memberId, member.getNickname(),
                 LocalDateTime.now()));
 
+        updateRoomMembersCache(roomId);
         updateRecentRoomAfterLeaving(memberId);
     }
 
@@ -310,7 +315,7 @@ public class ChatRoomService {
         Map<Long, Boolean> alarmEnabledMap = chatRoomAlarmRepository
             .findEnabledMap(memberId, roomIds);
 
-        // DB unreadCount map (폴백용)
+        // DB unreadCount map
         Map<Long, Long> dbUnreadCountMap = chatParticipantRepository
             .findAllByParticipantIdAndIsActiveTrue(memberId)
             .stream()
@@ -322,8 +327,18 @@ public class ChatRoomService {
         return chatRooms.stream()
             .map(room -> {
                 boolean alarmEnabled = alarmEnabledMap.getOrDefault(room.getId(), true);
-                long unreadCount = getUnreadCount(room.getId(), memberId,
-                    dbUnreadCountMap.getOrDefault(room.getId(), 0L));
+                long dbCount = dbUnreadCountMap.getOrDefault(room.getId(), 0L);
+
+                long redisCount = 0L;
+                try {
+                    String redisValue = redisTemplate.opsForValue()
+                        .get("unread:" + room.getId() + ":" + memberId);
+                    redisCount = redisValue != null ? Long.parseLong(redisValue) : 0L;
+                } catch (Exception e) {
+                    log.warn("Redis GET 실패 - DB 값만 사용. roomId: {}", room.getId());
+                }
+
+                long unreadCount = dbCount + redisCount;
                 return new AllRoomsResponse(room.getId(), room.getInviteCode(), room.getName(),
                     alarmEnabled, unreadCount);
             }).toList();
@@ -342,21 +357,30 @@ public class ChatRoomService {
 
     @Transactional
     public void incrementUnreadCount(Long roomId, Long senderId) {
-        ChatRoom room = getRoomById(roomId);
-        List<ChatParticipant> participants = chatParticipantRepository.findByChatRoom(room);
+        Set<String> members = redisTemplate.opsForSet().members("room:members:" + roomId);
 
-        participants.stream()
-            .filter(p -> !p.getParticipant().getId().equals(senderId))
-            .forEach(p -> {
-                Long memberId = p.getParticipant().getId();
+        if (members == null || members.isEmpty()) {
+            // Redis 캐시 미스 시 DB 조회 후 캐싱
+            updateRoomMembersCache(roomId);
+            members = redisTemplate.opsForSet().members("room:members:" + roomId);
+        }
+
+        if (members == null) {
+            return;
+        }
+
+        members.stream()
+            .filter(memberId -> !memberId.equals(senderId.toString()))
+            .forEach(memberId -> {
                 try {
-                    // Redis INCR
                     redisTemplate.opsForValue()
                         .increment("unread:" + roomId + ":" + memberId);
                 } catch (Exception e) {
-                    // Redis 장애 시 DB 폴백
                     log.warn("Redis INCR 실패 - DB 폴백. roomId: {}, memberId: {}", roomId, memberId);
-                    p.incrementUnreadCount();
+                    chatParticipantRepository
+                        .findByChatRoomIdAndParticipantIdAndIsActiveTrue(roomId,
+                            Long.parseLong(memberId))
+                        .ifPresent(ChatParticipant::incrementUnreadCount);
                 }
             });
     }
@@ -377,13 +401,31 @@ public class ChatRoomService {
                     .orElse(null);
 
                 try {
-                    // Redis 값 삭제
-                    redisTemplate.delete("unread:" + roomId + ":" + memberId);
+                    // GETDEL로 원자적으로 읽고 삭제
+                    String redisValue = redisTemplate.opsForValue()
+                        .getAndDelete("unread:" + roomId + ":" + memberId);
+                    // Redis 값은 버림 (어차피 DB 0으로 초기화)
                 } catch (Exception e) {
-                    log.warn("Redis DELETE 실패. roomId: {}, memberId: {}", roomId, memberId);
+                    log.warn("Redis GETDEL 실패. roomId: {}, memberId: {}", roomId, memberId);
                 }
 
-                p.resetUnreadCount(latestMessageId);
+                p.resetUnreadCount(latestMessageId);  // DB unread_count = 0
             });
+    }
+
+    private void updateRoomMembersCache(Long roomId) {
+        ChatRoom room = getRoomById(roomId);
+        List<ChatParticipant> participants = chatParticipantRepository.findByChatRoom(room);
+
+        String key = "room:members:" + roomId;
+        redisTemplate.delete(key);
+
+        if (!participants.isEmpty()) {
+            String[] memberIds = participants.stream()
+                .map(p -> p.getParticipant().getId().toString())
+                .toArray(String[]::new);
+            redisTemplate.opsForSet().add(key, memberIds);
+            redisTemplate.expire(key, 24, TimeUnit.HOURS);
+        }
     }
 }

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/entity/ChatParticipant.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/entity/ChatParticipant.java
@@ -82,6 +82,10 @@ public class ChatParticipant {
         this.lastReadMessageId = messageId;
     }
 
+    public void addUnreadCount(long count) {
+        this.unreadCount += count;
+    }
+
     public void leave() {
         this.isActive = false;
     }

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/scheduler/UnreadCountSyncScheduler.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/scheduler/UnreadCountSyncScheduler.java
@@ -1,0 +1,58 @@
+package project.backend.domain.chat.chatroom.scheduler;
+
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import project.backend.domain.chat.chatroom.dao.ChatParticipantRepository;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class UnreadCountSyncScheduler {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final ChatParticipantRepository chatParticipantRepository;
+
+    @Scheduled(cron = "0 0 * * * *") // 1시간마다
+    @Transactional
+    public void syncUnreadCountToDB() {
+        Set<String> keys = redisTemplate.keys("unread:*:*");
+        if (keys == null || keys.isEmpty()) {
+            return;
+        }
+
+        for (String key : keys) {
+            try {
+                // GETDEL로 원자적으로 읽고 삭제
+                String value = redisTemplate.opsForValue().getAndDelete(key);
+                if (value == null) {
+                    continue;
+                }
+
+                long count = Long.parseLong(value);
+                if (count == 0) {
+                    continue;
+                }
+
+                // key = "unread:{roomId}:{memberId}"
+                String[] parts = key.split(":");
+                Long roomId = Long.parseLong(parts[1]);
+                Long memberId = Long.parseLong(parts[2]);
+
+                chatParticipantRepository
+                    .findByChatRoomIdAndParticipantIdAndIsActiveTrue(roomId, memberId)
+                    .ifPresent(p -> p.addUnreadCount(count));
+
+                log.info("unread count 동기화 완료 - roomId: {}, memberId: {}, count: {}",
+                    roomId, memberId, count);
+
+            } catch (Exception e) {
+                log.error("unread count 동기화 실패: {}", key, e);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 🛰️ Issue Number
#184

## 🪐 작업 내용
- 방 목록 조회 시 Redis + DB 합산으로 unreadCount 반환
- 방 입장/읽음 처리 시 GETDEL로 원자적으로 Redis 삭제 후 DB 초기화
- 1시간마다 Redis unread 값 DB 동기화 스케줄러 추가

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?