### PR TITLE
Feat: 안 읽음 카운트 최적화를 위한 Write-Behind 배치 및 폴백 로직 구현 

### DIFF
--- a/backend/src/main/java/project/backend/auth/token/jwt/JwtProvider.java
+++ b/backend/src/main/java/project/backend/auth/token/jwt/JwtProvider.java
@@ -34,7 +34,7 @@ import project.backend.auth.dto.MemberDetails;
 @RequiredArgsConstructor
 public class JwtProvider {
 
-    public static final Long TOKEN_VALIDATION_SECOND = 10L * 10L * 60L;
+    public static final Long TOKEN_VALIDATION_SECOND = 10 * 60L;
     public static final Long REFRESH_TOKEN_VALIDATION_SECOND = 7 * 24 * 60 * 60L;
 
     private final TokenRedisRepository tokenRedisRepository;

--- a/backend/src/main/java/project/backend/domain/chat/chatmessage/app/ChatMessageService.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatmessage/app/ChatMessageService.java
@@ -79,8 +79,7 @@ public class ChatMessageService {
 
         chatMessageRepository.save(message);
 
-        chatRoomRedisRepository.incrementSequence(roomId);
-        chatRoomRedisRepository.updateRoomRanking(roomId);
+        chatRoomRedisRepository.handleMessageDelivery(roomId);
 
         if (isSearchable(message)) {
             eventPublisher.publishEvent(ChatMessageSavedEvent.from(message));

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomSequenceScheduler.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomSequenceScheduler.java
@@ -1,0 +1,37 @@
+package project.backend.domain.chat.chatroom.app;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import project.backend.domain.chat.chatroom.dao.ChatRoomRedisRepository;
+import project.backend.domain.chat.chatroom.dao.ChatRoomRepository;
+import project.backend.domain.chat.chatroom.entity.ChatRoom;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ChatRoomSequenceScheduler {
+
+    private final ChatRoomRepository chatRoomRepository;
+    private final ChatRoomRedisRepository chatRoomRedisRepository;
+    private final ChatRoomService chatRoomService;
+
+    @Scheduled(fixedRate = 60000)
+    public void syncLastSequence() {
+        try {
+            List<ChatRoom> rooms = chatRoomRepository.findAll();
+            if (rooms.isEmpty()) return;
+
+            List<Long> roomIds = rooms.stream().map(ChatRoom::getId).toList();
+            List<Long> redisSequences = chatRoomRedisRepository.getSequences(roomIds);
+
+            chatRoomService.syncSequencesToDb(rooms, redisSequences);
+            log.info("last_sequence 동기화 배치 완료");
+
+        } catch (Exception e) {
+            log.error("시퀀스 동기화 배치 중 에러 발생: {}", e.getMessage());
+        }
+    }
+}

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomSequenceScheduler.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomSequenceScheduler.java
@@ -1,35 +1,22 @@
 package project.backend.domain.chat.chatroom.app;
 
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-import project.backend.domain.chat.chatroom.dao.ChatRoomRedisRepository;
-import project.backend.domain.chat.chatroom.dao.ChatRoomRepository;
-import project.backend.domain.chat.chatroom.entity.ChatRoom;
 
 @Slf4j
 @Component
 @RequiredArgsConstructor
 public class ChatRoomSequenceScheduler {
 
-    private final ChatRoomRepository chatRoomRepository;
-    private final ChatRoomRedisRepository chatRoomRedisRepository;
     private final ChatRoomService chatRoomService;
 
     @Scheduled(fixedRate = 60000)
     public void syncLastSequence() {
         try {
-            List<ChatRoom> rooms = chatRoomRepository.findAll();
-            if (rooms.isEmpty()) return;
-
-            List<Long> roomIds = rooms.stream().map(ChatRoom::getId).toList();
-            List<Long> redisSequences = chatRoomRedisRepository.getSequences(roomIds);
-
-            chatRoomService.syncSequencesToDb(rooms, redisSequences);
-            log.info("last_sequence 동기화 배치 완료 - 대상 방 개수: {}개", rooms.size());
-
+            chatRoomService.syncSequencesToDb();
+            log.info("last_sequence 동기화 배치 완료");
         } catch (Exception e) {
             log.error("시퀀스 동기화 배치 중 에러 발생: {}", e.getMessage());
         }

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomSequenceScheduler.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomSequenceScheduler.java
@@ -28,7 +28,7 @@ public class ChatRoomSequenceScheduler {
             List<Long> redisSequences = chatRoomRedisRepository.getSequences(roomIds);
 
             chatRoomService.syncSequencesToDb(rooms, redisSequences);
-            log.info("last_sequence 동기화 배치 완료");
+            log.info("last_sequence 동기화 배치 완료 - 대상 방 개수: {}개", rooms.size());
 
         } catch (Exception e) {
             log.error("시퀀스 동기화 배치 중 에러 발생: {}", e.getMessage());

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomService.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomService.java
@@ -386,26 +386,33 @@ public class ChatRoomService {
         try {
             return chatRoomRedisRepository.getSequences(roomIds);
         } catch (Exception e) {
-            log.warn("Redis 장애 - DB last_sequence 폴백");
+            log.warn("Redis 장애 - DB lastSequence 폴백");
+            Map<Long, Long> seqMap = chatRoomRepository.findAllById(roomIds).stream()
+                    .collect(Collectors.toMap(
+                            ChatRoom::getId,
+                            r -> r.getLastSequence() != null ? r.getLastSequence() : 0L
+                    ));
             return roomIds.stream()
-                    .map(id -> chatRoomRepository.findById(id)
-                            .map(ChatRoom::getLastSequence)
-                            .orElse(0L))
+                    .map(id -> seqMap.getOrDefault(id, 0L))
                     .toList();
         }
     }
 
     @Transactional
-    public void syncSequencesToDb(List<ChatRoom> rooms, List<Long> redisSequences) {
+    public void syncSequencesToDb() {
+        List<ChatRoom> rooms = chatRoomRepository.findAll();
+        if (rooms.isEmpty()) return;
+
+        List<Long> roomIds = rooms.stream().map(ChatRoom::getId).toList();
+        List<Long> redisSequences = chatRoomRedisRepository.getSequences(roomIds);
+
         for (int i = 0; i < rooms.size(); i++) {
             Long redisSeq = redisSequences.get(i);
-            ChatRoom room = rooms.get(i);
-
-            long currentSeq = room.getLastSequence() != null ? room.getLastSequence() : 0L;
-
+            long currentSeq = rooms.get(i).getLastSequence() != null ? rooms.get(i).getLastSequence() : 0L;
             if (redisSeq != null && redisSeq > currentSeq) {
-                room.updateLastSequence(redisSeq);
+                rooms.get(i).updateLastSequence(redisSeq);
             }
         }
+        log.info("last_sequence 동기화 완료 - {}개 채팅방", rooms.size());
     }
 }

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomService.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomService.java
@@ -401,7 +401,9 @@ public class ChatRoomService {
             Long redisSeq = redisSequences.get(i);
             ChatRoom room = rooms.get(i);
 
-            if (redisSeq != null && redisSeq > room.getLastSequence()) {
+            long currentSeq = room.getLastSequence() != null ? room.getLastSequence() : 0L;
+
+            if (redisSeq != null && redisSeq > currentSeq) {
                 room.updateLastSequence(redisSeq);
             }
         }

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomService.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomService.java
@@ -386,8 +386,24 @@ public class ChatRoomService {
         try {
             return chatRoomRedisRepository.getSequences(roomIds);
         } catch (Exception e) {
-            log.warn("Redis 장애로 인해 시퀀스 조회를 생략합니다. (unreadCount는 null 처리됨)");
-            return null;
+            log.warn("Redis 장애 - DB last_sequence 폴백");
+            return roomIds.stream()
+                    .map(id -> chatRoomRepository.findById(id)
+                            .map(ChatRoom::getLastSequence)
+                            .orElse(0L))
+                    .toList();
+        }
+    }
+
+    @Transactional
+    public void syncSequencesToDb(List<ChatRoom> rooms, List<Long> redisSequences) {
+        for (int i = 0; i < rooms.size(); i++) {
+            Long redisSeq = redisSequences.get(i);
+            ChatRoom room = rooms.get(i);
+
+            if (redisSeq != null && redisSeq > room.getLastSequence()) {
+                room.updateLastSequence(redisSeq);
+            }
         }
     }
 }

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/dao/ChatRoomRedisRepository.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/dao/ChatRoomRedisRepository.java
@@ -1,9 +1,9 @@
 package project.backend.domain.chat.chatroom.dao;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisCallback;
@@ -15,64 +15,90 @@ import org.springframework.stereotype.Repository;
 @RequiredArgsConstructor
 public class ChatRoomRedisRepository {
 
-    private static final String ROOM_SEQUENCE_KEY = "room:sequence:";
-    private static final String ROOM_RANKING_KEY = "room:ranking";
+    private static final String ROOM_SEQUENCE_KEY = "room:%d:sequence";
+
+    private static final String UPDATED_ROOMS_KEY = "rooms:updated";
+    private static final String RANKING_ROOMS_KEY = "rooms:ranking";
 
     private final StringRedisTemplate redisTemplate;
 
-    public Long incrementSequence(Long roomId) {
-        return redisTemplate.opsForValue().increment(ROOM_SEQUENCE_KEY + roomId);
+    public void handleMessageDelivery(Long roomId) {
+        redisTemplate.executePipelined((RedisCallback<Object>) connection -> {
+            String seqKey = String.format(ROOM_SEQUENCE_KEY, roomId);
+            String roomIdStr = String.valueOf(roomId);
+
+            connection.stringCommands().incr(seqKey.getBytes());
+
+            connection.zSetCommands().zAdd(
+                    RANKING_ROOMS_KEY.getBytes(),
+                    System.currentTimeMillis(),
+                    roomIdStr.getBytes()
+            );
+
+            connection.setCommands().sAdd(
+                    UPDATED_ROOMS_KEY.getBytes(),
+                    roomIdStr.getBytes()
+            );
+            return null;
+        });
     }
 
     public Long getSequence(Long roomId) {
-        String value = redisTemplate.opsForValue().get(ROOM_SEQUENCE_KEY + roomId);
+        String key = String.format(ROOM_SEQUENCE_KEY, roomId);
+        String value = redisTemplate.opsForValue().get(key);
         return value == null ? 0L : Long.parseLong(value);
     }
 
     public List<Long> getSequences(List<Long> roomIds) {
+        if (roomIds == null || roomIds.isEmpty()) {
+            return List.of();
+        }
         List<Object> values = redisTemplate.executePipelined(
-            (RedisCallback<Object>) connection -> {
-                roomIds.forEach(roomId -> {
-                    String key = ROOM_SEQUENCE_KEY + roomId;
-                    connection.stringCommands().get(key.getBytes());
+                (RedisCallback<Object>) connection -> {
+                    for (Long roomId : roomIds) {
+                        String key = String.format(ROOM_SEQUENCE_KEY, roomId);
+                        connection.stringCommands().get(key.getBytes());
+                    }
+                    return null;
                 });
-                return null;
-            });
-        return values.stream()
-            .map(val -> val == null ? 0L : Long.parseLong(val.toString()))
-            .toList();
+        List<Long> result = new ArrayList<>(roomIds.size());
+
+        for (Object val : values) {
+            if (val == null) {
+                result.add(0L);
+            } else {
+                result.add(Long.parseLong(new String((byte[]) val)));
+            }
+        }
+        return result;
     }
 
-    public void updateRoomRanking(Long roomId) {
-        redisTemplate.opsForZSet().add(
-            ROOM_RANKING_KEY,
-            String.valueOf(roomId),
-            System.currentTimeMillis()
-        );
-    }
-
-    // 방목록 조회 시 정렬된 roomId 목록 가져오기
     public List<Long> getSortedRoomIds(List<Long> roomIds) {
+        if (roomIds == null || roomIds.isEmpty()) {
+            return List.of();
+        }
         Set<String> ranked = redisTemplate.opsForZSet()
-            .reverseRange(ROOM_RANKING_KEY, 0, -1);
+                .reverseRange(RANKING_ROOMS_KEY, 0, roomIds.size() - 1);
 
         if (ranked == null || ranked.isEmpty()) {
-            return roomIds;
+            return new ArrayList<>(roomIds);
         }
 
-        Set<Long> roomIdSet = new HashSet<>(roomIds);  // O(1) 탐색용
+        Set<Long> roomIdSet = new HashSet<>(roomIds);
+        List<Long> sorted = new ArrayList<>(roomIds.size());
+        for (String r : ranked) {
+            Long id = Long.valueOf(r);
+            if (roomIdSet.contains(id)) {
+                sorted.add(id);
+            }
+        }
 
-        List<Long> sorted = ranked.stream()
-            .map(Long::valueOf)
-            .filter(roomIdSet::contains)  // O(1)
-            .collect(Collectors.toList());
-
-        Set<Long> sortedSet = new HashSet<>(sorted);  // O(1) 탐색용
-        roomIds.stream()
-            .filter(id -> !sortedSet.contains(id))  // O(1)
-            .forEach(sorted::add);
-
+        Set<Long> added = new HashSet<>(sorted);
+        for (Long id : roomIds) {
+            if (!added.contains(id)) {
+                sorted.add(id);
+            }
+        }
         return sorted;
     }
-
 }

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/entity/ChatRoom.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/entity/ChatRoom.java
@@ -46,6 +46,9 @@ public class ChatRoom {
     @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ChatParticipant> participants = new ArrayList<>();
 
+    @Column(name = "last_sequence")
+    private Long lastSequence = 0L;
+
     @Builder
     public ChatRoom(String name, LocalDateTime createdAt, String repositoryUrl, String inviteCode,
         Long webhookId, List<ChatMessage> messages, List<ChatParticipant> participants) {
@@ -60,6 +63,10 @@ public class ChatRoom {
         if (participants != null) {
             this.participants = participants;
         }
+    }
+
+    public void updateLastSequence(Long sequence) {
+        this.lastSequence = sequence;
     }
 
     public void addParticipant(ChatParticipant chatParticipant) {

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/entity/ChatRoom.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/entity/ChatRoom.java
@@ -46,7 +46,7 @@ public class ChatRoom {
     @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ChatParticipant> participants = new ArrayList<>();
 
-    @Column(name = "last_sequence")
+    @Column(name = "last_sequence", nullable = false)
     private Long lastSequence = 0L;
 
     @Builder


### PR DESCRIPTION
## 🛰️ Issue Number
close #207 

## 🪐 작업 내용
- Redis의 최신 메시지 시퀀스를 주기적(1분)으로 DB에 동기화하는 스케줄러 추가
- DB 트랜잭션 효율을 위해 조회(Non-Transactional)와 업데이트(Transactional) 로직 분리
- JPA Dirty Checking을 활용하여 변경사항이 있는 채팅방만 선별하여 업데이트 수행(현재 lastSequence 값보다 큰 경우만 트랜잭션 태우기)
- Redis 장애 시 DB 스냅샷(last_sequence)을 활용할 수 있도록 안정성 확보
- last_sequence칼럼의 null 방어 로직 추가

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?