### PR TITLE
Fix: Redis sequence 키 없을 때 동시 복구 시 sequence 역행 문제 해결

### DIFF
--- a/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomRedisService.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomRedisService.java
@@ -27,9 +27,9 @@ public class ChatRoomRedisService {
             ChatRoom findRoom = chatRoomRepository.findById(roomId)
                     .orElseThrow(() -> new ChatRoomException(ChatRoomErrorCode.CHATROOM_NOT_FOUND));
 
-            long dbSeq = findRoom.getLastSequence() != null ? findRoom.getLastSequence() : 0L;
-            long recoveredSeq = dbSeq + 1;
-            chatRoomRedisRepository.setSequence(roomId, recoveredSeq);
+            long dbSeq = findRoom.getLastSequence();
+
+            Long recoveredSeq = chatRoomRedisRepository.recoverAndIncr(roomId, dbSeq);
 
             log.warn("Redis sequence 복구 - roomId: {}, dbSeq: {}, 복구값: {}", roomId, dbSeq, recoveredSeq);
             return recoveredSeq;

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/dao/ChatRoomRedisRepository.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/dao/ChatRoomRedisRepository.java
@@ -59,6 +59,36 @@ public class ChatRoomRedisRepository {
         }
     }
 
+    public Long recoverAndIncr(Long roomId, Long dbSeq) {
+        String script =
+                "redis.call('SET', KEYS[1], ARGV[1], 'NX'); " +
+                        "local seq = redis.call('INCR', KEYS[1]); " +
+                        "redis.call('EXPIRE', KEYS[1], ARGV[2]); " +
+                        "redis.call('ZADD', KEYS[2], ARGV[3], ARGV[4]); " +
+                        "redis.call('ZREMRANGEBYRANK', KEYS[2], 0, ARGV[5]); " +
+                        "redis.call('SADD', KEYS[3], ARGV[4]); " +
+                        "return seq;";
+
+        String seqKey = String.format(ROOM_SEQUENCE_KEY, roomId);
+        String roomIdStr = String.valueOf(roomId);
+
+        try {
+            return redisTemplate.execute(
+                    new DefaultRedisScript<>(script, Long.class),
+                    List.of(seqKey, RANKING_ROOMS_KEY, UPDATED_ROOMS_KEY),
+                    String.valueOf(dbSeq),
+                    String.valueOf(SEQUENCE_TTL_SEC),
+                    String.valueOf(System.currentTimeMillis()),
+                    roomIdStr,
+                    String.valueOf(-MAX_RANKING_SIZE - 1)
+            );
+        } catch (Exception e) {
+            log.error("recoverAndIncr 오류 - roomId: {}", roomId, e);
+            meterRegistry.counter("redis.fallback", "method", "recoverAndIncr").increment();
+            return null;
+        }
+    }
+
     public List<Long> getSortedRoomIds(List<Long> roomIds) {
         if (roomIds == null || roomIds.isEmpty()) {
             return List.of();


### PR DESCRIPTION
## 🛰️ Issue Number
close #228 

## 🪐 작업 내용

### 문제
Redis 재시작 또는 TTL 만료로 sequence 키가 없는 상황에서
동시에 여러 요청이 들어오면 sequence가 역행하는 문제가 있었습니다.

### 원인
키 없을 때 -1 반환 후
DB에서 값을 읽어 setSequence()로 복구하는 방식에서

A → INCR → 1 (-1 반환)
B → INCR → 2 (키 있음으로 판단)
A → DB 100 읽어서 setSequence(101) → Redis = 101

결과
A 메시지 → sequence 101
B 메시지 → sequence 2 (역행 💀)

### 해결
recoverAndIncr() 메서드 추가
SET NX + INCR 방식으로 변경

A, B 둘 다 -1 받음 → DB에서 100 읽음
    ↓
A → SET NX 100 성공 → Redis = 100
B → SET NX 100 스킵 (이미 초기화됨)
    ↓
A → INCR → 101
B → INCR → 102

결과
101, 102 (정상) ✅

### 장점
락 없이 처리 가능
→ 대기 없음
→ 네트워크 RTT 최소화
→ 장애 포인트 없음

### 변경사항
- recoverAndIncr() 메서드 추가 (SET NX + INCR)
- handleMessageDelivery()에서 setSequence() → recoverAndIncr() 로 변경

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?