### PR TITLE
Fix: 메시지 전송 시 프로필 이미지 미반영 문제 수정

### DIFF
--- a/backend/src/main/java/project/backend/domain/chat/chatmessage/app/ChatMessageService.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatmessage/app/ChatMessageService.java
@@ -32,6 +32,7 @@ import project.backend.domain.chat.chatroom.app.ChatRoomService;
 import project.backend.domain.chat.chatroom.entity.ChatRoom;
 import project.backend.domain.imagefile.ImageFile;
 import project.backend.domain.imagefile.ImageFileService;
+import project.backend.domain.member.app.MemberRedisService;
 import project.backend.domain.member.entity.Member;
 import project.backend.domain.chat.chatmessage.dto.ScrollPaginationCollection;
 import project.backend.global.exception.errorcode.AuthErrorCode;
@@ -56,6 +57,7 @@ public class ChatMessageService {
     private final EntityManager entityManager;
     private final ChatMessageMapper messageMapper;
     private final ChatRoomRedisService chatRoomRedisService;
+    private final MemberRedisService memberRedisService;
 
     @Transactional
     public ChatMessageResponse save(Long roomId, ChatMessageRequest request,
@@ -79,7 +81,7 @@ public class ChatMessageService {
         }
 
         chatMessageRepository.save(message);
-        String profileImage = chatRoomRedisService.getProfileImage(memberDetails.getId());
+        String profileImage = memberRedisService.getProfileImage(memberDetails.getId());
 
         if (isSearchable(message)) {
             eventPublisher.publishEvent(ChatMessageSavedEvent.from(message));
@@ -153,7 +155,7 @@ public class ChatMessageService {
                     searchEntity.updateContent(message.getContent());
                 });
         }
-        String profileImage = chatRoomRedisService.getProfileImage(memberDetails.getId());
+        String profileImage = memberRedisService.getProfileImage(memberDetails.getId());
         eventPublisher.publishEvent(ChatMessageBroadcastEvent.from(message, memberDetails, profileImage));
     }
 
@@ -177,7 +179,7 @@ public class ChatMessageService {
             chatMessageSearchRepository.findById(message.getId())
                 .ifPresent(ChatMessageSearch::deleteContent);
         }
-        String profileImage = chatRoomRedisService.getProfileImage(memberDetails.getId());
+        String profileImage = memberRedisService.getProfileImage(memberDetails.getId());
         eventPublisher.publishEvent(ChatMessageBroadcastEvent.from(message, memberDetails, profileImage));
     }
 

--- a/backend/src/main/java/project/backend/domain/chat/chatmessage/app/ChatMessageService.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatmessage/app/ChatMessageService.java
@@ -79,12 +79,13 @@ public class ChatMessageService {
         }
 
         chatMessageRepository.save(message);
+        String profileImage = chatRoomRedisService.getProfileImage(memberDetails.getId());
 
         if (isSearchable(message)) {
             eventPublisher.publishEvent(ChatMessageSavedEvent.from(message));
         }
-        eventPublisher.publishEvent(ChatMessageBroadcastEvent.from(message, memberDetails));
-        return messageMapper.toResponse(message, memberDetails);
+        eventPublisher.publishEvent(ChatMessageBroadcastEvent.from(message, memberDetails, profileImage));
+        return messageMapper.toResponse(message, memberDetails, profileImage);
     }
 
     private boolean isSearchable(ChatMessage message) {
@@ -152,7 +153,8 @@ public class ChatMessageService {
                     searchEntity.updateContent(message.getContent());
                 });
         }
-        eventPublisher.publishEvent(ChatMessageBroadcastEvent.from(message, memberDetails));
+        String profileImage = chatRoomRedisService.getProfileImage(memberDetails.getId());
+        eventPublisher.publishEvent(ChatMessageBroadcastEvent.from(message, memberDetails, profileImage));
     }
 
     @Transactional
@@ -175,7 +177,8 @@ public class ChatMessageService {
             chatMessageSearchRepository.findById(message.getId())
                 .ifPresent(ChatMessageSearch::deleteContent);
         }
