### PR TITLE
fix: WebSocket 재연결 시 새 Client 인스턴스 생성으로 변경

### DIFF
--- a/frontend/src/components/common/WebSocketContext.js
+++ b/frontend/src/components/common/WebSocketContext.js
@@ -11,57 +11,69 @@ export const WebSocketProvider = ({ children }) => {
   const navigate = useNavigate()
 
   useEffect(() => {
-    const client = new Client({
-      webSocketFactory: () => new WebSocket(process.env.REACT_APP_WEB_SOCKET_URL),
-      heartbeatIncoming: 15000,
-      heartbeatOutgoing: 10000,
-      withCredentials: true,
+    const createClient = () => {
+      const client = new Client({
+        webSocketFactory: () => new WebSocket(process.env.REACT_APP_WEB_SOCKET_URL),
+        heartbeatIncoming: 15000,
+        heartbeatOutgoing: 10000,
+        withCredentials: true,
 
-      onConnect: () => {
-        console.log("✅ Connected to WebSocket")
-        setConnected(true)
-      },
+        onConnect: () => {
+          console.log("✅ Connected to WebSocket")
+          setConnected(true)
+        },
 
-      onWebSocketClose: async () => {
-        console.warn("🛑 WebSocket 끊김 → 재연결 시도")
-        setConnected(false)
-        client.deactivate()
+        onWebSocketClose: async () => {
+          console.warn("🛑 WebSocket 끊김 → 재연결 시도")
+          setConnected(false)
+          client.deactivate()
 
-        let retryCount = 0
-        const maxRetry = 3
+          let retryCount = 0
+          const maxRetry = 3
 
-        const reconnect = async () => {
-          try {
-            console.log(`🔄 재연결 시도 (${retryCount + 1}/${maxRetry})`)
-            await safeRefreshToken()
-            client.activate()
-          } catch (err) {
-            if (retryCount < maxRetry) {
-              retryCount++
-              const delay = 1000 * retryCount // 1초, 2초, 3초
-              console.warn(`⏳ ${delay}ms 후 재시도`)
-              setTimeout(reconnect, delay)
-            } else {
-              console.error("❌ 재연결 최종 실패 → 로그인 페이지로 이동")
-              navigate("/login")
+          const reconnect = async () => {
+            try {
+              console.log(`🔄 재연결 시도 (${retryCount + 1}/${maxRetry})`)
+              await safeRefreshToken()
+
+              // 새 Client 인스턴스 생성
+              const newClient = createClient()
+              newClient.activate()
+              stompClientRef.current = newClient
+
+            } catch (err) {
+              if (retryCount < maxRetry) {
+                retryCount++
+                const delay = 1000 * retryCount
+                console.warn(`⏳ ${delay}ms 후 재시도`)
+                setTimeout(reconnect, delay)
+              } else {
+                console.error("❌ 재연결 최종 실패 → 로그인 페이지로 이동")
+                navigate("/login")
+              }
             }
           }
-        }
 
-        reconnect()
-      },
+          reconnect()
+        },
 
-      onStompError: (frame) => {
-        console.error("💥 STOMP error:", frame.headers["message"])
-      },
-    })
+        onStompError: (frame) => {
+          console.error("💥 STOMP error:", frame.headers["message"])
+        },
+      })
 
+      return client
+    }
+
+    const client = createClient()
     client.activate()
     stompClientRef.current = client
 
     return () => {
       setConnected(false)
-      if (client.active) client.deactivate()
+      if (stompClientRef.current?.active) {
+        stompClientRef.current.deactivate()
+      }
     }
   }, [navigate])
 


### PR DESCRIPTION
## 🛰️ Issue Number
close #223 

## 🪐 작업 내용

### 문제
블루그린 배포 시 WebSocket 연결이 끊긴 후
deactivate된 Client를 재활성화 시도했으나
재연결이 되지 않는 문제가 있었습니다.

### 원인
client.deactivate() 후 동일한 Client 인스턴스에
client.activate()를 호출해도 재연결이 안됨

### 해결
재연결 시 기존 Client 인스턴스를 버리고
새 Client 인스턴스를 생성하도록 변경

### 변경사항
- createClient() 함수로 Client 생성 로직 분리
- 재연결 시 새 Client 인스턴스 생성 후 교체
- 지수백오프 재시도 로직 추가 (최대 3회)
- cleanup 시 교체된 새 인스턴스도 정상 종료되도록 수정

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?