### PR TITLE
Fix: WebSocket 재연결 안정성 개선

### DIFF
--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -1,4 +1,9 @@
+server:
+  shutdown: graceful
+
 spring:
+  lifecycle:
+    timeout-per-shutdown-phase: 30s
   session:
     store-type: none
 

--- a/frontend/src/components/common/WebSocketContext.js
+++ b/frontend/src/components/common/WebSocketContext.js
@@ -23,15 +23,32 @@ export const WebSocketProvider = ({ children }) => {
       },
 
       onWebSocketClose: async () => {
-        console.warn("🛑 WebSocket 끊김 → 토큰 갱신 시도")
+        console.warn("🛑 WebSocket 끊김 → 재연결 시도")
+        setConnected(false)
         client.deactivate()
-        try {
-          await safeRefreshToken()
-          client.activate()
-        } catch (err) {
-          console.error("❌ 토큰 갱신 실패 → 로그인 페이지로 이동")
-          navigate("/login")
+
+        let retryCount = 0
+        const maxRetry = 3
+
+        const reconnect = async () => {
+          try {
+            console.log(`🔄 재연결 시도 (${retryCount + 1}/${maxRetry})`)
+            await safeRefreshToken()
+            client.activate()
+          } catch (err) {
+            if (retryCount < maxRetry) {
+              retryCount++
+              const delay = 1000 * retryCount // 1초, 2초, 3초
+              console.warn(`⏳ ${delay}ms 후 재시도`)
+              setTimeout(reconnect, delay)
+            } else {
+              console.error("❌ 재연결 최종 실패 → 로그인 페이지로 이동")
+              navigate("/login")
+            }
+          }
         }
+
+        reconnect()
       },
 
       onStompError: (frame) => {


### PR DESCRIPTION
## 🛰️ Issue Number
close #223 

## 🪐 작업 내용

### 문제
블루그린 배포 시 트래픽 전환 순간
WebSocket 연결이 끊기면서
토큰 갱신 요청이 실패하는 경우
바로 로그인 페이지로 이동하는 문제가 있었습니다.

### 원인
onWebSocketClose에서 safeRefreshToken 실패 시
재시도 없이 즉시 로그인 페이지로 이동

### 해결
지수백오프 방식으로 최대 3회 재연결 시도
1회 실패 → 1초 후 재시도
2회 실패 → 2초 후 재시도
3회 실패 → 3초 후 재시도
최대 재시도 초과 시 로그인 페이지로 이동

### 변경사항
- setConnected(false) 추가로 끊긴 순간 상태 업데이트
- 지수백오프 재연결 로직 추가 (최대 3회)
- 최대 재시도 초과 시에만 로그인 이동

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?