### PR TITLE
Feat: Redis sequence 재시작/TTL 만료 복구 로직 추가

### DIFF
--- a/backend/src/main/java/project/backend/domain/chat/chatmessage/app/ChatMessageService.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatmessage/app/ChatMessageService.java
@@ -28,6 +28,7 @@ import project.backend.domain.chat.chatmessage.entity.MessageType;
 import project.backend.domain.chat.chatmessage.mapper.ChatMessageMapper;
 import project.backend.domain.chat.chatroom.app.ChatRoomService;
 import project.backend.domain.chat.chatroom.dao.ChatRoomRedisRepository;
+import project.backend.domain.chat.chatroom.dao.ChatRoomRepository;
 import project.backend.domain.chat.chatroom.entity.ChatRoom;
 import project.backend.domain.imagefile.ImageFile;
 import project.backend.domain.imagefile.ImageFileService;
@@ -36,8 +37,10 @@ import project.backend.domain.member.entity.Member;
 import project.backend.domain.chat.chatmessage.dto.ScrollPaginationCollection;
 import project.backend.global.exception.errorcode.AuthErrorCode;
 import project.backend.global.exception.errorcode.ChatMessageErrorCode;
+import project.backend.global.exception.errorcode.ChatRoomErrorCode;
 import project.backend.global.exception.ex.AuthException;
 import project.backend.global.exception.ex.ChatMessageException;
+import project.backend.global.exception.ex.ChatRoomException;
 import project.backend.global.metric.TimeTrace;
 
 @Slf4j
