### PR TITLE
Fix: 223 graceful shutdown

### DIFF
--- a/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomService.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomService.java
@@ -410,7 +410,7 @@ public class ChatRoomService {
     public Long getLatestSequence(Long roomId) {
         try {
             Long redisSeq = chatRoomRedisService.getSequence(roomId);
-            if (redisSeq == 0L) {
+            if (redisSeq == -1L) {
                 ChatRoom room = chatRoomRepository.findById(roomId)
                         .orElseThrow(() -> new ChatRoomException(ChatRoomErrorCode.CHATROOM_NOT_FOUND));
                 long dbSeq = room.getLastSequence();

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/dao/ChatRoomRedisRepository.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/dao/ChatRoomRedisRepository.java
@@ -124,7 +124,7 @@ public class ChatRoomRedisRepository {
     public Long getSequence(Long roomId) {
         String key = String.format(ROOM_SEQUENCE_KEY, roomId);
         String value = redisTemplate.opsForValue().get(key);
-        return value == null ? 0L : Long.parseLong(value);
+        return value == null ? -1L : Long.parseLong(value);
     }
 
     public List<Long> getSequences(List<Long> roomIds) {

--- a/frontend/src/components/common/WebSocketContext.js
+++ b/frontend/src/components/common/WebSocketContext.js
@@ -29,7 +29,7 @@ export const WebSocketProvider = ({ children }) => {
           client.deactivate()
 
           let retryCount = 0
-          const maxRetry = 3
+          const maxRetry = 5
 
           const reconnect = async () => {
             try {
@@ -44,7 +44,7 @@ export const WebSocketProvider = ({ children }) => {
             } catch (err) {
               if (retryCount < maxRetry) {
                 retryCount++
-                const delay = 1000 * retryCount
+                const delay = 3000 * retryCount
                 console.warn(`⏳ ${delay}ms 후 재시도`)
                 setTimeout(reconnect, delay)
               } else {


### PR DESCRIPTION
## 🛰️ Issue Number


## 🪐 작업 내용
- 웹소켓 재연결 대기를 위한 지수 백오프 적용
- 메시지가 0개인 경우(0)와 Key가 없는 경우를 구분하기 위해
  Key 없음 시 반환값을 0L에서 -1L로 변경
- 메시지 전송 및 안읽음 수 조회 시 -1 감지 후 DB 기준으로 복구

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?