-        eventPublisher.publishEvent(ChatMessageBroadcastEvent.from(message, memberDetails));
+        String profileImage = chatRoomRedisService.getProfileImage(memberDetails.getId());
+        eventPublisher.publishEvent(ChatMessageBroadcastEvent.from(message, memberDetails, profileImage));
     }
 
     @TimeTrace

--- a/backend/src/main/java/project/backend/domain/chat/chatmessage/dto/event/ChatMessageBroadcastEvent.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatmessage/dto/event/ChatMessageBroadcastEvent.java
@@ -8,14 +8,14 @@ public record ChatMessageBroadcastEvent(
     Long roomId,
     ChatMessageResponse response
 ) {
-    public static ChatMessageBroadcastEvent from(ChatMessage message, MemberDetails sender) {
+    public static ChatMessageBroadcastEvent from(ChatMessage message, MemberDetails sender, String profileImage) {
         ChatMessageResponse response = ChatMessageResponse.builder()
                 .senderName(sender.getNickname())
                 .content(message.getContent())
                 .type(message.getType())
                 .sendAt(message.getSendAt())
                 .language(message.getCodeLanguage())
-                .profileImageUrl(sender.getProfileImg())
+                .profileImageUrl(profileImage)
                 .chatImageUrl(
                         message.getChatImage() != null ? message.getChatImage().getStoreFileName() : null
                 )

--- a/backend/src/main/java/project/backend/domain/chat/chatmessage/mapper/ChatMessageMapper.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatmessage/mapper/ChatMessageMapper.java
@@ -123,14 +123,14 @@ public class ChatMessageMapper {
             .build();
     }
 
-    public ChatMessageResponse toResponse(ChatMessage message, MemberDetails memberDetails) {
+    public ChatMessageResponse toResponse(ChatMessage message, MemberDetails memberDetails, String profileImage) {
         return ChatMessageResponse.builder()
             .senderName(memberDetails.getNickname())
             .content(message.getContent())
             .type(message.getType())
             .sendAt(message.getSendAt())
             .language(message.getCodeLanguage())
-            .profileImageUrl(memberDetails.getProfileImg())
+            .profileImageUrl(profileImage)
             .chatImageUrl(
                 Optional.ofNullable(message.getChatImage())
                     .map(ImageFile::getStoreFileName)

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomRedisService.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomRedisService.java
@@ -58,11 +58,4 @@ public class ChatRoomRedisService {
         return chatRoomRedisRepository.getSequences(roomIds);
     }
 
-    public String getProfileImage(Long memberId) {
-        return chatRoomRedisRepository.getProfileImage(memberId);
-    }
-
-    public void setProfileImage(Long memberId, String profileImg) {
-        chatRoomRedisRepository.setProfileImage(memberId, profileImg);
-    }
 }

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomRedisService.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomRedisService.java
@@ -57,4 +57,12 @@ public class ChatRoomRedisService {
     public List<Long> getSequences(List<Long> roomIds) {
         return chatRoomRedisRepository.getSequences(roomIds);
     }
+
+    public String getProfileImage(Long memberId) {
+        return chatRoomRedisRepository.getProfileImage(memberId);
+    }
+
+    public void setProfileImage(Long memberId, String profileImg) {
+        chatRoomRedisRepository.setProfileImage(memberId, profileImg);
+    }
 }

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/dao/ChatRoomRedisRepository.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/dao/ChatRoomRedisRepository.java
@@ -161,8 +161,4 @@ public class ChatRoomRedisRepository {
         redisTemplate.opsForValue().set(key, profileImg, PROFILE_TTL_SEC, java.util.concurrent.TimeUnit.SECONDS);
     }
 
-    public void deleteProfileImage(Long memberId) {
-        String key = String.format(MEMBER_PROFILE_KEY, memberId);
-        redisTemplate.delete(key);
-    }
 }

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/dao/ChatRoomRedisRepository.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/dao/ChatRoomRedisRepository.java
@@ -21,7 +21,6 @@ public class ChatRoomRedisRepository {
     private static final String ROOM_SEQUENCE_KEY = "room:%d:sequence";
     private static final String UPDATED_ROOMS_KEY = "rooms:updated";
     private static final String RANKING_ROOMS_KEY = "rooms:ranking";
-    private static final String MEMBER_PROFILE_KEY = "member:%d:profile";
 
     private static final int MAX_RANKING_SIZE = 1000;
     private static final long SEQUENCE_TTL_SEC = 60 * 60 * 24 * 3; // 3일
@@ -149,16 +148,6 @@ public class ChatRoomRedisRepository {
 
     private byte[] toBytes(String key) {
         return redisTemplate.getStringSerializer().serialize(key);
-    }
-
-    public String getProfileImage(Long memberId) {
-        String key = String.format(MEMBER_PROFILE_KEY, memberId);
-        return redisTemplate.opsForValue().get(key);
-    }
-
-    public void setProfileImage(Long memberId, String profileImg) {
-        String key = String.format(MEMBER_PROFILE_KEY, memberId);
-        redisTemplate.opsForValue().set(key, profileImg, PROFILE_TTL_SEC, java.util.concurrent.TimeUnit.SECONDS);
     }
 
 }

--- a/backend/src/main/java/project/backend/domain/member/app/MemberRedisService.java
+++ b/backend/src/main/java/project/backend/domain/member/app/MemberRedisService.java
@@ -1,0 +1,27 @@
+package project.backend.domain.member.app;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+public class MemberRedisService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    private static final String MEMBER_PROFILE_KEY = "member:%d:profile";
+    private static final long PROFILE_TTL_SEC = 60 * 60 * 24 * 7L; // 7일
+
+    public void setProfileImage(Long memberId, String profileImg) {
+        String key = String.format(MEMBER_PROFILE_KEY, memberId);
+        redisTemplate.opsForValue().set(key, profileImg, PROFILE_TTL_SEC, TimeUnit.SECONDS);
+    }
+
+    public String getProfileImage(Long memberId) {
+        String key = String.format(MEMBER_PROFILE_KEY, memberId);
+        return redisTemplate.opsForValue().get(key);
+    }
+}

--- a/backend/src/main/java/project/backend/domain/member/app/MemberService.java
+++ b/backend/src/main/java/project/backend/domain/member/app/MemberService.java
@@ -13,6 +13,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+import project.backend.domain.chat.chatroom.app.ChatRoomRedisService;
 import project.backend.domain.imagefile.ImageFileService;
 import project.backend.domain.member.dao.MemberRepository;
 import project.backend.domain.member.dto.MemberSearchResponse;
@@ -40,6 +41,7 @@ public class MemberService {
     private final ImageFileService imageFileService;
     private final PasswordEncoder passwordEncoder;
     private final ApplicationEventPublisher eventPublisher;
+    private final ChatRoomRedisService chatRoomRedisService;
 
     @Value("${file.images.profile.default}")
     private String defaultProfileImg;
@@ -87,6 +89,8 @@ public class MemberService {
         if (file != null) {
             String profileImage = imageFileService.saveProfileImage(file);
             targetMember.updateProfileImage(profileImage);
+
+            chatRoomRedisService.setProfileImage(targetMember.getId(), profileImage);
         }
     }
 

--- a/backend/src/main/java/project/backend/domain/member/app/MemberService.java
+++ b/backend/src/main/java/project/backend/domain/member/app/MemberService.java
@@ -3,7 +3,6 @@ package project.backend.domain.member.app;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.cache.annotation.Cacheable;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -13,7 +12,6 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
-import project.backend.domain.chat.chatroom.app.ChatRoomRedisService;
 import project.backend.domain.imagefile.ImageFileService;
 import project.backend.domain.member.dao.MemberRepository;
 import project.backend.domain.member.dto.MemberSearchResponse;
@@ -41,7 +39,7 @@ public class MemberService {
     private final ImageFileService imageFileService;
     private final PasswordEncoder passwordEncoder;
     private final ApplicationEventPublisher eventPublisher;
-    private final ChatRoomRedisService chatRoomRedisService;
+    private final MemberRedisService memberRedisService;
 
     @Value("${file.images.profile.default}")
     private String defaultProfileImg;
@@ -90,7 +88,7 @@ public class MemberService {
             String profileImage = imageFileService.saveProfileImage(file);
             targetMember.updateProfileImage(profileImage);
 
-            chatRoomRedisService.setProfileImage(targetMember.getId(), profileImage);
+            memberRedisService.setProfileImage(targetMember.getId(), profileImage);
         }
     }
 

--- a/backend/src/main/java/project/backend/global/security/handler/form/FormSuccessHandler.java
+++ b/backend/src/main/java/project/backend/global/security/handler/form/FormSuccessHandler.java
@@ -15,6 +15,7 @@ import project.backend.auth.dto.MemberDetails;
 import project.backend.auth.token.jwt.Token;
 import project.backend.auth.token.dao.TokenRedisRepository;
 import project.backend.auth.token.entity.TokenRedis;
+import project.backend.domain.member.app.MemberRedisService;
 
 @Slf4j
 @Component
@@ -23,13 +24,14 @@ public class FormSuccessHandler implements AuthenticationSuccessHandler {
 
 	private final JwtProvider jwtProvider;
 	private final TokenRedisRepository tokenRedisRepository;
+	private final MemberRedisService memberRedisService;
 
 	@Override
 	public void onAuthenticationSuccess(HttpServletRequest request,
 		HttpServletResponse response,
 		Authentication authentication) throws IOException {
 
-		var memberDetails = (MemberDetails) authentication.getPrincipal();
+		MemberDetails memberDetails = (MemberDetails) authentication.getPrincipal();
 
 		Token token = jwtProvider.generateTokenPair(memberDetails);
 
@@ -39,6 +41,8 @@ public class FormSuccessHandler implements AuthenticationSuccessHandler {
 			new TokenRedis(memberDetails.getId(), token.accessToken(), token.refreshToken(),
 				null)
 		);
+
+		memberRedisService.setProfileImage(memberDetails.getId(), memberDetails.getProfileImg());
 
 		response.setStatus(HttpServletResponse.SC_OK);
 		response.setContentType("application/json");

--- a/backend/src/main/java/project/backend/global/security/handler/oauth/OAuth2SuccessHandler.java
+++ b/backend/src/main/java/project/backend/global/security/handler/oauth/OAuth2SuccessHandler.java
@@ -16,7 +16,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.util.UriComponentsBuilder;
 import project.backend.auth.dto.MemberDetails;
-import project.backend.domain.member.dao.MemberRepository;
+import project.backend.domain.member.app.MemberRedisService;
 import project.backend.domain.member.entity.Member;
 import project.backend.auth.app.CookieUtils;
 import project.backend.auth.app.OAuthSignUpService;
@@ -31,12 +31,12 @@ import project.backend.auth.token.dao.TokenRedisRepository;
 @RequiredArgsConstructor
 public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
+    private final MemberRedisService memberRedisService;
     @Value("${jwt.redirection.base}")
     private String baseUrl;
 
     private final JwtProvider jwtProvider;
     private final OAuthSignUpService oAuthSignUpService;
-    private final MemberRepository memberRepository;
     private final TokenRedisRepository tokenRedisRepository;
 
     @Override
@@ -71,6 +71,8 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
                 githubAccess));
 
         log.info("OAuth 로그인 성공: {}", member.getUsername());
+
+        memberRedisService.setProfileImage(member.getId(), member.getProfileImage());
 
         String redirectUrl = UriComponentsBuilder.fromUriString(baseUrl)
             .build().toUriString();


### PR DESCRIPTION
## 🛰️ Issue Number
close #218 

## 🪐 작업 내용
- 기존 toResponse에서 JWT 토큰의 profileImg를 사용하여 프로필 업데이트 후 새로고침 전까지 구버전 이미지가 노출되는 문제 수정
- 로그인 시 Redis에 profileImage 적재
- 프로필 업데이트 시 Redis 캐시 갱신
- 로그아웃 시 Redis 캐시 삭제
- 메시지 전송/수정 시 Redis에서 최신 profileImage 조회하여 broadcast

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?