@@ -45,6 +48,7 @@ import project.backend.global.metric.TimeTrace;
 @RequiredArgsConstructor
 public class ChatMessageService {
 
+    private final ChatRoomRepository chatRoomRepository;
     private final ChatMessageRepository chatMessageRepository;
     private final ChatRoomRedisRepository chatRoomRedisRepository;
     private final ChatMessageSearchRepository chatMessageSearchRepository;
@@ -79,7 +83,17 @@ public class ChatMessageService {
 
         chatMessageRepository.save(message);
 
-        chatRoomRedisRepository.handleMessageDelivery(roomId);
+        Long seq = chatRoomRedisRepository.handleMessageDelivery(roomId);
+
+        if (seq != null && seq == -1L) {
+            ChatRoom findRoom = chatRoomRepository.findById(roomId)
+                    .orElseThrow(() -> new ChatRoomException(ChatRoomErrorCode.CHATROOM_NOT_FOUND));
+
+            long dbSeq = findRoom.getLastSequence() != null ? findRoom.getLastSequence() : 0L;
+            chatRoomRedisRepository.setSequence(roomId, dbSeq + 1);
+
+            log.warn("Redis sequence 복구 - roomId: {}, dbSeq: {}, 복구값: {}", roomId, dbSeq, dbSeq + 1);
+        }
 
         if (isSearchable(message)) {
             eventPublisher.publishEvent(ChatMessageSavedEvent.from(message));

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomService.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomService.java
@@ -1,13 +1,10 @@
 package project.backend.domain.chat.chatroom.app;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
+
+import io.micrometer.core.instrument.MeterRegistry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -68,6 +65,8 @@ public class ChatRoomService {
 
     private final ApplicationEventPublisher eventPublisher;
 
+    private final MeterRegistry meterRegistry;
+
     @Value("${github.username}")
     private String githubUsername;
 
@@ -93,6 +92,7 @@ public class ChatRoomService {
         return chatRoomMapper.toSimpleResponse(savedRoom, owner);
     }
 
+    @Transactional
     public void createAlarm(Long memberId, Long roomId) {
         ChatRoomAlarm alarm = new ChatRoomAlarm(memberId, roomId);
         chatRoomAlarmRepository.save(alarm);
@@ -144,7 +144,6 @@ public class ChatRoomService {
         }
     }
 
-    @Transactional(readOnly = true)
     public String getRecentRoomInviteCode(Long memberId) {
         Long roomId = memberService.getMemberById(memberId).getRecentRoomId();
 
@@ -155,7 +154,6 @@ public class ChatRoomService {
         return getRoomById(roomId).getInviteCode();
     }
 
-    @Transactional(readOnly = true)
     public Page<MyChatRoomResponse> findAllRoomsByOwnerId(Long memberId, Pageable pageable) {
         Page<ChatRoom> allRoomsByOwnerId = chatRoomRepository.findAllRoomsByOwnerId(memberId,
             pageable);
@@ -163,7 +161,6 @@ public class ChatRoomService {
         return allRoomsByOwnerId.map(ChatRoomMapper::toProfileResponse);
     }
 
-    @Transactional(readOnly = true)
     public Page<RoomInfoResponse> findChatRoomsByMemberId(Long memberId, Pageable pageable) {
 
         Page<ChatRoom> chatRooms = chatRoomRepository.findChatRoomsByParticipantId(
@@ -172,7 +169,6 @@ public class ChatRoomService {
         return chatRooms.map(ChatRoomMapper::toListResponse);
     }
 
-    @Transactional(readOnly = true)
     public List<ChatParticipantResponse> getParticipants(Long memberId, Long roomId) {
         ChatRoom chatRoom = chatRoomRepository.findById(roomId)
             .orElseThrow(() -> new ChatRoomException(ChatRoomErrorCode.CHATROOM_NOT_FOUND));
@@ -226,7 +222,6 @@ public class ChatRoomService {
             .orElseThrow(() -> new ChatRoomException(ChatRoomErrorCode.CHATROOM_NOT_FOUND));
     }
 
-    @Transactional(readOnly = true)
     public ChatRoom getRoomById(Long roomId) {
         return chatRoomRepository.findById(roomId)
             .orElseThrow(() -> new ChatRoomException(ChatRoomErrorCode.CHATROOM_NOT_FOUND));
@@ -238,7 +233,7 @@ public class ChatRoomService {
         validateParticipant(memberId, room.getId());
 
         try {
-            Long currentSequence = chatRoomRedisRepository.getSequence(room.getId());
+            Long currentSequence = getLatestSequence(room.getId());
             chatParticipantRepository
                 .findByChatRoomIdAndParticipantIdAndIsActiveTrue(room.getId(), memberId)
                 .ifPresent(p -> p.updateLastReadSequence(currentSequence));
@@ -261,7 +256,6 @@ public class ChatRoomService {
         return owner.getParticipant().getId();
     }
 
-    @Transactional(readOnly = true)
     public RoomInfoResponse getRoomInfo(String inviteCode, Long memberId) {
         ChatRoom room = getByInviteCode(inviteCode);
         return ChatRoomMapper.toListResponse(room);
@@ -312,11 +306,9 @@ public class ChatRoomService {
     }
 
     public List<AllRoomsResponse> findAllRoomsByMemberId(Long memberId) {
-        // 1. 단일 프로젝션 쿼리로 DB 조회
         List<ChatRoomWithSequenceProjection> roomProjections =
             chatRoomRepository.findAllRoomsWithSequenceByParticipantId(memberId);
 
-        // 2. 단 한 번의 순회로 모든 맵 구조 생성 (O(N))
         List<Long> roomIds = new ArrayList<>(roomProjections.size());
         Map<Long, ChatRoomWithSequenceProjection> projectionMap = new HashMap<>();
         Map<Long, Integer> sequenceIndexMap = new HashMap<>();
@@ -326,10 +318,9 @@ public class ChatRoomService {
             Long id = p.getChatRoomId();
             roomIds.add(id);
             projectionMap.put(id, p);
-            sequenceIndexMap.put(id, i); // 인덱스 미리 저장 완료
+            sequenceIndexMap.put(id, i);
         }
 
-        // 3. Redis 정렬
         List<Long> sortedRoomIds;
         try {
             sortedRoomIds = chatRoomRedisRepository.getSortedRoomIds(roomIds);
@@ -338,13 +329,11 @@ public class ChatRoomService {
             sortedRoomIds = roomIds;
         }
 
-        // 4. 추가 데이터(알람, 시퀀스) 일괄 조회
         Map<Long, Boolean> alarmEnabledMap = roomIds.isEmpty()
             ? Collections.emptyMap()
             : fetchAlarmEnabledMap(memberId, roomIds);
         List<Long> sequences = getSequencesSafe(roomIds);
 
-        // 6. 최종 결과 조립
         return sortedRoomIds.stream().map(roomId -> {
             ChatRoomWithSequenceProjection p = projectionMap.get(roomId);
             boolean alarmEnabled = alarmEnabledMap.getOrDefault(roomId, true);
@@ -376,7 +365,7 @@ public class ChatRoomService {
 
     @Transactional
     public void updateLastReadSequence(Long roomId, Long memberId) {
-        Long currentSequence = chatRoomRedisRepository.getSequence(roomId);
+        Long currentSequence = getLatestSequence(roomId);
         chatParticipantRepository
             .findByChatRoomIdAndParticipantIdAndIsActiveTrue(roomId, memberId)
             .ifPresent(p -> p.updateLastReadSequence(currentSequence));
@@ -387,6 +376,7 @@ public class ChatRoomService {
             return chatRoomRedisRepository.getSequences(roomIds);
         } catch (Exception e) {
             log.warn("Redis 장애 - DB lastSequence 폴백");
+            meterRegistry.counter("redis.fallback", "reason", "sequence").increment();
             Map<Long, Long> seqMap = chatRoomRepository.findAllById(roomIds).stream()
                     .collect(Collectors.toMap(
                             ChatRoom::getId,
@@ -400,11 +390,15 @@ public class ChatRoomService {
 
     @Transactional
     public void syncSequencesToDb() {
-        List<ChatRoom> rooms = chatRoomRepository.findAll();
+        Set<String> updatedRoomIds = chatRoomRedisRepository.getAndClearUpdatedRooms();
+        if (updatedRoomIds.isEmpty()) return;
+
+        List<Long> roomIds = updatedRoomIds.stream().map(Long::valueOf).toList();
+        List<ChatRoom> rooms = chatRoomRepository.findAllById(roomIds);
         if (rooms.isEmpty()) return;
 
-        List<Long> roomIds = rooms.stream().map(ChatRoom::getId).toList();
-        List<Long> redisSequences = chatRoomRedisRepository.getSequences(roomIds);
+        List<Long> targetIds = rooms.stream().map(ChatRoom::getId).toList();
+        List<Long> redisSequences = chatRoomRedisRepository.getSequences(targetIds);
 
         for (int i = 0; i < rooms.size(); i++) {
             Long redisSeq = redisSequences.get(i);
@@ -414,5 +408,19 @@ public class ChatRoomService {
             }
         }
         log.info("last_sequence 동기화 완료 - {}개 채팅방", rooms.size());
+    }
+
+    public Long getLatestSequence(Long roomId) {
+        Long redisSeq = chatRoomRedisRepository.getSequence(roomId);
+
+        if (redisSeq == 0L) {
+            ChatRoom room = chatRoomRepository.findById(roomId)
+                    .orElseThrow(() -> new ChatRoomException(ChatRoomErrorCode.CHATROOM_NOT_FOUND));
+
+            long dbSeq = room.getLastSequence();
+            chatRoomRedisRepository.setSequence(roomId, dbSeq);
+            return dbSeq;
+        }
+        return redisSeq;
     }
 }

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/dao/ChatRoomRedisRepository.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/dao/ChatRoomRedisRepository.java
@@ -106,8 +106,7 @@ public class ChatRoomRedisRepository {
                 "if cur == false or tonumber(cur) < tonumber(ARGV[1]) then " +
                 "  redis.call('SET', KEYS[1], ARGV[1]); " +
                 "  redis.call('EXPIRE', KEYS[1], ARGV[2]); " +
-                "end; " +
-                "return tonumber(redis.call('GET', KEYS[1]));";
+                "end; ";
 
         String key = String.format(ROOM_SEQUENCE_KEY, roomId);
         redisTemplate.execute(

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/dao/ChatRoomRedisRepository.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/dao/ChatRoomRedisRepository.java
@@ -4,10 +4,13 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+
+import io.micrometer.core.instrument.MeterRegistry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisCallback;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.stereotype.Repository;
 
 @Slf4j
@@ -16,76 +19,57 @@ import org.springframework.stereotype.Repository;
 public class ChatRoomRedisRepository {
 
     private static final String ROOM_SEQUENCE_KEY = "room:%d:sequence";
-
     private static final String UPDATED_ROOMS_KEY = "rooms:updated";
     private static final String RANKING_ROOMS_KEY = "rooms:ranking";
 
+    private static final int MAX_RANKING_SIZE = 1000;
+    private static final long SEQUENCE_TTL_SEC = 60 * 60 * 24 * 3; // 3일
+
     private final StringRedisTemplate redisTemplate;
+    private final MeterRegistry meterRegistry;
 
-    public void handleMessageDelivery(Long roomId) {
-        redisTemplate.executePipelined((RedisCallback<Object>) connection -> {
-            String seqKey = String.format(ROOM_SEQUENCE_KEY, roomId);
-            String roomIdStr = String.valueOf(roomId);
+    // 방 시퀀스 INCR -> INCR된 키의 ZSET TTL 초기화 (3일) -> 랭킹 상단 등록 -> 랭킹 MAX 사이즈만큼 자르기 -> ROOM SET 추가
+    public Long handleMessageDelivery(Long roomId) {
+        String script =
+                "local prev = redis.call('GET', KEYS[1]); " +
+                "local seq = redis.call('INCR', KEYS[1]); " +
+                "redis.call('EXPIRE', KEYS[1], ARGV[1]); " +
+                "redis.call('ZADD', KEYS[2], ARGV[2], ARGV[3]); " +
+                "redis.call('ZREMRANGEBYRANK', KEYS[2], 0, ARGV[4]); " +
+                "redis.call('SADD', KEYS[3], ARGV[3]); " +
+                "if prev == false then return -1 end; " +
+                "return seq;";
 
-            connection.stringCommands().incr(seqKey.getBytes());
+        String seqKey = String.format(ROOM_SEQUENCE_KEY, roomId);
+        String roomIdStr = String.valueOf(roomId);
 
-            connection.zSetCommands().zAdd(
-                    RANKING_ROOMS_KEY.getBytes(),
-                    System.currentTimeMillis(),
-                    roomIdStr.getBytes()
+        try {
+            return redisTemplate.execute(
+                    new DefaultRedisScript<>(script, Long.class),
+                    List.of(seqKey, RANKING_ROOMS_KEY, UPDATED_ROOMS_KEY),
+                    String.valueOf(SEQUENCE_TTL_SEC),
+                    String.valueOf(System.currentTimeMillis()),
+                    roomIdStr,
+                    String.valueOf(-MAX_RANKING_SIZE - 1)
             );
-
-            connection.setCommands().sAdd(
-                    UPDATED_ROOMS_KEY.getBytes(),
-                    roomIdStr.getBytes()
-            );
+        } catch (Exception e) {
+            log.error("Lua 스크립트 실행 오류 - roomId: {}", roomId, e);
+            meterRegistry.counter("redis.fallback", "method", "handleMessageDelivery").increment();
             return null;
-        });
-    }
-
-    public Long getSequence(Long roomId) {
-        String key = String.format(ROOM_SEQUENCE_KEY, roomId);
-        String value = redisTemplate.opsForValue().get(key);
-        return value == null ? 0L : Long.parseLong(value);
-    }
-
-    public List<Long> getSequences(List<Long> roomIds) {
-        if (roomIds == null || roomIds.isEmpty()) {
-            return List.of();
         }
-        List<Object> values = redisTemplate.executePipelined(
-                (RedisCallback<Object>) connection -> {
-                    for (Long roomId : roomIds) {
-                        String key = String.format(ROOM_SEQUENCE_KEY, roomId);
-                        connection.stringCommands().get(key.getBytes());
-                    }
-                    return null;
-                });
-        List<Long> result = new ArrayList<>(roomIds.size());
-
-        for (Object val : values) {
-            if (val == null) {
-                result.add(0L);
-            } else {
-                result.add(Long.parseLong(new String((byte[]) val)));
-            }
-        }
-        return result;
     }
 
     public List<Long> getSortedRoomIds(List<Long> roomIds) {
-        if (roomIds == null || roomIds.isEmpty()) {
-            return List.of();
-        }
-        Set<String> ranked = redisTemplate.opsForZSet()
-                .reverseRange(RANKING_ROOMS_KEY, 0, roomIds.size() - 1);
+        if (roomIds == null || roomIds.isEmpty()) return List.of();
 
-        if (ranked == null || ranked.isEmpty()) {
-            return new ArrayList<>(roomIds);
-        }
+        Set<String> ranked = redisTemplate.opsForZSet()
+                .reverseRange(RANKING_ROOMS_KEY, 0, MAX_RANKING_SIZE);
+
+        if (ranked == null || ranked.isEmpty()) return new ArrayList<>(roomIds);
 
         Set<Long> roomIdSet = new HashSet<>(roomIds);
         List<Long> sorted = new ArrayList<>(roomIds.size());
+
         for (String r : ranked) {
             Long id = Long.valueOf(r);
             if (roomIdSet.contains(id)) {
@@ -100,5 +84,69 @@ public class ChatRoomRedisRepository {
             }
         }
         return sorted;
+    }
+
+    public Set<String> getAndClearUpdatedRooms() {
+        String script =
+                "local members = redis.call('SMEMBERS', KEYS[1]); " +
+                        "redis.call('DEL', KEYS[1]); " +
+                        "return members;";
+
+        List<String> result = redisTemplate.execute(
+                new DefaultRedisScript<>(script, List.class),
+                List.of(UPDATED_ROOMS_KEY)
+        );
+
+        return result != null ? new HashSet<>(result) : Set.of();
+    }
+
+    public void setSequence(Long roomId, Long sequence) {
+        String script =
+                "local cur = redis.call('GET', KEYS[1]); " +
+                "if cur == false or tonumber(cur) < tonumber(ARGV[1]) then " +
+                "  redis.call('SET', KEYS[1], ARGV[1]); " +
+                "  redis.call('EXPIRE', KEYS[1], ARGV[2]); " +
+                "end; " +
+                "return tonumber(redis.call('GET', KEYS[1]));";
+
+        String key = String.format(ROOM_SEQUENCE_KEY, roomId);
+        redisTemplate.execute(
+                new DefaultRedisScript<>(script, Long.class),
+                List.of(key),
+                String.valueOf(sequence),
+                String.valueOf(SEQUENCE_TTL_SEC)
+        );
+    }
+
+    public Long getSequence(Long roomId) {
+        String key = String.format(ROOM_SEQUENCE_KEY, roomId);
+        String value = redisTemplate.opsForValue().get(key);
+        return value == null ? 0L : Long.parseLong(value);
+    }
+
+    public List<Long> getSequences(List<Long> roomIds) {
+        if (roomIds == null || roomIds.isEmpty()) return List.of();
+
+        List<Object> values = redisTemplate.executePipelined((RedisCallback<Object>) connection -> {
+            for (Long roomId : roomIds) {
+                connection.stringCommands().get(toBytes(String.format(ROOM_SEQUENCE_KEY, roomId)));
+            }
+            return null;
+        });
+
+        List<Long> result = new ArrayList<>(roomIds.size());
+        for (Object val : values) {
+            if (val == null) {
+                result.add(0L);
+            } else {
+                String strVal = val instanceof byte[] ? new String((byte[]) val) : val.toString();
+                result.add(Long.parseLong(strVal));
+            }
+        }
+        return result;
+    }
+
+    private byte[] toBytes(String key) {
+        return redisTemplate.getStringSerializer().serialize(key);
     }
 }

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/dao/ChatRoomRepository.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/dao/ChatRoomRepository.java
@@ -32,14 +32,6 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
     Page<ChatRoom> findAllRoomsByOwnerId(Long ownerId, Pageable pageable);
 
     @Query("""
-        SELECT cr
-        FROM ChatRoom cr
-        JOIN cr.participants cp
-        WHERE cp.participant.id = :memberId AND cp.isActive = true
-        """)
-    List<ChatRoom> findAllRoomsByParticipantId(@Param("memberId") Long memberId);
-
-    @Query("""
         SELECT cr.id AS chatRoomId, cr.name AS name, cr.inviteCode AS inviteCode,
         	   cp.lastReadSequence AS lastReadSequence
         FROM ChatRoom cr

--- a/backend/src/main/java/project/backend/domain/community/app/PostService.java
+++ b/backend/src/main/java/project/backend/domain/community/app/PostService.java
@@ -12,7 +12,6 @@ import project.backend.domain.chat.chatmessage.entity.ChatMessage;
 import project.backend.domain.chat.chatmessage.mapper.ChatMessageMapper;
 import project.backend.domain.chat.chatroom.app.ChatRoomService;
 import project.backend.domain.chat.chatroom.dao.ChatParticipantRepository;
-import project.backend.domain.chat.chatroom.dao.ChatRoomRedisRepository;
 import project.backend.domain.chat.chatroom.dao.ChatRoomRepository;
 import project.backend.domain.chat.chatroom.entity.ChatParticipant;
 import project.backend.domain.chat.chatroom.entity.ChatRoom;
@@ -46,7 +45,6 @@ public class PostService {
     private final PostRepository postRepository;
     private final ChatRoomRepository chatRoomRepository;
     private final ChatMessageRepository chatMessageRepository;
-    private final ChatRoomRedisRepository chatRoomRedisRepository;
     private final ChatParticipantRepository chatParticipantRepository;
     private final ApplicantRepository applicantRepository;
     private final ChatMessageMapper chatMessageMapper;
@@ -82,7 +80,6 @@ public class PostService {
         return posts.map(PostResponse::from);
     }
 
-    // 게시글 상세 조회 + 조회수 증가
     @Transactional
     public PostResponse getPost(Long postId) {
         Post post = postRepository.findById(postId)
@@ -91,7 +88,6 @@ public class PostService {
         return PostResponse.from(post);
     }
 
-    // 게시글 작성
     @Transactional
     public PostResponse createPost(PostCreateRequest request, MemberDetails memberDetails) {
         Member author = Member.of(memberDetails);
@@ -108,7 +104,6 @@ public class PostService {
             postRepository.save(CommunityMapper.toPost(request, author, chatRoom)));
     }
 
-    // 게시글 수정
     @Transactional
     public PostResponse updatePost(Long postId, PostUpdateRequest request,
         MemberDetails memberDetails) {
@@ -138,7 +133,6 @@ public class PostService {
         return PostResponse.from(post);
     }
 
-    // 게시글 삭제
     @Transactional
     public void deletePost(Long postId, MemberDetails memberDetails) {
         Post post = postRepository.findById(postId)
@@ -169,6 +163,12 @@ public class PostService {
         if (post.getAuthor().getId().equals(member.getId())) {
             throw new PostException(PostErrorCode.CANNOT_APPLY_OWN_POST);
         }
+
+        if (chatParticipantRepository.existsByParticipantIdAndChatRoomIdAndIsActiveTrue(
+                member.getId(), post.getChatRoom().getId())) {
+            throw new ChatRoomException(ChatRoomErrorCode.ALREADY_PARTICIPANT);
+        }
+
         applicantRepository.findByPost_IdAndMember_Id(postId, member.getId())
             .ifPresent(existing -> {
                 existing.validateReapply();
@@ -210,7 +210,7 @@ public class PostService {
             post.getChatRoom());
         chatParticipantRepository.save(chatParticipant);
 
-        Long currentSequence = chatRoomRedisRepository.getSequence(post.getChatRoom().getId());
+        Long currentSequence = chatRoomService.getLatestSequence(post.getChatRoom().getId());
         chatParticipant.updateLastReadSequence(currentSequence);
 
         chatRoomService.createAlarm(applicant.getMember().getId(), post.getChatRoom().getId());

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -14,36 +14,38 @@ import Signup from './pages/signup';
 import MyPage from './pages/profile';
 import EditProfilePage from './pages/editprofile';
 import ErrorPage from './pages/ErrorPage';
+import { WebSocketProvider } from './components/common/WebSocketContext'
 
 import Layout from './Layout';
 import { AlarmProvider } from './context/AlarmContext';
 
 function App() {
-
   return (
-  <AlarmProvider>
-    <BrowserRouter>
-      <Routes>
-        {/* 공통 레이아웃이 적용될 라우트들 */}
-        <Route element={<Layout />}>
-          <Route path="/chat/:inviteCode" element={<ChatRoom />} />
-          <Route path="/blank" element={<BlankRoom />} />
-          <Route path="/community" element={<Community />} />
-          <Route path="/community/write" element={<CommunityWrite />} />
-          <Route path="/community/:postId" element={<CommunityDetail />} />
-          <Route path="/community/:postId/edit" element={<CommunityEdit />} />
-          <Route path="/community/:postId/applicants" element={<CommunityApplicants />} />
-          <Route path="/myprofile" element={<MyPage />} />
-          <Route path="/myprofile/edit" element={<EditProfilePage />} />
-          <Route path="/" element={<Home />} />
-        </Route>
-        {/* 레이아웃 없는 라우트 (예: 로그인, 회원가입, 에러 페이지) */}
-        <Route path="/login" element={<Login />} />
-        <Route path="/signup" element={<Signup />} />
-        <Route path="/error" element={<ErrorPage />} />
-      </Routes>
-    </BrowserRouter>
-  </AlarmProvider>
+    <AlarmProvider>
+      <BrowserRouter>
+        <Routes>
+          <Route element={
+            <WebSocketProvider>
+              <Layout />
+            </WebSocketProvider>
+          }>
+            <Route path="/chat/:inviteCode" element={<ChatRoom />} />
+            <Route path="/blank" element={<BlankRoom />} />
+            <Route path="/community" element={<Community />} />
+            <Route path="/community/write" element={<CommunityWrite />} />
+            <Route path="/community/:postId" element={<CommunityDetail />} />
+            <Route path="/community/:postId/edit" element={<CommunityEdit />} />
+            <Route path="/community/:postId/applicants" element={<CommunityApplicants />} />
+            <Route path="/myprofile" element={<MyPage />} />
+            <Route path="/myprofile/edit" element={<EditProfilePage />} />
+            <Route path="/" element={<Home />} />
+          </Route>
+          <Route path="/login" element={<Login />} />
+          <Route path="/signup" element={<Signup />} />
+          <Route path="/error" element={<ErrorPage />} />
+        </Routes>
+      </BrowserRouter>
+    </AlarmProvider>
   );
 }
 

--- a/frontend/src/components/SideBar.jsx
+++ b/frontend/src/components/SideBar.jsx
@@ -39,11 +39,7 @@ const Sidebar = ({ onStartChat }) => {
 
   const [currentUser, setCurrentUser] = useState(null)
   const [roomId, setRoomId] = useState(null)
-
-  const roomIdRef = useRef(null)
-  useEffect(() => {
-    roomIdRef.current = roomId
-  }, [roomId])
+  const roomIdRef = useRef(roomId)
 
   const { getAlarmStatus, alarmStatusMap = {} } = useAlarm()
 
@@ -56,11 +52,16 @@ const Sidebar = ({ onStartChat }) => {
     }
   })
 
+  // roomId 최신값 유지
+  useEffect(() => {
+    roomIdRef.current = roomId
+  }, [roomId])
+
   const handleSidebarMessage = (roomUniqueId, message) => {
     if (Number(roomIdRef.current) !== Number(roomUniqueId)) {
       setAlarmRooms(prev => prev.map(r =>
         Number(r.uniqueId) === Number(roomUniqueId)
-          ? { ...r, unreadCount: r.unreadCount === null ? null : (r.unreadCount ?? 0) + 1 }
+          ? { ...r, unreadCount: (r.unreadCount ?? 0) + 1 }
           : r
       ))
 
@@ -93,26 +94,26 @@ const Sidebar = ({ onStartChat }) => {
     }
   }
 
-  const stompClientRef = useWebSocket({
+  useWebSocket({
     chatRooms: alarmRooms,
     currentRoomId: roomId,
     onSidebarMessage: handleSidebarMessage,
-    onMessageReceived: () => {},
-    roomId: null,
   })
 
-  useEffect(() => {
-    const handleRoomRead = () => fetchAllRooms()
-    window.addEventListener('room:read', handleRoomRead)
-    return () => window.removeEventListener('room:read', handleRoomRead)
-  }, [])
-
+  // 초기 로드 및 탭/알람 변경 시 (inviteCode 제거 → room:read 이벤트로 대체)
   useEffect(() => {
     if (activeTab === "chat") {
       fetchAllRooms()
       fetchCurrentUser()
     }
-  }, [activeTab])
+  }, [activeTab, alarmStatusMap])
+
+  // room:read 이벤트 수신 시 fetchAllRooms → /read API 완료 후 서버 상태 반영
+  useEffect(() => {
+    const handleRoomRead = () => fetchAllRooms()
+    window.addEventListener('room:read', handleRoomRead)
+    return () => window.removeEventListener('room:read', handleRoomRead)
+  }, [])
 
   useEffect(() => {
     if (!inviteCode) {
@@ -125,7 +126,7 @@ const Sidebar = ({ onStartChat }) => {
     } else {
       setRoomId(null)
     }
-  }, [inviteCode, alarmRooms])
+  }, [inviteCode, alarmRooms, alarmStatusMap])
 
   const fetchCurrentUser = async () => {
     try {
@@ -148,19 +149,11 @@ const Sidebar = ({ onStartChat }) => {
         alarmEnabled: room.alarmEnabled ?? true,
         roomName: room.roomName || `Room ${room.roomId || room.id}`,
         inviteCode: room.inviteCode,
-        unreadCount: room.unreadCount !== undefined ? room.unreadCount : null,
+        unreadCount: room.unreadCount ?? 0,
       })).filter(room => room.uniqueId)
 
-      const currentRoomId = roomIdRef.current
-      const correctedRooms = rooms.map(room => {
-        if (currentRoomId && Number(room.uniqueId) === Number(currentRoomId)) {
-          return { ...room, unreadCount: 0 }
-        }
-        return room
-      })
-
-      setAlarmRooms(correctedRooms)
-      localStorage.setItem(CACHE_KEY, JSON.stringify(correctedRooms))
+      setAlarmRooms(rooms)
+      localStorage.setItem(CACHE_KEY, JSON.stringify(rooms))
       setRoomsReady(true)
     } catch (e) {
       console.error('채팅방 목록 로딩 실패', e)
@@ -171,12 +164,14 @@ const Sidebar = ({ onStartChat }) => {
 
   const navigateToRoom = async (id, inviteCode) => {
     if (id) {
-      const prevRoomId = roomIdRef.current
-      if (prevRoomId) {
-        setAlarmRooms(prev => prev.map(r =>
-          Number(r.uniqueId) === Number(prevRoomId) ? { ...r, unreadCount: 0 } : r
-        ))
+      if (roomIdRef.current) {
+        await axiosInstance.post(`/chat-rooms/${roomIdRef.current}/read`).catch((e) => {
+          console.error("read API 실패:", e)
+        })
       }
+      setAlarmRooms(prev => prev.map(r =>
+        Number(r.uniqueId) === Number(roomIdRef.current) ? { ...r, unreadCount: 0 } : r
+      ))
       navigate(`/chat/${inviteCode}`)
     }
   }
@@ -257,24 +252,7 @@ const Sidebar = ({ onStartChat }) => {
 
       const created = res.data
       setShowCreateModal(false)
-      fetchAllRooms()
-
-      if (created) {
-        const newRoom = {
-          ...created,
-          uniqueId: created.id || created.roomId,
-          ownerId: created.ownerId || (currentUser ? currentUser.id : null),
-          participants: [
-            {
-              ...(currentUser || {}),
-              owner: true,
-              nickname: currentUser?.nickname || currentUser?.username || "나",
-            },
-          ],
-        }
-        setAlarmRooms(prev => [newRoom, ...prev.slice(0, 9)])
-        fetchAllRooms()
-      }
+      await fetchAllRooms()
 
       if (created?.id) {
         navigate(`/chat/${created.inviteCode}`)
@@ -288,9 +266,9 @@ const Sidebar = ({ onStartChat }) => {
   const handleJoinRoom = async (inviteCode) => {
     try {
       const res = await axiosInstance.post("/chat-rooms/join", { inviteCode })
-      const joined = await res.data
+      const joined = res.data
       setShowJoinModal(false)
-      fetchAllRooms()
+      await fetchAllRooms()
 
       if (joined?.id) {
         navigate(`/chat/${joined.inviteCode}`)
@@ -319,9 +297,8 @@ const Sidebar = ({ onStartChat }) => {
               const isCurrentRoom = roomId && Number(roomId) === Number(roomUniqueId)
               const isSelectedForModal = selectedRoom && Number(selectedRoom.uniqueId) === Number(roomUniqueId) && showMembersModal
               const roomInviteCode = room.inviteCode
-              const unreadCount = room.unreadCount
-              const isNew = unreadCount === null
-              const hasUnread = (isNew || unreadCount > 0) && !isCurrentRoom
+              const unreadCount = room.unreadCount ?? 0
+              const hasUnread = unreadCount > 0 && !isCurrentRoom
 
               return (
                 <div key={`room-${roomUniqueId}`} className={styles.roomItem}>
@@ -334,7 +311,7 @@ const Sidebar = ({ onStartChat }) => {
                         <FaRegCommentDots size={14} />
                         {hasUnread && (
                           <div className={styles.unreadBadge}>
-                            {isNew ? 'NEW' : unreadCount > 99 ? "99+" : unreadCount}
+                            {unreadCount > 99 ? "99+" : unreadCount}
                           </div>
                         )}
                       </div>

--- a/frontend/src/components/chatroom/MessageList.jsx
+++ b/frontend/src/components/chatroom/MessageList.jsx
@@ -172,7 +172,7 @@ const EditedLabel = () => (
   <span style={{ marginLeft: '5px', fontSize: '11px', color: '#ccc', fontStyle: 'italic' }}>(수정됨)</span>
 );
 
-/* ── 메시지 아이템 ── ✅ export 추가 */
+/* ── 메시지 아이템 ── */
 export const MessageItem = ({
   msg, currentUser, contextMenuId, setContextMenuId,
   setEditMessageId, setEditContent, handleEditMessage,
@@ -196,6 +196,11 @@ export const MessageItem = ({
   const isMenuOpen = contextMenuId === msg.messageId;
   const isOwn = currentUser?.id === msg.senderId;
 
+  // profileImageUrl 없으면 처음부터 fallback → 실패 요청 없음
+  const profileSrc = msg.profileImageUrl
+    ? `${process.env.REACT_APP_PROFILE_IMAGE_URL}/${msg.profileImageUrl}`
+    : '/images/not-found-profile.png';
+
   return (
     <div
       id={`message-${msg.messageId}`}
@@ -212,12 +217,12 @@ export const MessageItem = ({
         marginBottom: '2px',
       }}
     >
-      {/* 프로필 이미지 */}
       <img
-        src={`${process.env.REACT_APP_PROFILE_IMAGE_URL}/${msg.profileImageUrl}`}
+        src={profileSrc}
         alt="프로필"
         width={36}
         height={36}
+        loading="eager"
         onError={(e) => { e.currentTarget.src = '/images/not-found-profile.png'; }}
         style={{
           borderRadius: '4px',
@@ -229,7 +234,6 @@ export const MessageItem = ({
       />
 
       <div style={{ flex: 1, minWidth: 0 }}>
-        {/* 발신자 + 시간 */}
         <div style={{ display: 'flex', alignItems: 'baseline', gap: '6px', marginBottom: '3px' }}>
           <span style={{ fontWeight: '700', fontSize: '14px', color: '#1d1c1d' }}>
             {msg.senderName}
@@ -239,7 +243,6 @@ export const MessageItem = ({
           </span>
         </div>
 
-        {/* 메시지 본문 */}
         <MessageContent
           msg={msg}
           editMessageId={editMessageId}
@@ -251,7 +254,6 @@ export const MessageItem = ({
         />
       </div>
 
-      {/* 호버 액션 버튼 (본인 메시지만) */}
       {isOwn && !(msg.status === 'DELETED') && (isHovered || isMenuOpen) && (
         <div style={{
           position: 'absolute',
@@ -311,7 +313,7 @@ const ActionBtn = ({ label, onClick, danger = false }) => {
   );
 };
 
-/* ── 날짜 구분선 ── ✅ export 추가 */
+/* ── 날짜 구분선 ── */
 export const DateDivider = ({ label }) => (
   <div style={{
     display: 'flex', alignItems: 'center',
@@ -330,7 +332,7 @@ export const DateDivider = ({ label }) => (
   </div>
 );
 
-/* ── 메시지 리스트 (기존 사용처 호환용 default export 유지) ── */
+/* ── 메시지 리스트 ── */
 const MessageList = ({
   messages, currentUser, contextMenuId, setContextMenuId,
   setEditMessageId, setEditContent, editMessageId, editContent,

--- a/frontend/src/components/common/WebSocketContext.js
+++ b/frontend/src/components/common/WebSocketContext.js
@@ -1,0 +1,58 @@
+import { createContext, useContext, useEffect, useRef, useState } from "react"
+import { Client } from "@stomp/stompjs"
+import { useNavigate } from "react-router-dom"
+import { safeRefreshToken } from "../api/refreshManager"
+
+const WebSocketContext = createContext(null)
+
+export const WebSocketProvider = ({ children }) => {
+  const stompClientRef = useRef(null)
+  const [connected, setConnected] = useState(false)
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    const client = new Client({
+      webSocketFactory: () => new WebSocket(process.env.REACT_APP_WEB_SOCKET_URL),
+      heartbeatIncoming: 15000,
+      heartbeatOutgoing: 10000,
+      withCredentials: true,
+
+      onConnect: () => {
+        console.log("✅ Connected to WebSocket")
+        setConnected(true)
+      },
+
+      onWebSocketClose: async () => {
+        console.warn("🛑 WebSocket 끊김 → 토큰 갱신 시도")
+        client.deactivate()
+        try {
+          await safeRefreshToken()
+          client.activate()
+        } catch (err) {
+          console.error("❌ 토큰 갱신 실패 → 로그인 페이지로 이동")
+          navigate("/login")
+        }
+      },
+
+      onStompError: (frame) => {
+        console.error("💥 STOMP error:", frame.headers["message"])
+      },
+    })
+
+    client.activate()
+    stompClientRef.current = client
+
+    return () => {
+      setConnected(false)
+      if (client.active) client.deactivate()
+    }
+  }, [navigate])
+
+  return (
+    <WebSocketContext.Provider value={{ stompClientRef, connected }}>
+      {children}
+    </WebSocketContext.Provider>
+  )
+}
+
+export const useWebSocketContext = () => useContext(WebSocketContext)

--- a/frontend/src/components/common/useWebSocket.jsx
+++ b/frontend/src/components/common/useWebSocket.jsx
@@ -1,9 +1,7 @@
 "use client"
 
-import { useEffect, useRef, useState } from "react"
-import { Client } from "@stomp/stompjs"
-import { useNavigate } from "react-router-dom"
-import { safeRefreshToken } from "../api/refreshManager"
+import { useEffect, useRef } from "react"
+import { useWebSocketContext } from "./WebSocketContext"
 
 const useWebSocket = ({
   roomId,
@@ -18,212 +16,112 @@ const useWebSocket = ({
   dmRoomId,
   onDmMessageReceived,
 }) => {
-  const stompClientRef = useRef(null)
+  const { stompClientRef, connected } = useWebSocketContext()
+
+  // 모든 콜백을 ref로 관리 → 구독 재등록 없이 항상 최신 함수 호출
+  const onMessageReceivedRef = useRef(onMessageReceived)
+  const onNotificationReceivedRef = useRef(onNotificationReceived)
+  const onProfileUpdateRef = useRef(onProfileUpdate)
+  const onRoomDeletedRef = useRef(onRoomDeleted)
+  const onSidebarMessageRef = useRef(onSidebarMessage)
+  const onDmMessageReceivedRef = useRef(onDmMessageReceived)
+  const currentRoomIdRef = useRef(currentRoomId)
+
+  useEffect(() => { onMessageReceivedRef.current = onMessageReceived }, [onMessageReceived])
+  useEffect(() => { onNotificationReceivedRef.current = onNotificationReceived }, [onNotificationReceived])
+  useEffect(() => { onProfileUpdateRef.current = onProfileUpdate }, [onProfileUpdate])
+  useEffect(() => { onRoomDeletedRef.current = onRoomDeleted }, [onRoomDeleted])
+  useEffect(() => { onSidebarMessageRef.current = onSidebarMessage }, [onSidebarMessage])
+  useEffect(() => { onDmMessageReceivedRef.current = onDmMessageReceived }, [onDmMessageReceived])
+  useEffect(() => { currentRoomIdRef.current = currentRoomId }, [currentRoomId])
+
   const subscriptionRef = useRef(null)
   const notificationSubscriptionRef = useRef(null)
   const profileSubscriptionRef = useRef(null)
-  const hasConnectedRef = useRef(false)
-  const sidebarSubscriptionsRef = useRef(new Map())
-  const keepAliveIntervalRef = useRef(null)
   const deleteSubscriptionRef = useRef(null)
-  const [connected, setConnected] = useState(false)
+  const sidebarSubscriptionsRef = useRef(new Map())
 
-  const navigate = useNavigate()
-
-  // 메인 웹소켓 연결 (사이드바 구독 제외)
-  useEffect(() => {
-    const client = new Client({
-      webSocketFactory: () => new WebSocket(process.env.REACT_APP_WEB_SOCKET_URL),
-      heartbeatIncoming: 15000,
-      heartbeatOutgoing: 10000,
-      withCredentials: true,
-      debug: (str) => console.log(`[STOMP] ${str}`),
-
-      onConnect: () => {
-        console.log("✅ Connected to WebSocket")
-        setConnected(true)
-        hasConnectedRef.current = true
-
-        // 들어가 있는 채팅방 구독
-        if (roomId && onMessageReceived) {
-          if (subscriptionRef.current) {
-            subscriptionRef.current.unsubscribe()
-            console.log("🔁 Previous chat subscription cleared.")
-          }
-
-          subscriptionRef.current = client.subscribe(`/topic/chat/${roomId}`, (message) => {
-            try {
-              const received = JSON.parse(message.body)
-              received.sendAt = received.sendAt || new Date().toISOString()
-              onMessageReceived(received)
-            } catch (e) {
-              console.error("📛 Failed to parse chat message", e)
-            }
-          })
-        }
-
-        // Notification 구독
-        if (username && onNotificationReceived) {
-          if (notificationSubscriptionRef.current) {
-            notificationSubscriptionRef.current.unsubscribe()
-            console.log("🔁 Previous notification subscription cleared.")
-          }
-
-          notificationSubscriptionRef.current = client.subscribe(`/topic/notifications/${username}`, (message) => {
-            try {
-              const notification = JSON.parse(message.body)
-              notification.timestamp = new Date().toISOString()
-              notification.id = `${Date.now()}-${Math.random()}`
-              console.log("🔔 New notification received:", notification)
-              onNotificationReceived(notification)
-            } catch (e) {
-              console.error("📛 Failed to parse notification message", e)
-            }
-          })
-
-          console.log(`🔔 Subscribed to notifications for user: ${username}`)
-        }
-
-        // 프로필 업데이트 구독
-        if (onProfileUpdate) {
-          if (profileSubscriptionRef.current) {
-            profileSubscriptionRef.current.unsubscribe()
-            console.log("🔁 Previous profile subscription cleared.")
-          }
-
-          profileSubscriptionRef.current = client.subscribe('/topic/profile-update', (message) => {
-            try {
-              const profileUpdate = JSON.parse(message.body)
-              console.log("🔥 프로필 업데이트 수신:", profileUpdate)
-              onProfileUpdate(profileUpdate)
-            } catch (e) {
-              console.error("📛 Failed to parse profile update message", e)
-            }
-          })
-
-          console.log("👤 프로필 업데이트 구독 완료")
-        }
-
-        // 방 삭제 구독
-        if (roomId && onRoomDeleted) {
-          deleteSubscriptionRef.current = client.subscribe(`/topic/chat/${roomId}/deleted`, (message) => {
-            try {
-              const deleteData = JSON.parse(message.body)
-              console.log("🗑️ Room deletion received:", deleteData)
-              if (onRoomDeleted && typeof onRoomDeleted === "function") {
-                onRoomDeleted(deleteData)
-              }
-            } catch (e) {
-              console.error("📛 Failed to parse delete message", e)
-            }
-          })
-        }
-
-        // Keep alive
-        if (keepAliveIntervalRef.current) clearInterval(keepAliveIntervalRef.current)
-
-        keepAliveIntervalRef.current = setInterval(() => {
-          if (client && client.connected) {
-            client.publish({
-              destination: "/app/ping",
-              body: "p"
-            })
-            console.log("📡 Sent keep-alive ping")
-          }
-        }, 15000)
-      },
-
-      onWebSocketClose: async () => {
-        console.warn('🛑 WebSocket 끊김 → 토큰 갱신 시도')
-        client.deactivate()
-        try {
-          await safeRefreshToken()
-          client.activate()
-        } catch (err) {
-          console.error('❌ 토큰 갱신 실패 → 로그인 페이지로 이동')
-          navigate('/login')
-        }
-      },
-
-      onStompError: (frame) => {
-        console.error("💥 STOMP error:", frame.headers['message'])
-      }
-    })
-
-    client.activate()
-    stompClientRef.current = client
-
-    return () => {
-      console.log("🧹 Cleaning up WebSocket...")
-      setConnected(false)
-
-      if (keepAliveIntervalRef.current) {
-        clearInterval(keepAliveIntervalRef.current)
-        keepAliveIntervalRef.current = null
-        console.log("🔕 Stopped keep-alive ping")
-      }
-
-      if (subscriptionRef.current) {
-        subscriptionRef.current.unsubscribe()
-        subscriptionRef.current = null
-        console.log("🔌 Chat subscription unsubscribed.")
-      }
-
-      if (notificationSubscriptionRef.current) {
-        notificationSubscriptionRef.current.unsubscribe()
-        notificationSubscriptionRef.current = null
-        console.log("🔔 Notification subscription unsubscribed.")
-      }
-
-      if (profileSubscriptionRef.current) {
-        profileSubscriptionRef.current.unsubscribe()
-        profileSubscriptionRef.current = null
-        console.log("👤 Profile subscription unsubscribed.")
-      }
-
-      if (deleteSubscriptionRef.current) {
-        deleteSubscriptionRef.current.unsubscribe()
-        deleteSubscriptionRef.current = null
-        console.log("🗑️ Delete subscription unsubscribed.")
-      }
-
-      sidebarSubscriptionsRef.current.forEach((subscription) => {
-        subscription.unsubscribe()
-      })
-      sidebarSubscriptionsRef.current.clear()
-
-      if (client && client.active) {
-        client.deactivate().then(() => {
-          console.log("🛑 Disconnected from WebSocket")
-        })
-      }
-    }
-  }, [currentRoomId, navigate, onProfileUpdate, roomId, username, onNotificationReceived])
-
-  // 사이드바 구독 전용 useEffect
-  // chatRooms가 바뀌거나 연결될 때만 재구독, 방 이동 시 웹소켓 재연결 없이 currentRoomId만 업데이트
+  // 채팅방 + 프로필 + 방 삭제 + 알림 구독
+  // 콜백은 ref로 관리하므로 의존성에서 제외 → roomId, connected 바뀔 때만 재구독
   useEffect(() => {
     const client = stompClientRef.current
-    if (!client?.connected || !chatRooms.length || !onSidebarMessage) return
+    if (!client?.connected) return
 
-    // 기존 사이드바 구독 정리
-    sidebarSubscriptionsRef.current.forEach((sub, id) => {
-      sub.unsubscribe()
-      console.log(`🔁 Previous sidebar subscription for room ${id} cleared.`)
+    if (roomId) {
+      subscriptionRef.current?.unsubscribe()
+      subscriptionRef.current = client.subscribe(`/topic/chat/${roomId}`, (message) => {
+        try {
+          const received = JSON.parse(message.body)
+          received.sendAt = received.sendAt || new Date().toISOString()
+          onMessageReceivedRef.current?.(received)
+        } catch (e) {
+          console.error("📛 Failed to parse chat message", e)
+        }
+      })
+
+      deleteSubscriptionRef.current?.unsubscribe()
+      deleteSubscriptionRef.current = client.subscribe(`/topic/chat/${roomId}/deleted`, (message) => {
+        try {
+          onRoomDeletedRef.current?.(JSON.parse(message.body))
+        } catch (e) {
+          console.error("📛 Failed to parse delete message", e)
+        }
+      })
+    }
+
+    if (username) {
+      notificationSubscriptionRef.current?.unsubscribe()
+      notificationSubscriptionRef.current = client.subscribe(`/topic/notifications/${username}`, (message) => {
+        try {
+          const notification = JSON.parse(message.body)
+          notification.timestamp = new Date().toISOString()
+          notification.id = `${Date.now()}-${Math.random()}`
+          onNotificationReceivedRef.current?.(notification)
+        } catch (e) {
+          console.error("📛 Failed to parse notification message", e)
+        }
+      })
+    }
+
+    profileSubscriptionRef.current?.unsubscribe()
+    profileSubscriptionRef.current = client.subscribe("/topic/profile-update", (message) => {
+      try {
+        onProfileUpdateRef.current?.(JSON.parse(message.body))
+      } catch (e) {
+        console.error("📛 Failed to parse profile update message", e)
+      }
     })
+
+    return () => {
+      subscriptionRef.current?.unsubscribe()
+      subscriptionRef.current = null
+      deleteSubscriptionRef.current?.unsubscribe()
+      deleteSubscriptionRef.current = null
+      notificationSubscriptionRef.current?.unsubscribe()
+      notificationSubscriptionRef.current = null
+      profileSubscriptionRef.current?.unsubscribe()
+      profileSubscriptionRef.current = null
+    }
+  }, [connected, roomId, username])
+
+  // 사이드바 구독 (현재 방 제외)
+  useEffect(() => {
+    const client = stompClientRef.current
+    if (!client?.connected || !chatRooms.length) return
+
+    sidebarSubscriptionsRef.current.forEach((sub) => sub.unsubscribe())
     sidebarSubscriptionsRef.current.clear()
 
-    // 새로 구독
-    chatRooms.forEach(room => {
+    chatRooms.forEach((room) => {
       const roomUniqueId = room.uniqueId
       if (!roomUniqueId) return
+      if (Number(currentRoomIdRef.current) === Number(roomUniqueId)) return
 
       const sub = client.subscribe(`/topic/chat/${roomUniqueId}`, (message) => {
         try {
           const received = JSON.parse(message.body)
-          if (Number(currentRoomId) !== Number(roomUniqueId) && received.type !== 'EVENT') {
-            onSidebarMessage(roomUniqueId, received)
-            console.log(`📨 New message in room ${roomUniqueId}`)
+          if (received.type !== "EVENT" && Number(currentRoomIdRef.current) !== Number(roomUniqueId)) {
+            onSidebarMessageRef.current?.(roomUniqueId, received)
           }
         } catch (e) {
           console.error("📛 Failed to parse sidebar message", e)
@@ -231,41 +129,29 @@ const useWebSocket = ({
       })
 
       sidebarSubscriptionsRef.current.set(roomUniqueId, sub)
-      console.log(`📡 Subscribed to sidebar room: ${roomUniqueId}`)
     })
 
     return () => {
-      sidebarSubscriptionsRef.current.forEach((sub, id) => {
-        sub.unsubscribe()
-        console.log(`🔌 Sidebar subscription for room ${id} unsubscribed.`)
-      })
+      sidebarSubscriptionsRef.current.forEach((sub) => sub.unsubscribe())
       sidebarSubscriptionsRef.current.clear()
     }
-  }, [connected, chatRooms, currentRoomId, onSidebarMessage])
+  }, [connected, chatRooms, currentRoomId])
 
   // DM 구독
   useEffect(() => {
     const client = stompClientRef.current
-    if (!client?.connected || !dmRoomId || !onDmMessageReceived) return
+    if (!client?.connected || !dmRoomId) return
 
-    const destination = `/topic/dm/${dmRoomId}`
-
-    const subscription = client.subscribe(destination, (message) => {
+    const subscription = client.subscribe(`/topic/dm/${dmRoomId}`, (message) => {
       try {
-        const parsed = JSON.parse(message.body)
-        onDmMessageReceived(parsed)
+        onDmMessageReceivedRef.current?.(JSON.parse(message.body))
       } catch (e) {
         console.error("📛 Failed to parse DM message:", e)
       }
     })
 
-    console.log(`📡 Subscribed to ${destination}`)
-
-    return () => {
-      console.log(`🔌 Unsubscribing from ${destination}`)
-      subscription.unsubscribe()
-    }
-  }, [dmRoomId, onDmMessageReceived, stompClientRef.current?.connected])
+    return () => subscription.unsubscribe()
+  }, [connected, dmRoomId])
 
   return { stompClientRef, connected }
 }

--- a/frontend/src/pages/ChatRoom.jsx
+++ b/frontend/src/pages/ChatRoom.jsx
@@ -24,6 +24,14 @@ const formatDate = (dateString) => {
   return date.toLocaleDateString('ko-KR', { year: 'numeric', month: 'long', day: 'numeric' });
 };
 
+const preloadImages = (urls) => {
+  urls.forEach(url => {
+    if (!url) return;
+    const img = new Image();
+    img.src = `${process.env.REACT_APP_PROFILE_IMAGE_URL}/${url}`;
+  });
+};
+
 const VirtuosoMessageItem = React.memo(({
   msg, prevMsg,
   currentUser, contextMenuId, setContextMenuId,
@@ -171,6 +179,10 @@ const ChatRoom = () => {
         .map((msg) => ({ ...msg, sendAt: msg.sendAt && !isNaN(new Date(msg.sendAt).getTime()) ? msg.sendAt : new Date().toISOString() }))
         .sort((a, b) => new Date(a.sendAt) - new Date(b.sendAt));
 
+      // 메시지 목록의 프로필 이미지 프리로드
+      const uniqueProfileUrls = [...new Set(sorted.map(m => m.profileImageUrl).filter(Boolean))];
+      preloadImages(uniqueProfileUrls);
+
       if (isLoadMore) {
         setFirstItemIndex((prev) => prev - sorted.length);
         setMessages((prev) => {
@@ -196,6 +208,10 @@ const ChatRoom = () => {
     try {
       const res = await axiosInstance.get('/user/details');
       setCurrentUser(res.data);
+      // 내 프로필 이미지 프리로드
+      if (res.data?.profileImageUrl) {
+        preloadImages([res.data.profileImageUrl]);
+      }
     } catch {}
     setInitState((prev) => ({ ...prev, isUserLoaded: true }));
   }, []);
@@ -208,6 +224,10 @@ const ChatRoom = () => {
   };
 
   const handleProfileUpdate = useCallback((data) => {
+    // 업데이트된 프로필 이미지 프리로드
+    if (data?.profileImageUrl) {
+      preloadImages([data.profileImageUrl]);
+    }
     setMessages((prev) =>
       prev.map((msg) =>
         msg.senderId === data.userId
@@ -220,6 +240,11 @@ const ChatRoom = () => {
   const { stompClientRef } = useWebSocket({
     roomId: initState.isRoomValidated ? roomId : null,
     onMessageReceived: (received) => {
+      // 새 메시지 발신자 프로필 이미지 프리로드
+      if (received?.profileImageUrl) {
+        preloadImages([received.profileImageUrl]);
+      }
+
       setMessages((prev) => {
         const updated = prev.some((m) => m.messageId === received.messageId)
           ? prev.map((m) => (m.messageId === received.messageId ? received : m))
@@ -431,7 +456,6 @@ const ChatRoom = () => {
           )}
 
           <div style={{ flex: 1, minHeight: 0, position: 'relative' }}>
-            {/* 로딩 오버레이 */}
             {!isFullyLoaded && (
               <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', backgroundColor: '#fff', zIndex: 10 }}>
                 <div style={{ textAlign: 'center' }}>
@@ -441,7 +465,6 @@ const ChatRoom = () => {
               </div>
             )}
 
-            {/* 메시지 로드 완료 후에만 Virtuoso 렌더 → initialTopMostItemIndex 정상 동작 */}
             {messages.length > 0 && (
               <Virtuoso
                 key={roomId}


### PR DESCRIPTION
## 🛰️ Issue Number
close #209 

## 🪐 작업 내용
### 안정성 개선

handleMessageDelivery Lua 스크립트 도입으로 INCR → EXPIRE → ZADD → SADD 원자 처리
getAndClearUpdatedRooms Lua 스크립트로 SMEMBERS → DEL 원자 처리 → 다중 인스턴스 중복 반영 방지
setSequence Lua 스크립트로 현재값보다 클 때만 세팅 → sequence 역행 방지

### Redis 재시작 / TTL 만료 복구

handleMessageDelivery에서 키 없음(prev == false) 감지 시 -1 반환
ChatMessageService.save에서 -1 감지 → DB lastSequence 기반으로 Redis sequence 복구
createChatRoom에 입장 메시지 추가 → 방 생성 시 sequence 1로 초기화 보장

### 폴백 및 모니터링

getSequencesSafe Redis 장애 시 DB lastSequence 폴백
MeterRegistry로 Redis 폴백 발생률 메트릭 수집 (redis.fallback)

### 메모리 관리

rooms:updated Set 무한 증가 방지 → 스케줄러 실행 시 Lua로 원자적 회수 후 삭제
sequence TTL 3일 설정으로 미사용 키 자동 만료

### 스터디 게시물로 중복입장이 가능했던 문제 해결
- 채팅방 중복 입장 방어 로직 구현

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?