### PR TITLE
Refactor: Redis lastMessageId 갱신 비동기 처리로 메시지 전송 응답시간 개선

### DIFF
--- a/backend/src/main/java/project/backend/domain/chat/chatmessage/api/ChatMessageController.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatmessage/api/ChatMessageController.java
@@ -23,6 +23,7 @@ import project.backend.domain.chat.chatmessage.dto.ChatMessageResponse;
 import project.backend.domain.chat.chatmessage.dto.ChatMessageSearchRequest;
 import project.backend.domain.chat.chatmessage.dto.ChatMessageSearchResponse;
 import project.backend.domain.chat.chatmessage.dto.ChatScrollResponse;
+import project.backend.domain.chat.chatroom.app.ChatRoomService;
 import project.backend.domain.imagefile.ImageFile;
 import project.backend.domain.imagefile.ImageFileService;
 
@@ -30,8 +31,9 @@ import project.backend.domain.imagefile.ImageFileService;
 @RequiredArgsConstructor
 public class ChatMessageController {
 
-    private final ChatMessageService chatMessageService;
+    private final ChatRoomService chatRoomService;
     private final ImageFileService imageFileService;
+    private final ChatMessageService chatMessageService;
     private final SimpMessagingTemplate messagingTemplate;
 
     @MessageMapping("/send-message/{roomId}") //클라이언트가 메세지를 보낼 경로
@@ -41,6 +43,8 @@ public class ChatMessageController {
             principal.getName());
 
         messagingTemplate.convertAndSend("/topic/chat/" + roomId, response);
+
+        chatRoomService.updateLastMessageId(roomId, response.getMessageId());
 
         return response;
     }

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomService.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomService.java
@@ -12,6 +12,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import project.backend.domain.chat.chatmessage.dao.ChatMessageRepository;
@@ -170,13 +171,15 @@ public class ChatRoomService {
 
     @Transactional(readOnly = true)
     public List<ChatParticipantResponse> getParticipants(Long memberId, Long roomId) {
+        ChatRoom chatRoom = chatRoomRepository.findById(roomId)
+            .orElseThrow(() -> new ChatRoomException(ChatRoomErrorCode.CHATROOM_NOT_FOUND));
 
         validateParticipant(memberId, roomId);
 
-        List<ChatParticipant> participants = chatParticipantRepository.findByChatRoomId(roomId);
+        List<ChatParticipant> participants = chatParticipantRepository.findByChatRoom(chatRoom);
 
         return participants.stream()
-            .map(ChatRoomMapper::toParticipantResponse).toList();
+            .map(ChatRoomMapper::toParticipantResponse).collect(Collectors.toList());
     }
 
     @Transactional
@@ -358,5 +361,10 @@ public class ChatRoomService {
             return 0L;
         }
         return 0L;
+    }
+
+    @Async("redisUpdateExecutor")
+    public void updateLastMessageId(Long roomId, Long messageId) {
+        chatRoomRedisRepository.updateLastMessageId(roomId, messageId);
     }
 }

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/dao/ChatParticipantRepository.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/dao/ChatParticipantRepository.java
@@ -18,7 +18,7 @@ public interface ChatParticipantRepository extends JpaRepository<ChatParticipant
         WHERE cp.chatRoom = :chatRoom 
           AND cp.isActive = true
         """)
-    List<ChatParticipant> findByChatRoomId(Long chatRoomId);
+    List<ChatParticipant> findByChatRoom(ChatRoom chatRoom);
 
     Optional<ChatParticipant> findByChatRoomIdAndParticipantIdAndIsActiveTrue(Long chatRoomId,
         Long participantId);

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/dao/ChatRoomRedisRepository.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/dao/ChatRoomRedisRepository.java
@@ -2,10 +2,12 @@ package project.backend.domain.chat.chatroom.dao;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisCallback;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Repository;
 
+@Slf4j
 @Repository
 @RequiredArgsConstructor
 public class ChatRoomRedisRepository {
@@ -42,4 +44,14 @@ public class ChatRoomRedisRepository {
 
         return Long.parseLong(value);
     }
+
+    public void updateLastMessageId(Long roomId, Long messageId) {
+        try {
+            redisTemplate.opsForValue()
+                .set(ROOM_LAST_MESSAGE_KEY + roomId, messageId.toString());
+        } catch (Exception e) {
+            log.warn("Redis lastMessageId 갱신 실패. roomId: {}", roomId);
+        }
+    }
+
 }

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/entity/ChatRoom.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/entity/ChatRoom.java
@@ -24,55 +24,55 @@ import project.backend.domain.chat.chatmessage.entity.ChatMessage;
 @Getter
 public class ChatRoom {
 
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "room_id")
-	private Long id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "room_id")
+    private Long id;
 
-	@Column(nullable = false)
-	private String name;
+    @Column(nullable = false)
+    private String name;
 
-	private LocalDateTime createdAt;
+    private LocalDateTime createdAt;
 
-	private String repositoryUrl;
+    private String repositoryUrl;
 
-	private String inviteCode;
+    private String inviteCode;
 
-	private Long webhookId;
+    private Long webhookId;
 
-	@OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL, orphanRemoval = true)
-	private List<ChatMessage> messages = new ArrayList<>();
+    @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ChatMessage> messages = new ArrayList<>();
 
-	@OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL, orphanRemoval = true)
-	private List<ChatParticipant> participants = new ArrayList<>();
+    @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ChatParticipant> participants = new ArrayList<>();
 
-	@Builder
-	public ChatRoom(String name, LocalDateTime createdAt, String repositoryUrl, String inviteCode,
-		Long webhookId, List<ChatMessage> messages, List<ChatParticipant> participants) {
-		this.name = name;
-		this.createdAt = createdAt != null ? createdAt : LocalDateTime.now();
-		this.repositoryUrl = repositoryUrl;
-		this.inviteCode = inviteCode;
-		this.webhookId = webhookId;
-		if (messages != null) {
-			this.messages = messages;
-		}
-		if (participants != null) {
-			this.participants = participants;
-		}
-	}
+    @Builder
+    public ChatRoom(String name, LocalDateTime createdAt, String repositoryUrl, String inviteCode,
+        Long webhookId, List<ChatMessage> messages, List<ChatParticipant> participants) {
+        this.name = name;
+        this.createdAt = createdAt != null ? createdAt : LocalDateTime.now();
+        this.repositoryUrl = repositoryUrl;
+        this.inviteCode = inviteCode;
+        this.webhookId = webhookId;
+        if (messages != null) {
+            this.messages = messages;
+        }
+        if (participants != null) {
+            this.participants = participants;
+        }
+    }
 
-	public void addParticipant(ChatParticipant chatParticipant) {
-		participants.add(chatParticipant);
-	}
+    public void addParticipant(ChatParticipant chatParticipant) {
+        participants.add(chatParticipant);
+    }
 
-	public int getActiveParticipantCount() {
-		return (int) participants.stream()
-			.filter(ChatParticipant::isActive)
-			.count();
-	}
+    public int getActiveParticipantCount() {
+        return (int) participants.stream()
+            .filter(ChatParticipant::isActive)
+            .count();
+    }
 
-	public void updateWebhookId(Long webhookId) {
-		this.webhookId = webhookId;
-	}
+    public void updateWebhookId(Long webhookId) {
+        this.webhookId = webhookId;
+    }
 }

--- a/backend/src/main/java/project/backend/domain/member/app/MemberService.java
+++ b/backend/src/main/java/project/backend/domain/member/app/MemberService.java
@@ -3,6 +3,7 @@ package project.backend.domain.member.app;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -35,134 +36,134 @@ import project.backend.global.exception.ex.MemberException;
 @RequiredArgsConstructor
 public class MemberService {
 
-	private final MemberRepository memberRepository;
-	private final ImageFileService imageFileService;
-	private final PasswordEncoder passwordEncoder;
-	private final ApplicationEventPublisher eventPublisher;
+    private final MemberRepository memberRepository;
+    private final ImageFileService imageFileService;
+    private final PasswordEncoder passwordEncoder;
+    private final ApplicationEventPublisher eventPublisher;
 
-	@Value("${file.images.profile.default}")
-	private String defaultProfileImg;
+    @Value("${file.images.profile.default}")
+    private String defaultProfileImg;
 
-	public MemberResponse saveMember(SignUpRequest request) {
+    public MemberResponse saveMember(SignUpRequest request) {
 
-		if (checkUsernameAlreadyExists(request.getUsername())) {
-			throw new MemberException(MemberErrorCode.USERNAME_ALREADY_EXISTS);
-		}
+        if (checkUsernameAlreadyExists(request.getUsername())) {
+            throw new MemberException(MemberErrorCode.USERNAME_ALREADY_EXISTS);
+        }
 
-		if (request.getEmail() != null && checkEmailAlreadyExists(request.getEmail())) {
-			throw new MemberException(MemberErrorCode.EMAIL_ALREADY_EXISTS);
-		}
+        if (request.getEmail() != null && checkEmailAlreadyExists(request.getEmail())) {
+            throw new MemberException(MemberErrorCode.EMAIL_ALREADY_EXISTS);
+        }
 
-		String encryptedPassword = passwordEncoder.encode(request.getPassword());
+        String encryptedPassword = passwordEncoder.encode(request.getPassword());
 
-		Member newMember = memberRepository.save(
-			MemberMapper.toEntity(request, encryptedPassword, defaultProfileImg));
+        Member newMember = memberRepository.save(
+            MemberMapper.toEntity(request, encryptedPassword, defaultProfileImg));
 
-		return MemberMapper.toResponse(newMember);
-	}
+        return MemberMapper.toResponse(newMember);
+    }
 
-	public MemberResponse updateMemberInfo(Authentication auth, MemberInfoUpdateRequest request,
-		MultipartFile file) {
-		MemberDetails memberDetails = checkAuthentication(auth);
-		Member targetMember = getMemberById(memberDetails.getId());
+    public MemberResponse updateMemberInfo(Authentication auth, MemberInfoUpdateRequest request,
+        MultipartFile file) {
+        MemberDetails memberDetails = checkAuthentication(auth);
+        Member targetMember = getMemberById(memberDetails.getId());
 
-		doUpdateMemberInfo(targetMember, request, file);
+        doUpdateMemberInfo(targetMember, request, file);
 
-		eventPublisher.publishEvent(ProfileUpdateEvent.of(targetMember));
+        eventPublisher.publishEvent(ProfileUpdateEvent.of(targetMember));
 
-		return MemberMapper.toResponse(targetMember);
-	}
+        return MemberMapper.toResponse(targetMember);
+    }
 
-	private void doUpdateMemberInfo(Member targetMember, MemberInfoUpdateRequest request,
-		MultipartFile file) {
-		if (request.getNickname() != null) {
-			targetMember.updateNickname(request.getNickname());
-		}
+    private void doUpdateMemberInfo(Member targetMember, MemberInfoUpdateRequest request,
+        MultipartFile file) {
+        if (request.getNickname() != null) {
+            targetMember.updateNickname(request.getNickname());
+        }
 
-		if (request.getEmail() != null) {
-			targetMember.updateEmail(request.getEmail());
-		}
+        if (request.getEmail() != null) {
+            targetMember.updateEmail(request.getEmail());
+        }
 
-		if (file != null) {
-			String profileImage = imageFileService.saveProfileImage(file);
-			targetMember.updateProfileImage(profileImage);
-		}
-	}
+        if (file != null) {
+            String profileImage = imageFileService.saveProfileImage(file);
+            targetMember.updateProfileImage(profileImage);
+        }
+    }
 
-	public void updatePassword(Authentication auth, PasswordChangeRequest request) {
-		MemberDetails memberDetails = checkAuthentication(auth);
-		Member targetMember = getMemberById(memberDetails.getId());
+    public void updatePassword(Authentication auth, PasswordChangeRequest request) {
+        MemberDetails memberDetails = checkAuthentication(auth);
+        Member targetMember = getMemberById(memberDetails.getId());
 
-		if (targetMember.getProvider() != ProviderType.LOCAL) {
-			throw new AuthException(AuthErrorCode.WRONG_AUTH_TYPE_LOGIN);
-		}
+        if (targetMember.getProvider() != ProviderType.LOCAL) {
+            throw new AuthException(AuthErrorCode.WRONG_AUTH_TYPE_LOGIN);
+        }
 
-		String currentPassword = targetMember.getPassword();
+        String currentPassword = targetMember.getPassword();
 
-		if (!passwordEncoder.matches(request.getCurrentPassword(),
-			currentPassword)) {
-			throw new MemberException(MemberErrorCode.WRONG_PASSWORD);
-		}
+        if (!passwordEncoder.matches(request.getCurrentPassword(),
+            currentPassword)) {
+            throw new MemberException(MemberErrorCode.WRONG_PASSWORD);
+        }
 
-		if (passwordEncoder.matches(request.getNewPassword(), currentPassword)) {
-			throw new MemberException(MemberErrorCode.SAME_AS_OLD_PASSWORD);
-		}
+        if (passwordEncoder.matches(request.getNewPassword(), currentPassword)) {
+            throw new MemberException(MemberErrorCode.SAME_AS_OLD_PASSWORD);
+        }
 
-		targetMember.updatePassword(request.getNewPassword(), passwordEncoder);
-	}
+        targetMember.updatePassword(request.getNewPassword(), passwordEncoder);
+    }
 
 
-	// Spring Security에서 UsernameNotFoundException을 처리하도록 유도하는 메서드
-	public Member getMemberForLogin(String username) {
-		try {
-			return getMemberByUsername(username);
-		} catch (MemberException e) {
-			log.info("존재하지 않는 username으로 로그인 시도: {}", username);
-			throw new UsernameNotFoundException("존재하지 않는 유저입니다: " + username, e);
-		}
-	}
+    // Spring Security에서 UsernameNotFoundException을 처리하도록 유도하는 메서드
+    public Member getMemberForLogin(String username) {
+        try {
+            return getMemberByUsername(username);
+        } catch (MemberException e) {
+            log.info("존재하지 않는 username으로 로그인 시도: {}", username);
+            throw new UsernameNotFoundException("존재하지 않는 유저입니다: " + username, e);
+        }
+    }
 
-	public Member getMemberByUsername(String username) {
-		return memberRepository.findByUsername(username)
-			.orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
-	}
+    public Member getMemberByUsername(String username) {
+        return memberRepository.findByUsername(username)
+            .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+    }
 
-	public Member getMemberById(Long id) {
-		return memberRepository.findById(id)
-			.orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
-	}
+    public Member getMemberById(Long id) {
+        return memberRepository.findById(id)
+            .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+    }
 
-	public MemberResponse getMemberDetails(Authentication auth) {
-		MemberDetails loginMember = (MemberDetails) auth.getPrincipal();
-		Long memberId = loginMember.getId();
-		Member member = getMemberById(memberId);
-		return MemberMapper.toResponse(member);
-	}
+    public MemberResponse getMemberDetails(Authentication auth) {
+        MemberDetails loginMember = (MemberDetails) auth.getPrincipal();
+        Long memberId = loginMember.getId();
+        Member member = getMemberById(memberId);
+        return MemberMapper.toResponse(member);
+    }
 
-	public Page<MemberSearchResponse> searchMembers(Authentication auth, String keyword,
-		Pageable pageable) {
-		var memberDetails = checkAuthentication(auth);
+    public Page<MemberSearchResponse> searchMembers(Authentication auth, String keyword,
+        Pageable pageable) {
+        var memberDetails = checkAuthentication(auth);
 
-		return memberRepository.searchByNicknameExcludeSelf(keyword, memberDetails.getNickname(),
-			memberDetails.getId(),
-			pageable);
-	}
+        return memberRepository.searchByNicknameExcludeSelf(keyword, memberDetails.getNickname(),
+            memberDetails.getId(),
+            pageable);
+    }
 
-	private boolean checkUsernameAlreadyExists(String username) {
-		return memberRepository.findByUsername(username).isPresent();
-	}
+    private boolean checkUsernameAlreadyExists(String username) {
+        return memberRepository.findByUsername(username).isPresent();
+    }
 
-	private boolean checkEmailAlreadyExists(String email) {
-		return memberRepository.findByEmail(email).isPresent();
-	}
+    private boolean checkEmailAlreadyExists(String email) {
+        return memberRepository.findByEmail(email).isPresent();
+    }
 
-	public MemberDetails checkAuthentication(Authentication auth) {
-		var memberDetails = (MemberDetails) auth.getPrincipal();
-		if (memberDetails == null) {
-			throw new AuthException(AuthErrorCode.UNAUTHORIZED_USER);
-		}
+    public MemberDetails checkAuthentication(Authentication auth) {
+        var memberDetails = (MemberDetails) auth.getPrincipal();
+        if (memberDetails == null) {
+            throw new AuthException(AuthErrorCode.UNAUTHORIZED_USER);
+        }
 
-		return memberDetails;
-	}
+        return memberDetails;
+    }
 
 }

--- a/backend/src/main/java/project/backend/domain/member/entity/Member.java
+++ b/backend/src/main/java/project/backend/domain/member/entity/Member.java
@@ -29,73 +29,73 @@ import project.backend.domain.member.friend.entity.Friends;
 @AllArgsConstructor
 public class Member {
 
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "member_id")
-	private Long id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id")
+    private Long id;
 
-	@Column(nullable = false, unique = true)
-	private String username;
+    @Column(nullable = false, unique = true)
+    private String username;
 
-	@Column(nullable = false)
-	private String nickname;
+    @Column(nullable = false)
+    private String nickname;
 
-	@Column(unique = true)
-	private String email;
+    @Column(unique = true)
+    private String email;
 
-	private String password;
+    private String password;
 
-	@Column(updatable = false)
-	@Enumerated(EnumType.STRING)
-	private ProviderType provider;
+    @Column(updatable = false)
+    @Enumerated(EnumType.STRING)
+    private ProviderType provider;
 
-	@Builder.Default
-	private LocalDateTime joinAt = LocalDateTime.now();
+    @Builder.Default
+    private LocalDateTime joinAt = LocalDateTime.now();
 
-	@Builder.Default
-	@OneToMany(mappedBy = "participant")
-	private List<ChatParticipant> participants = new ArrayList<>();
+    @Builder.Default
+    @OneToMany(mappedBy = "participant")
+    private List<ChatParticipant> participants = new ArrayList<>();
 
-	@Builder.Default
-	@OneToMany(mappedBy = "owner", cascade = CascadeType.ALL, orphanRemoval = true)
-	private List<Friends> friends = new ArrayList<>();
+    @Builder.Default
+    @OneToMany(mappedBy = "owner", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Friends> friends = new ArrayList<>();
 
-	@Column(nullable = false)
-	private String profileImage;
+    @Column(nullable = false)
+    private String profileImage;
 
-	@Setter
-	private Long recentRoomId;
+    @Setter
+    private Long recentRoomId;
 
-	public static Member of(MemberDetails memberDetails) {
-		return Member.builder()
-			.id(memberDetails.getId())
-			.username(memberDetails.getUsername())
-			.email(memberDetails.getEmail())
-			.password(memberDetails.getPassword())
-			.nickname(memberDetails.getNickname())
-			.provider(memberDetails.getProvider())
-			.profileImage(memberDetails.getProfileImg())
-			.build();
-	}
+    public static Member of(MemberDetails memberDetails) {
+        return Member.builder()
+            .id(memberDetails.getId())
+            .username(memberDetails.getUsername())
+            .email(memberDetails.getEmail())
+            .password(memberDetails.getPassword())
+            .nickname(memberDetails.getNickname())
+            .provider(memberDetails.getProvider())
+            .profileImage(memberDetails.getProfileImg())
+            .build();
+    }
 
-	public void updateNickname(String nickname) {
-		this.nickname = nickname;
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
 
-	}
+    }
 
-	public void updateEmail(String email) {
-		this.email = email;
-	}
+    public void updateEmail(String email) {
+        this.email = email;
+    }
 
-	public void updatePassword(String password, PasswordEncoder encoder) {
-		this.password = encoder.encode(password);
-	}
+    public void updatePassword(String password, PasswordEncoder encoder) {
+        this.password = encoder.encode(password);
+    }
 
-	public void updateProfileImage(String profileImage) {
-		this.profileImage = profileImage;
-	}
+    public void updateProfileImage(String profileImage) {
+        this.profileImage = profileImage;
+    }
 
-	public void addFriend(Friends friend) {
-		this.friends.add(friend);
-	}
+    public void addFriend(Friends friend) {
+        this.friends.add(friend);
+    }
 }

--- a/backend/src/main/java/project/backend/global/asyncConfig/AsyncConfig.java
+++ b/backend/src/main/java/project/backend/global/asyncConfig/AsyncConfig.java
@@ -37,4 +37,16 @@ public class AsyncConfig {
         executor.initialize();
         return executor;
     }
+
+    @Bean(name = "redisUpdateExecutor")
+    public Executor getRedisUpdateExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(5);
+        executor.setMaxPoolSize(20);
+        executor.setQueueCapacity(500);
+        executor.setThreadNamePrefix("RedisUpdate-");
+        executor.setRejectedExecutionHandler(rejectExecutionHandler);
+        executor.initialize();
+        return executor;
+    }
 }


### PR DESCRIPTION
## 🛰️ Issue Number

## 🪐 작업 내용
### 개요
메시지 전송 트랜잭션 내에서 동기로 처리되던 Redis lastMessageId 갱신을
비동기로 분리하여 메시지 전송 응답시간을 개선했습니다.

### 변경 사항
- ChatRoomService에 updateLastMessageId() @Async 메서드 추가
- ChatMessageService.save()에서 Redis 갱신을 트랜잭션 밖 비동기로 분리
- chatRoomEventExecutor 스레드 풀 재사용

### 비고
- Redis 갱신 실패 시 DB 폴백으로 unread 계산 가능
- @Async는 같은 클래스 내부 호출 시 동작하지 않아 ChatRoomService로 분리

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?