### PR TITLE
Feat: Redis 장애 대응을 위한 Circuit Breaker 도입 및 서비스 책임 분리

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -35,6 +35,7 @@ dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
+    implementation 'org.springframework.cloud:spring-cloud-starter-circuitbreaker-resilience4j'
     testImplementation 'io.projectreactor:reactor-test'
 
     implementation 'org.flywaydb:flyway-core'
@@ -57,6 +58,11 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testCompileOnly 'org.projectlombok:lombok'
     testAnnotationProcessor 'org.projectlombok:lombok'
+}
+dependencyManagement {
+    imports {
+        mavenBom 'org.springframework.cloud:spring-cloud-dependencies:2023.0.3'
+    }
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/project/backend/domain/chat/chatmessage/app/ChatMessageService.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatmessage/app/ChatMessageService.java
@@ -2,6 +2,8 @@ package project.backend.domain.chat.chatmessage.app;
 
 import jakarta.persistence.EntityManager;
 import jakarta.validation.Valid;
+
+import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -27,8 +29,10 @@ import project.backend.domain.chat.chatmessage.entity.ChatMessage;
 import project.backend.domain.chat.chatmessage.entity.ChatMessageSearch;
 import project.backend.domain.chat.chatmessage.entity.MessageType;
 import project.backend.domain.chat.chatmessage.mapper.ChatMessageMapper;
+import project.backend.domain.chat.chatroom.app.ChatRoomCacheService;
+import project.backend.domain.chat.chatroom.app.ChatRoomParticipantService;
 import project.backend.domain.chat.chatroom.app.ChatRoomRedisService;
-import project.backend.domain.chat.chatroom.app.ChatRoomService;
+import project.backend.domain.chat.chatroom.dao.ChatRoomRepository;
 import project.backend.domain.chat.chatroom.entity.ChatRoom;
 import project.backend.domain.imagefile.ImageFile;
 import project.backend.domain.imagefile.ImageFileService;
@@ -49,21 +53,22 @@ public class ChatMessageService {
     private final ChatMessageRepository chatMessageRepository;
     private final ChatMessageSearchRepository chatMessageSearchRepository;
 
-    private final ChatRoomService chatRoomService;
+    private final ChatRoomParticipantService chatRoomParticipantService;
+    private final ChatRoomRepository chatRoomRepository;
     private final ImageFileService imageFileService;
 
     private final ApplicationEventPublisher eventPublisher;
 
     private final EntityManager entityManager;
     private final ChatMessageMapper messageMapper;
-    private final ChatRoomRedisService chatRoomRedisService;
+    private final ChatRoomCacheService chatRoomCacheService;
     private final MemberRedisService memberRedisService;
 
     @Transactional
     public ChatMessageResponse save(Long roomId, ChatMessageRequest request,
-        MemberDetails memberDetails) {
+                                    MemberDetails memberDetails) {
 
-        Long seq = chatRoomRedisService.handleMessageDelivery(roomId);
+        Long seq = chatRoomCacheService.handleMessageDelivery(roomId);
 
         Member sender = entityManager.getReference(Member.class, memberDetails.getId());
         ChatRoom room = entityManager.getReference(ChatRoom.class, roomId);
@@ -96,15 +101,15 @@ public class ChatMessageService {
 
     @Transactional(readOnly = true)
     public Slice<ChatMessageSearchResponse> searchMessages(Long memberId, Long roomId,
-        @Valid ChatMessageSearchRequest request) {
+                                                           @Valid ChatMessageSearchRequest request) {
 
-        chatRoomService.validateParticipant(memberId, roomId);
+        chatRoomParticipantService.validateParticipant(memberId, roomId);
 
         List<Long> messageIds = chatMessageSearchRepository.searchIdsByKeywordAndRoomIdWithCursor(
-            request.getKeyword(),
-            roomId,
-            request.getLastMessageId(),
-            request.getPageSize() + 1
+                request.getKeyword(),
+                roomId,
+                request.getLastMessageId(),
+                request.getPageSize() + 1
         );
 
         boolean hasNext = messageIds.size() > request.getPageSize();
@@ -115,24 +120,24 @@ public class ChatMessageService {
         Long totalCount = null;
         if (request.getLastMessageId() == null) {
             totalCount = chatMessageSearchRepository.countByKeywordAndRoomId(
-                request.getKeyword(), roomId);
+                    request.getKeyword(), roomId);
         }
 
         List<ChatMessageSearchResponse> resultList = chatMessageRepository.findByIdIn(messageIds)
-            .stream()
-            .sorted(Comparator.comparingInt(cm -> messageIds.indexOf(cm.getId())))
-            .map(messageMapper::toSearchResponse)
-            .toList();
+                .stream()
+                .sorted(Comparator.comparingInt(cm -> messageIds.indexOf(cm.getId())))
+                .map(messageMapper::toSearchResponse)
+                .toList();
 
         return new ChatMessageSearchSlice(resultList,
-            PageRequest.of(0, request.getPageSize()), hasNext, totalCount);
+                PageRequest.of(0, request.getPageSize()), hasNext, totalCount);
     }
 
     @Transactional
     public void editMessage(Long roomId, ChatMessageEditRequest request, MemberDetails memberDetails) {
 
         ChatMessage message = chatMessageRepository.findById(request.messageId())
-            .orElseThrow(() -> new ChatMessageException(ChatMessageErrorCode.MESSAGE_NOT_FOUND));
+                .orElseThrow(() -> new ChatMessageException(ChatMessageErrorCode.MESSAGE_NOT_FOUND));
 
         if (!message.getChatRoom().getId().equals(roomId)) {
             throw new AuthException(AuthErrorCode.FORBIDDEN_MESSAGE_EDIT);
@@ -144,16 +149,15 @@ public class ChatMessageService {
 
         message.updateContent(request.content());
 
-        //현재 코드 언어 변경은 받지 않고 있음 (확장성 고려)
         if (message.getType().equals(MessageType.CODE)) {
             message.updateLanguage(request.language());
         }
 
         if (isSearchable(message)) {
             chatMessageSearchRepository.findById(message.getId())
-                .ifPresent(searchEntity -> {
-                    searchEntity.updateContent(message.getContent());
-                });
+                    .ifPresent(searchEntity -> {
+                        searchEntity.updateContent(message.getContent());
+                    });
         }
         String profileImage = memberRedisService.getProfileImage(memberDetails.getId());
         eventPublisher.publishEvent(ChatMessageBroadcastEvent.from(message, memberDetails, profileImage));
@@ -163,7 +167,7 @@ public class ChatMessageService {
     public void deleteMessage(Long roomId, Long messageId, MemberDetails memberDetails) {
 
         ChatMessage message = chatMessageRepository.findById(messageId)
-            .orElseThrow(() -> new ChatMessageException(ChatMessageErrorCode.MESSAGE_NOT_FOUND));
+                .orElseThrow(() -> new ChatMessageException(ChatMessageErrorCode.MESSAGE_NOT_FOUND));
 
         if (!message.getChatRoom().getId().equals(roomId)) {
             throw new AuthException(AuthErrorCode.FORBIDDEN_MESSAGE_DELETE);
@@ -177,7 +181,7 @@ public class ChatMessageService {
 
         if (isSearchable(message)) {
             chatMessageSearchRepository.findById(message.getId())
-                .ifPresent(ChatMessageSearch::deleteContent);
+                    .ifPresent(ChatMessageSearch::deleteContent);
         }
         String profileImage = memberRedisService.getProfileImage(memberDetails.getId());
         eventPublisher.publishEvent(ChatMessageBroadcastEvent.from(message, memberDetails, profileImage));
@@ -186,28 +190,40 @@ public class ChatMessageService {
     @TimeTrace
     @Transactional(readOnly = true)
     public ChatScrollResponse getMessagesByRoomId(Long memberId, Long roomId, Long cursor,
-        int size) {
-        chatRoomService.getRoomById(roomId);
-        chatRoomService.validateParticipant(memberId, roomId);
+                                                  int size) {
+        chatRoomRepository.findById(roomId)
+                .orElseThrow(() -> new ChatMessageException(ChatMessageErrorCode.MESSAGE_NOT_FOUND));
+        chatRoomParticipantService.validateParticipant(memberId, roomId);
 
         PageRequest pageRequest = PageRequest.of(0, size + 1);
         List<ChatMessage> result;
 
         if (cursor == null) {
             result = chatMessageRepository.findByChatRoom_IdOrderByIdDesc(
-                roomId, pageRequest);
+                    roomId, pageRequest);
         } else {
             result = chatMessageRepository.findByChatRoom_IdAndIdLessThanOrderByIdDesc(
-                roomId, cursor, pageRequest);
+                    roomId, cursor, pageRequest);
         }
         ScrollPaginationCollection<ChatMessage> scroll = ScrollPaginationCollection.of(result,
-            size);
+                size);
 
         List<ChatMessageResponse> responses = scroll.getCurrentScrollItems().stream()
-            .map(messageMapper::toResponse).toList();
+                .map(messageMapper::toResponse).toList();
 
         Long nextCursor = scroll.isLastScroll() ? null : scroll.getNextCursor().getId();
 
         return new ChatScrollResponse(responses, nextCursor);
+    }
+
+    public ChatMessage saveJoinEvent(ChatRoom room, Member member, Long seq) {
+        ChatMessage message = messageMapper.toEntityWithJoinEvent(room, member, LocalDateTime.now(), seq);
+        return chatMessageRepository.save(message);
+    }
+
+    @Transactional
+    public void deleteByRoomId(Long roomId) {
+        chatMessageRepository.deleteByChatRoom_Id(roomId);
+        chatMessageSearchRepository.deleteByRoomId(roomId);
     }
 }

--- a/backend/src/main/java/project/backend/domain/chat/chatmessage/app/ChatMessageService.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatmessage/app/ChatMessageService.java
@@ -68,7 +68,7 @@ public class ChatMessageService {
     public ChatMessageResponse save(Long roomId, ChatMessageRequest request,
                                     MemberDetails memberDetails) {
 
-        Long seq = chatRoomCacheService.handleMessageDelivery(roomId);
+        Long seq = chatRoomCacheService.handleMessageDelivery(roomId, memberDetails.getId());
 
         Member sender = entityManager.getReference(Member.class, memberDetails.getId());
         ChatRoom room = entityManager.getReference(ChatRoom.class, roomId);

--- a/backend/src/main/java/project/backend/domain/chat/chatmessage/dao/ChatMessageSearchRepository.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatmessage/dao/ChatMessageSearchRepository.java
@@ -31,5 +31,7 @@ public interface ChatMessageSearchRepository extends JpaRepository<ChatMessageSe
         AND MATCH(content) AGAINST (:keyword IN NATURAL LANGUAGE MODE)
         """, nativeQuery = true)
     long countByKeywordAndRoomId(@Param("keyword") String keyword, @Param("roomId") Long roomId);
+
+    void deleteByRoomId(Long roomId);
 }
 

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomAlarmService.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomAlarmService.java
@@ -1,0 +1,49 @@
+package project.backend.domain.chat.chatroom.app;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import project.backend.domain.chat.chatroom.dao.ChatRoomAlarmRepository;
+import project.backend.domain.chat.chatroom.entity.ChatRoomAlarm;
+import project.backend.global.exception.errorcode.ChatRoomErrorCode;
+import project.backend.global.exception.ex.ChatRoomException;
+
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ChatRoomAlarmService {
+
+    private final ChatRoomAlarmRepository chatRoomAlarmRepository;
+
+    @Transactional
+    public void createAlarm(Long memberId, Long roomId) {
+        ChatRoomAlarm alarm = new ChatRoomAlarm(memberId, roomId);
+        chatRoomAlarmRepository.save(alarm);
+    }
+
+    @Transactional
+    public boolean toggleAlarm(Long roomId, Long memberId) {
+        ChatRoomAlarm alarm = chatRoomAlarmRepository
+                .findByIdMemberIdAndIdRoomId(memberId, roomId)
+                .orElseThrow(() -> new ChatRoomException(ChatRoomErrorCode.ALARM_NOT_FOUND));
+
+        log.debug("Before toggle: {}", alarm.isEnabled());
+        alarm.setEnabled(!alarm.isEnabled());
+        log.debug("After toggle: {}", alarm.isEnabled());
+
+        return alarm.isEnabled();
+    }
+
+    public boolean isAlarmEnabled(Long memberId, Long roomId) {
+        return chatRoomAlarmRepository.findEnabledByMemberIdAndRoomId(memberId, roomId);
+    }
+
+    public Map<Long, Boolean> findAlarmEnabledMap(Long memberId, List<Long> roomIds) {
+        return chatRoomAlarmRepository.findEnabledMap(memberId, roomIds);
+    }
+}

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomCacheService.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomCacheService.java
@@ -1,11 +1,15 @@
 package project.backend.domain.chat.chatroom.app;
 
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import io.github.resilience4j.ratelimiter.RequestNotPermitted;
+import io.github.resilience4j.ratelimiter.annotation.RateLimiter;
 import io.micrometer.core.instrument.MeterRegistry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import project.backend.domain.chat.chatroom.app.limiter.FallbackLimiter;
+import project.backend.domain.chat.chatroom.app.limiter.UserRateLimiter;
 import project.backend.domain.chat.chatroom.dao.ChatRoomRepository;
 import project.backend.domain.chat.chatroom.entity.ChatRoom;
 import project.backend.global.exception.errorcode.ChatRoomErrorCode;
@@ -22,20 +26,51 @@ public class ChatRoomCacheService {
 
     private final ChatRoomRedisService chatRoomRedisService;
     private final ChatRoomRepository chatRoomRepository;
-
     private final MeterRegistry meterRegistry;
+    private final UserRateLimiter userRateLimiter;
+    private final FallbackLimiter fallbackLimiter;
 
     @CircuitBreaker(name = "redis", fallbackMethod = "handleMessageDeliveryFallback")
-    public Long handleMessageDelivery(Long roomId) {
+    public Long handleMessageDelivery(Long roomId, Long userId) {
+        if (!userRateLimiter.allow(userId)) {
+            throw new ChatRoomException(ChatRoomErrorCode.TOO_MANY_REQUESTS);
+        }
         return chatRoomRedisService.handleMessageDelivery(roomId);
     }
 
-    @Transactional
-    public Long handleMessageDeliveryFallback(Long roomId, Exception e) {
+    @RateLimiter(name = "redis-fallback", fallbackMethod = "handleMessageDeliveryRateLimitFallback")
+    public Long handleMessageDeliveryFallback(Long roomId, Long userId, Exception e) {
         log.warn("Circuit OPEN - handleMessageDelivery 폴백 roomId={}", roomId);
         meterRegistry.counter("redis.fallback", "method", "handleMessageDelivery").increment();
+
+        if (!userRateLimiter.allow(userId)) {
+            log.warn("Rate Limit 초과 - userId={}", userId);
+            throw new ChatRoomException(ChatRoomErrorCode.TOO_MANY_REQUESTS);
+        }
+
+        if (!fallbackLimiter.tryAcquire()) {
+            log.warn("Fallback 동시 처리 한도 초과 - DB 보호 roomId={}", roomId);
+            meterRegistry.counter("redis.fallback.rejected").increment();
+            throw new ChatRoomException(ChatRoomErrorCode.SERVICE_UNAVAILABLE);
+        }
+
+        try {
+            return incrementSequenceFromDb(roomId);
+        } finally {
+            fallbackLimiter.release();
+        }
+    }
+
+    @Transactional
+    public Long incrementSequenceFromDb(Long roomId) {
         chatRoomRepository.incrementSequence(roomId);
         return chatRoomRepository.findLastInsertId();
+    }
+
+    public Long handleMessageDeliveryRateLimitFallback(Long roomId, Long userId, RequestNotPermitted e) {
+        log.warn("Fallback RateLimit 초과 - DB 보호 roomId={}", roomId);
+        meterRegistry.counter("redis.fallback.rejected").increment();
+        throw new ChatRoomException(ChatRoomErrorCode.SERVICE_UNAVAILABLE);
     }
 
     @CircuitBreaker(name = "redis", fallbackMethod = "getSequencesFallback")

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomCacheService.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomCacheService.java
@@ -1,0 +1,89 @@
+package project.backend.domain.chat.chatroom.app;
+
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import io.micrometer.core.instrument.MeterRegistry;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import project.backend.domain.chat.chatroom.dao.ChatRoomRepository;
+import project.backend.domain.chat.chatroom.entity.ChatRoom;
+import project.backend.global.exception.errorcode.ChatRoomErrorCode;
+import project.backend.global.exception.ex.ChatRoomException;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChatRoomCacheService {
+
+    private final ChatRoomRedisService chatRoomRedisService;
+    private final ChatRoomRepository chatRoomRepository;
+
+    private final MeterRegistry meterRegistry;
+
+    @CircuitBreaker(name = "redis", fallbackMethod = "handleMessageDeliveryFallback")
+    public Long handleMessageDelivery(Long roomId) {
+        return chatRoomRedisService.handleMessageDelivery(roomId);
+    }
+
+    @Transactional
+    public Long handleMessageDeliveryFallback(Long roomId, Exception e) {
+        log.warn("Circuit OPEN - handleMessageDelivery 폴백 roomId={}", roomId);
+        meterRegistry.counter("redis.fallback", "method", "handleMessageDelivery").increment();
+        chatRoomRepository.incrementSequence(roomId);
+        return chatRoomRepository.findLastInsertId();
+    }
+
+    @CircuitBreaker(name = "redis", fallbackMethod = "getSequencesFallback")
+    public List<Long> getSequences(List<Long> roomIds) {
+        return chatRoomRedisService.getSequences(roomIds);
+    }
+
+    public List<Long> getSequencesFallback(List<Long> roomIds, Exception e) {
+        log.warn("Circuit OPEN - getSequences 폴백");
+        meterRegistry.counter("redis.fallback", "reason", "sequence").increment();
+        Map<Long, Long> seqMap = chatRoomRepository.findAllById(roomIds).stream()
+                .collect(Collectors.toMap(
+                        ChatRoom::getId,
+                        ChatRoom::getLastSequence
+                ));
+        return roomIds.stream()
+                .map(id -> seqMap.getOrDefault(id, 0L))
+                .toList();
+    }
+
+    @CircuitBreaker(name = "redis", fallbackMethod = "getLatestSequenceFallback")
+    public Long getLatestSequence(Long roomId) {
+        Long redisSeq = chatRoomRedisService.getSequence(roomId);
+        if (redisSeq == -1L) {
+            ChatRoom room = chatRoomRepository.findById(roomId)
+                    .orElseThrow(() -> new ChatRoomException(ChatRoomErrorCode.CHATROOM_NOT_FOUND));
+            long dbSeq = room.getLastSequence();
+            chatRoomRedisService.setSequence(roomId, dbSeq);
+            return dbSeq;
+        }
+        return redisSeq;
+    }
+
+    public Long getLatestSequenceFallback(Long roomId, Exception e) {
+        log.warn("Circuit OPEN - getLatestSequence 폴백 roomId={}", roomId);
+        meterRegistry.counter("redis.fallback", "reason", "latestSequence").increment();
+        return chatRoomRepository.findById(roomId)
+                .map(ChatRoom::getLastSequence)
+                .orElse(0L);
+    }
+
+    @CircuitBreaker(name = "redis", fallbackMethod = "getSortedRoomIdsFallback")
+    public List<Long> getSortedRoomIds(List<Long> roomIds) {
+        return chatRoomRedisService.getSortedRoomIds(roomIds);
+    }
+
+    public List<Long> getSortedRoomIdsFallback(List<Long> roomIds, Exception e) {
+        log.warn("Circuit OPEN - getSortedRoomIds 폴백");
+        return roomIds;
+    }
+}

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomParticipantService.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomParticipantService.java
@@ -1,0 +1,104 @@
+package project.backend.domain.chat.chatroom.app;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import project.backend.domain.chat.chatroom.dao.ChatParticipantRepository;
+import project.backend.domain.chat.chatroom.dto.ChatParticipantResponse;
+import project.backend.domain.chat.chatroom.dto.event.LeaveChatRoomEvent;
+import project.backend.domain.chat.chatroom.entity.ChatParticipant;
+import project.backend.domain.chat.chatroom.entity.ChatRoom;
+import project.backend.domain.chat.chatroom.mapper.ChatRoomMapper;
+import project.backend.domain.member.entity.Member;
+import project.backend.global.exception.errorcode.ChatRoomErrorCode;
+import project.backend.global.exception.ex.ChatRoomException;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ChatRoomParticipantService {
+
+    private final ChatParticipantRepository chatParticipantRepository;
+    private final ApplicationEventPublisher eventPublisher;
+
+    public void handleParticipantJoin(ChatRoom room, Member member) {
+        Optional<ChatParticipant> existingParticipant =
+                chatParticipantRepository.findByChatRoomIdAndParticipantId(
+                        room.getId(), member.getId());
+
+        if (existingParticipant.isPresent()) {
+            ChatParticipant participant = existingParticipant.get();
+            if (participant.isActive()) {
+                throw new ChatRoomException(ChatRoomErrorCode.ALREADY_PARTICIPANT);
+            }
+            participant.rejoin();
+        } else {
+            ChatParticipant chatParticipant = ChatParticipant.of(member, room);
+            room.addParticipant(chatParticipant);
+        }
+    }
+
+    @Transactional
+    public void leaveChatRoom(Long roomId, Long memberId, String nickname) {
+        ChatParticipant participant = chatParticipantRepository
+                .findByChatRoomIdAndParticipantIdAndIsActiveTrue(roomId, memberId)
+                .orElseThrow(() -> new ChatRoomException(ChatRoomErrorCode.NOT_PARTICIPANT));
+
+        if (participant.isOwner()) {
+            throw new ChatRoomException(ChatRoomErrorCode.OWNER_CANNOT_LEAVE);
+        }
+
+        participant.leave();
+
+        eventPublisher.publishEvent(
+                new LeaveChatRoomEvent(roomId, memberId, nickname, LocalDateTime.now()));
+    }
+
+    public List<ChatParticipantResponse> getParticipants(Long memberId, Long roomId) {
+        validateParticipant(memberId, roomId);
+        ChatParticipant owner = chatParticipantRepository
+                .findByChatRoomIdAndIsOwnerTrue(roomId)
+                .orElseThrow(() -> new ChatRoomException(ChatRoomErrorCode.OWNER_NOT_FOUND));
+
+        return chatParticipantRepository
+                .findByChatRoom(owner.getChatRoom()).stream()
+                .map(ChatRoomMapper::toParticipantResponse)
+                .collect(Collectors.toList());
+    }
+
+    public Long findOwnerId(Long roomId) {
+        return chatParticipantRepository.findByChatRoomIdAndIsOwnerTrue(roomId)
+                .orElseThrow(() -> new ChatRoomException(ChatRoomErrorCode.OWNER_NOT_FOUND))
+                .getParticipant().getId();
+    }
+
+    public void validateParticipant(Long memberId, Long roomId) {
+        if (!chatParticipantRepository
+                .existsByParticipantIdAndChatRoomIdAndIsActiveTrue(memberId, roomId)) {
+            throw new ChatRoomException(ChatRoomErrorCode.NOT_PARTICIPANT);
+        }
+    }
+
+    public Optional<ChatParticipant> findTopRecentActiveRoom(Long memberId) {
+        return chatParticipantRepository
+                .findTopByParticipantIdAndIsActiveTrueOrderByJoinAtDesc(memberId);
+    }
+
+    public Optional<ChatParticipant> findActiveParticipant(Long roomId, Long memberId) {
+        return chatParticipantRepository
+                .findByChatRoomIdAndParticipantIdAndIsActiveTrue(roomId, memberId);
+    }
+
+    @Transactional
+    public void deleteAllByRoomId(Long roomId) {
+        chatParticipantRepository.deleteByChatRoom_Id(roomId);
+    }
+}

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomRedisService.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomRedisService.java
@@ -27,8 +27,7 @@ public class ChatRoomRedisService {
             ChatRoom findRoom = chatRoomRepository.findById(roomId)
                     .orElseThrow(() -> new ChatRoomException(ChatRoomErrorCode.CHATROOM_NOT_FOUND));
 
-            long dbSeq = findRoom.getLastSequence();
-
+            long dbSeq = findRoom.getLastSequence() != null ? findRoom.getLastSequence() : 0L;
             Long recoveredSeq = chatRoomRedisRepository.recoverAndIncr(roomId, dbSeq);
 
             log.warn("Redis sequence 복구 - roomId: {}, dbSeq: {}, 복구값: {}", roomId, dbSeq, recoveredSeq);
@@ -57,5 +56,4 @@ public class ChatRoomRedisService {
     public List<Long> getSequences(List<Long> roomIds) {
         return chatRoomRedisRepository.getSequences(roomIds);
     }
-
 }

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomSequenceScheduler.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomSequenceScheduler.java
@@ -10,12 +10,12 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class ChatRoomSequenceScheduler {
 
-    private final ChatRoomService chatRoomService;
+    private final ChatRoomSequenceService ChatRoomSequenceService;
 
     @Scheduled(fixedRate = 60000)
     public void syncLastSequence() {
         try {
-            chatRoomService.syncSequencesToDb();
+            ChatRoomSequenceService.syncSequencesToDb();
             log.info("last_sequence 동기화 배치 완료");
         } catch (Exception e) {
             log.error("시퀀스 동기화 배치 중 에러 발생: {}", e.getMessage());

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomSequenceService.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomSequenceService.java
@@ -1,0 +1,104 @@
+package project.backend.domain.chat.chatroom.app;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import project.backend.domain.chat.chatroom.dao.ChatParticipantRepository;
+import project.backend.domain.chat.chatroom.dao.ChatRoomRepository;
+import project.backend.domain.chat.chatroom.dao.ChatRoomWithSequenceProjection;
+import project.backend.domain.chat.chatroom.dto.AllRoomsResponse;
+import project.backend.domain.chat.chatroom.entity.ChatRoom;
+
+import java.util.*;
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ChatRoomSequenceService {
+
+    private final ChatRoomRepository chatRoomRepository;
+    private final ChatParticipantRepository chatParticipantRepository;
+    private final ChatRoomCacheService chatRoomCacheService;
+    private final ChatRoomRedisService chatRoomRedisService;
+
+    public List<AllRoomsResponse> findAllRoomsWithUnread(Long memberId,
+                                                         List<ChatRoomWithSequenceProjection> roomProjections,
+                                                         Map<Long, Boolean> alarmEnabledMap) {
+
+        List<Long> roomIds = new ArrayList<>(roomProjections.size());
+        Map<Long, ChatRoomWithSequenceProjection> projectionMap = new HashMap<>();
+        Map<Long, Integer> sequenceIndexMap = new HashMap<>();
+
+        for (int i = 0; i < roomProjections.size(); i++) {
+            ChatRoomWithSequenceProjection p = roomProjections.get(i);
+            Long id = p.getChatRoomId();
+            roomIds.add(id);
+            projectionMap.put(id, p);
+            sequenceIndexMap.put(id, i);
+        }
+
+        List<Long> sortedRoomIds = chatRoomCacheService.getSortedRoomIds(roomIds);
+        List<Long> sequences = chatRoomCacheService.getSequences(roomIds);
+
+        return sortedRoomIds.stream().map(roomId -> {
+            ChatRoomWithSequenceProjection p = projectionMap.get(roomId);
+            boolean alarmEnabled = alarmEnabledMap.getOrDefault(roomId, true);
+            Long lastRead = (p.getLastReadSequence() != null) ? p.getLastReadSequence() : 0L;
+
+            Long unreadCount = null;
+            Integer originalIdx = sequenceIndexMap.get(roomId);
+            if (sequences != null && originalIdx != null) {
+                unreadCount = calculateUnread(lastRead, sequences.get(originalIdx));
+            }
+
+            return new AllRoomsResponse(
+                    roomId,
+                    p.getInviteCode(),
+                    p.getName(),
+                    alarmEnabled,
+                    unreadCount
+            );
+        }).toList();
+    }
+
+    @Transactional
+    public void updateLastReadSequence(Long roomId, Long memberId) {
+        Long currentSequence = chatRoomCacheService.getLatestSequence(roomId);
+        chatParticipantRepository
+                .findByChatRoomIdAndParticipantIdAndIsActiveTrue(roomId, memberId)
+                .ifPresent(p -> p.updateLastReadSequence(currentSequence));
+    }
+
+    public Long getLatestSequence(Long roomId) {
+        return chatRoomCacheService.getLatestSequence(roomId);
+    }
+
+    @Transactional
+    public void syncSequencesToDb() {
+        Set<String> updatedRoomIds = chatRoomRedisService.getAndClearUpdatedRooms();
+        if (updatedRoomIds.isEmpty()) return;
+
+        List<Long> roomIds = updatedRoomIds.stream().map(Long::valueOf).toList();
+        List<ChatRoom> rooms = chatRoomRepository.findAllById(roomIds);
+        if (rooms.isEmpty()) return;
+
+        List<Long> targetIds = rooms.stream().map(ChatRoom::getId).toList();
+        List<Long> redisSequences = chatRoomRedisService.getSequences(targetIds);
+
+        for (int i = 0; i < rooms.size(); i++) {
+            Long redisSeq = redisSequences.get(i);
+            long currentSeq = rooms.get(i).getLastSequence() != null
+                    ? rooms.get(i).getLastSequence() : 0L;
+            if (redisSeq != null && redisSeq > currentSeq) {
+                rooms.get(i).updateLastSequence(redisSeq);
+            }
+        }
+        log.info("last_sequence 동기화 완료 - {}개 채팅방", rooms.size());
+    }
+
+    private long calculateUnread(long lastReadSequence, long lastMessageSequence) {
+        return Math.max(0, lastMessageSequence - lastReadSequence);
+    }
+}

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomService.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomService.java
@@ -1,10 +1,8 @@
 package project.backend.domain.chat.chatroom.app;
 
-import java.time.LocalDateTime;
 import java.util.*;
 import java.util.stream.Collectors;
 
-import io.micrometer.core.instrument.MeterRegistry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -13,27 +11,13 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import project.backend.domain.chat.chatmessage.dao.ChatMessageRepository;
+import project.backend.domain.chat.chatmessage.app.ChatMessageService;
 import project.backend.domain.chat.chatmessage.entity.ChatMessage;
-import project.backend.domain.chat.chatmessage.mapper.ChatMessageMapper;
-import project.backend.domain.chat.chatroom.dao.ChatParticipantRepository;
-import project.backend.domain.chat.chatroom.dao.ChatRoomAlarmRepository;
 import project.backend.domain.chat.chatroom.dao.ChatRoomRepository;
 import project.backend.domain.chat.chatroom.dao.ChatRoomWithSequenceProjection;
-import project.backend.domain.chat.chatroom.dto.AllRoomsResponse;
-import project.backend.domain.chat.chatroom.dto.ChatParticipantResponse;
-import project.backend.domain.chat.chatroom.dto.ChatRoomRequest;
-import project.backend.domain.chat.chatroom.dto.ChatRoomSimpleResponse;
-import project.backend.domain.chat.chatroom.dto.EntryRoomResponse;
-import project.backend.domain.chat.chatroom.dto.InviteJoinResponse;
-import project.backend.domain.chat.chatroom.dto.MyChatRoomResponse;
-import project.backend.domain.chat.chatroom.dto.RoomInfoResponse;
-import project.backend.domain.chat.chatroom.dto.event.DeleteChatRoomEvent;
-import project.backend.domain.chat.chatroom.dto.event.JoinChatRoomEvent;
-import project.backend.domain.chat.chatroom.dto.event.LeaveChatRoomEvent;
-import project.backend.domain.chat.chatroom.entity.ChatParticipant;
-import project.backend.domain.chat.chatroom.entity.ChatRoom;
-import project.backend.domain.chat.chatroom.entity.ChatRoomAlarm;
+import project.backend.domain.chat.chatroom.dto.*;
+import project.backend.domain.chat.chatroom.dto.event.*;
+import project.backend.domain.chat.chatroom.entity.*;
 import project.backend.domain.chat.chatroom.mapper.ChatRoomMapper;
 import project.backend.domain.chat.github.app.GitMessageService;
 import project.backend.domain.community.dao.PostRepository;
@@ -51,20 +35,18 @@ public class ChatRoomService {
 
     private final PostRepository postRepository;
     private final ChatRoomRepository chatRoomRepository;
-    private final ChatMessageRepository chatMessageRepository;
-    private final ChatRoomAlarmRepository chatRoomAlarmRepository;
-    private final ChatParticipantRepository chatParticipantRepository;
 
     private final ChatRoomMapper chatRoomMapper;
-    private final ChatMessageMapper chatMessageMapper;
 
     private final MemberService memberService;
+    private final ChatMessageService chatMessageService;
     private final GitMessageService gitMessageService;
-    private final ChatRoomRedisService chatRoomRedisService;
+    private final ChatRoomCacheService chatRoomCacheService;
+    private final ChatRoomAlarmService chatRoomAlarmService;
+    private final ChatRoomSequenceService chatRoomSequenceService;
+    private final ChatRoomParticipantService chatRoomParticipantService;
 
     private final ApplicationEventPublisher eventPublisher;
-
-    private final MeterRegistry meterRegistry;
 
     @Value("${github.username}")
     private String githubUsername;
@@ -72,29 +54,20 @@ public class ChatRoomService {
     @Transactional
     public ChatRoomSimpleResponse createChatRoom(ChatRoomRequest request, Long ownerId) {
         Member owner = memberService.getMemberById(ownerId);
-
         ChatRoom chatRoom = chatRoomMapper.toEntity(request);
-
         ChatParticipant chatParticipant = ChatParticipant.createOwner(owner, chatRoom);
         chatRoom.addParticipant(chatParticipant);
-
         ChatRoom savedRoom = chatRoomRepository.save(chatRoom);
 
-        createAlarm(ownerId, chatRoom.getId());
+        chatRoomAlarmService.createAlarm(ownerId, chatRoom.getId());
 
         if (!request.getRepositoryUrl().isBlank()) {
             gitMessageService.registerWebhook(request.getRepositoryUrl(),
-                savedRoom.getId(), owner.getId()); //웹훅 자동 등록
-            joinGitHubBot(savedRoom); //깃허브봇 채팅 참가
+                    savedRoom.getId(), owner.getId());
+            joinGitHubBot(savedRoom);
         }
 
         return chatRoomMapper.toSimpleResponse(savedRoom, owner);
-    }
-
-    @Transactional
-    public void createAlarm(Long memberId, Long roomId) {
-        ChatRoomAlarm alarm = new ChatRoomAlarm(memberId, roomId);
-        chatRoomAlarmRepository.save(alarm);
     }
 
     private void joinGitHubBot(ChatRoom room) {
@@ -110,45 +83,23 @@ public class ChatRoomService {
         ChatRoom room = getByInviteCode(inviteCode);
         Member member = memberService.getMemberById(memberId);
 
-        handleParticipantJoin(room, member);
-        createAlarm(memberId, room.getId());
+        chatRoomParticipantService.handleParticipantJoin(room, member);
+        chatRoomAlarmService.createAlarm(memberId, room.getId());
 
-        Long seq = chatRoomRedisService.handleMessageDelivery(room.getId());
+        Long seq = chatRoomCacheService.handleMessageDelivery(room.getId());
 
-        ChatMessage message = chatMessageMapper.toEntityWithJoinEvent(room, member,
-            LocalDateTime.now(), seq);
-        ChatMessage savedMessage = chatMessageRepository.save(message);
+        ChatMessage savedMessage = chatMessageService.saveJoinEvent(room, member, seq);
 
         eventPublisher.publishEvent(
-            new JoinChatRoomEvent(room.getId(), memberId, member.getNickname(),
-                savedMessage.getId(), savedMessage.getSendAt()));
+                new JoinChatRoomEvent(room.getId(), memberId, member.getNickname(),
+                        savedMessage.getId(), savedMessage.getSendAt()));
 
         return ChatRoomMapper.toInviteJoinResponse(room.getId(), room.getInviteCode(),
-            room.getName());
-    }
-
-    private void handleParticipantJoin(ChatRoom room, Member member) {
-        //참여중 여부와 관계없이 기존 참가 기록들을 확인
-        Optional<ChatParticipant> existingParticipant =
-            chatParticipantRepository.findByChatRoomIdAndParticipantId(
-                room.getId(), member.getId());
-
-        if (existingParticipant.isPresent()) {
-            ChatParticipant participant = existingParticipant.get();
-            if (participant.isActive()) {
-                throw new ChatRoomException(ChatRoomErrorCode.ALREADY_PARTICIPANT);
-            }
-            participant.rejoin();
-        } else {
-            ChatParticipant chatParticipant = ChatParticipant.of(member, room);
-            room.addParticipant(chatParticipant);
-        }
+                room.getName());
     }
 
     public String getRecentRoomInviteCode(Long memberId) {
         Long roomId = memberService.getMemberById(memberId).getRecentRoomId();
-
-        // 아무 채팅방에도 참여한 적이 없음 → 예외 던지기
         if (roomId == null) {
             throw new ChatRoomException(ChatRoomErrorCode.CHATROOM_NOT_EXIST);
         }
@@ -156,101 +107,65 @@ public class ChatRoomService {
     }
 
     public Page<MyChatRoomResponse> findAllRoomsByOwnerId(Long memberId, Pageable pageable) {
-        Page<ChatRoom> allRoomsByOwnerId = chatRoomRepository.findAllRoomsByOwnerId(memberId,
-            pageable);
-
-        return allRoomsByOwnerId.map(ChatRoomMapper::toProfileResponse);
+        return chatRoomRepository.findAllRoomsByOwnerId(memberId, pageable)
+                .map(ChatRoomMapper::toProfileResponse);
     }
 
     public Page<RoomInfoResponse> findChatRoomsByMemberId(Long memberId, Pageable pageable) {
-
-        Page<ChatRoom> chatRooms = chatRoomRepository.findChatRoomsByParticipantId(
-            memberId, pageable);
-
-        return chatRooms.map(ChatRoomMapper::toListResponse);
+        return chatRoomRepository.findChatRoomsByParticipantId(memberId, pageable)
+                .map(ChatRoomMapper::toListResponse);
     }
 
     public List<ChatParticipantResponse> getParticipants(Long memberId, Long roomId) {
-        ChatRoom chatRoom = chatRoomRepository.findById(roomId)
-            .orElseThrow(() -> new ChatRoomException(ChatRoomErrorCode.CHATROOM_NOT_FOUND));
-
-        validateParticipant(memberId, roomId);
-
-        List<ChatParticipant> participants = chatParticipantRepository.findByChatRoom(chatRoom);
-
-        return participants.stream()
-            .map(ChatRoomMapper::toParticipantResponse).collect(Collectors.toList());
+        return chatRoomParticipantService.getParticipants(memberId, roomId);
     }
 
     @Transactional
     public void leaveChatRoom(Long roomId, Long memberId) {
-
-        ChatParticipant participant = chatParticipantRepository.findByChatRoomIdAndParticipantIdAndIsActiveTrue(
-                roomId, memberId)
-            .orElseThrow(() -> new ChatRoomException(ChatRoomErrorCode.NOT_PARTICIPANT));
-
-        if (participant.isOwner()) {
-            throw new ChatRoomException(ChatRoomErrorCode.OWNER_CANNOT_LEAVE);
-        }
-
-        participant.leave();
-
         Member member = memberService.getMemberById(memberId);
-
-        eventPublisher.publishEvent(
-            new LeaveChatRoomEvent(roomId, memberId, member.getNickname(),
-                LocalDateTime.now()));
-
+        chatRoomParticipantService.leaveChatRoom(roomId, memberId, member.getNickname());
         updateRecentRoomAfterLeaving(memberId);
     }
 
     private void updateRecentRoomAfterLeaving(Long memberId) {
         Member member = memberService.getMemberById(memberId);
-
-        Optional<ChatParticipant> mostRecentActiveRoom =
-            chatParticipantRepository.findTopByParticipantIdAndIsActiveTrueOrderByJoinAtDesc(
-                memberId);
-
-        if (mostRecentActiveRoom.isPresent()) {
-            member.setRecentRoomId(mostRecentActiveRoom.get().getChatRoom().getId());
-        } else {
-            member.setRecentRoomId(null);
-        }
+        chatRoomParticipantService.findTopRecentActiveRoom(memberId)
+                .ifPresentOrElse(
+                        p -> member.setRecentRoomId(p.getChatRoom().getId()),
+                        () -> member.setRecentRoomId(null)
+                );
     }
 
-    private ChatRoom getByInviteCode(String inviteCode) {
-        return chatRoomRepository.findByInviteCode(inviteCode)
-            .orElseThrow(() -> new ChatRoomException(ChatRoomErrorCode.CHATROOM_NOT_FOUND));
-    }
+    public List<AllRoomsResponse> findAllRoomsByMemberId(Long memberId) {
+        List<ChatRoomWithSequenceProjection> roomProjections =
+                chatRoomRepository.findAllRoomsWithSequenceByParticipantId(memberId);
 
-    public ChatRoom getRoomById(Long roomId) {
-        return chatRoomRepository.findById(roomId)
-            .orElseThrow(() -> new ChatRoomException(ChatRoomErrorCode.CHATROOM_NOT_FOUND));
+        List<Long> roomIds = roomProjections.stream()
+                .map(ChatRoomWithSequenceProjection::getChatRoomId)
+                .collect(Collectors.toList());
+
+        Map<Long, Boolean> alarmEnabledMap = roomIds.isEmpty()
+                ? Collections.emptyMap()
+                : chatRoomAlarmService.findAlarmEnabledMap(memberId, roomIds);
+
+        return chatRoomSequenceService.findAllRoomsWithUnread(memberId, roomProjections, alarmEnabledMap);
     }
 
     @Transactional
     public EntryRoomResponse getEntryInfo(String inviteCode, Long memberId) {
         ChatRoom room = getByInviteCode(inviteCode);
-        validateParticipant(memberId, room.getId());
+        chatRoomParticipantService.validateParticipant(memberId, room.getId());
 
-        Long currentSequence = getLatestSequence(room.getId());
-        chatParticipantRepository
-                .findByChatRoomIdAndParticipantIdAndIsActiveTrue(room.getId(), memberId)
+        Long currentSequence = chatRoomSequenceService.getLatestSequence(room.getId());
+        chatRoomParticipantService.findActiveParticipant(room.getId(), memberId)
                 .ifPresent(p -> p.updateLastReadSequence(currentSequence));
 
         memberService.getMemberById(memberId).setRecentRoomId(room.getId());
 
-        Long ownerId = findOwnerId(room.getId());
-        boolean alarmEnable = chatRoomAlarmRepository
-            .findEnabledByMemberIdAndRoomId(memberId, room.getId());
+        Long ownerId = chatRoomParticipantService.findOwnerId(room.getId());
+        boolean alarmEnable = chatRoomAlarmService.isAlarmEnabled(memberId, room.getId());
 
         return new EntryRoomResponse(room.getId(), room.getName(), ownerId, alarmEnable);
-    }
-
-    private Long findOwnerId(Long roomId) {
-        ChatParticipant owner = chatParticipantRepository.findByChatRoomIdAndIsOwnerTrue(roomId)
-            .orElseThrow(() -> new ChatRoomException(ChatRoomErrorCode.OWNER_NOT_FOUND));
-        return owner.getParticipant().getId();
     }
 
     public RoomInfoResponse getRoomInfo(String inviteCode, Long memberId) {
@@ -258,171 +173,44 @@ public class ChatRoomService {
         return ChatRoomMapper.toListResponse(room);
     }
 
-    public void validateParticipant(Long memberId, Long roomId) {
-        if (!chatParticipantRepository.
-            existsByParticipantIdAndChatRoomIdAndIsActiveTrue(memberId, roomId)) {
-            throw new ChatRoomException(ChatRoomErrorCode.NOT_PARTICIPANT);
-        }
-    }
-
     @Transactional
     public void deleteChatRoom(Long roomId, Long memberId) {
         ChatRoom room = getRoomById(roomId);
 
-        ChatParticipant participant = chatParticipantRepository.findByChatRoomIdAndParticipantIdAndIsActiveTrue(
-                roomId, memberId)
-            .orElseThrow(() -> new ChatRoomException(ChatRoomErrorCode.NOT_PARTICIPANT));
+        ChatParticipant participant = chatRoomParticipantService
+                .findActiveParticipant(roomId, memberId)
+                .orElseThrow(() -> new ChatRoomException(ChatRoomErrorCode.NOT_PARTICIPANT));
 
         if (!participant.isOwner()) {
             throw new ChatRoomException(ChatRoomErrorCode.OWNER_PERMISSION_REQUIRED);
         }
 
         gitMessageService.deleteWebhook(room, memberId);
+        eventPublisher.publishEvent(new DeleteChatRoomEvent(roomId, room.getName()));
 
-        eventPublisher.publishEvent(
-            new DeleteChatRoomEvent(roomId, room.getName())
-        );
-
-        chatParticipantRepository.deleteByChatRoom_Id(roomId);
-        chatMessageRepository.deleteByChatRoom_Id(roomId);
+        chatRoomParticipantService.deleteAllByRoomId(roomId);
+        chatMessageService.deleteByRoomId(roomId);
         postRepository.deleteByChatRoom_Id(roomId);
-
         chatRoomRepository.delete(room);
     }
 
     @Transactional
     public boolean toggleAlarm(Long roomId, Long memberId) {
-        ChatRoomAlarm alarm = chatRoomAlarmRepository.findByIdMemberIdAndIdRoomId(memberId, roomId)
-            .orElseThrow(() -> new ChatRoomException(ChatRoomErrorCode.ALARM_NOT_FOUND));
-
-        log.debug("Before toggle: {}", alarm.isEnabled());
-        alarm.setEnabled(!alarm.isEnabled());
-        log.debug("After toggle: {}", alarm.isEnabled());
-
-        return alarm.isEnabled();
-    }
-
-    public List<AllRoomsResponse> findAllRoomsByMemberId(Long memberId) {
-        List<ChatRoomWithSequenceProjection> roomProjections =
-            chatRoomRepository.findAllRoomsWithSequenceByParticipantId(memberId);
-
-        List<Long> roomIds = new ArrayList<>(roomProjections.size());
-        Map<Long, ChatRoomWithSequenceProjection> projectionMap = new HashMap<>();
-        Map<Long, Integer> sequenceIndexMap = new HashMap<>();
-
-        for (int i = 0; i < roomProjections.size(); i++) {
-            ChatRoomWithSequenceProjection p = roomProjections.get(i);
-            Long id = p.getChatRoomId();
-            roomIds.add(id);
-            projectionMap.put(id, p);
-            sequenceIndexMap.put(id, i);
-        }
-
-        List<Long> sortedRoomIds;
-        try {
-            sortedRoomIds = chatRoomRedisService.getSortedRoomIds(roomIds);
-        } catch (Exception e) {
-            log.warn("Redis 장애 - 정렬 생략", e);
-            sortedRoomIds = roomIds;
-        }
-
-        Map<Long, Boolean> alarmEnabledMap = roomIds.isEmpty()
-            ? Collections.emptyMap()
-            : fetchAlarmEnabledMap(memberId, roomIds);
-        List<Long> sequences = getSequencesSafe(roomIds);
-
-        return sortedRoomIds.stream().map(roomId -> {
-            ChatRoomWithSequenceProjection p = projectionMap.get(roomId);
-            boolean alarmEnabled = alarmEnabledMap.getOrDefault(roomId, true);
-            Long lastRead = (p.getLastReadSequence() != null) ? p.getLastReadSequence() : 0L;
-
-            Long unreadCount = null;
-            Integer originalIdx = sequenceIndexMap.get(roomId); // 2번에서 만든 맵 사용
-            if (sequences != null && originalIdx != null) {
-                unreadCount = calculateUnread(lastRead, sequences.get(originalIdx));
-            }
-
-            return new AllRoomsResponse(
-                roomId,
-                p.getInviteCode(),
-                p.getName(),
-                alarmEnabled,
-                unreadCount
-            );
-        }).toList();
-    }
-
-    private Map<Long, Boolean> fetchAlarmEnabledMap(Long memberId, List<Long> roomIds) {
-        return chatRoomAlarmRepository.findEnabledMap(memberId, roomIds);
-    }
-
-    private long calculateUnread(long lastReadSequence, long lastMessageSequence) {
-        return Math.max(0, lastMessageSequence - lastReadSequence);
+        return chatRoomAlarmService.toggleAlarm(roomId, memberId);
     }
 
     @Transactional
     public void updateLastReadSequence(Long roomId, Long memberId) {
-        Long currentSequence = getLatestSequence(roomId);
-        chatParticipantRepository
-            .findByChatRoomIdAndParticipantIdAndIsActiveTrue(roomId, memberId)
-            .ifPresent(p -> p.updateLastReadSequence(currentSequence));
+        chatRoomSequenceService.updateLastReadSequence(roomId, memberId);
     }
 
-    private List<Long> getSequencesSafe(List<Long> roomIds) {
-        try {
-            return chatRoomRedisService.getSequences(roomIds);
-        } catch (Exception e) {
-            log.warn("Redis 장애 - DB lastSequence 폴백");
-            meterRegistry.counter("redis.fallback", "reason", "sequence").increment();
-            Map<Long, Long> seqMap = chatRoomRepository.findAllById(roomIds).stream()
-                    .collect(Collectors.toMap(
-                            ChatRoom::getId,
-                            r -> r.getLastSequence() != null ? r.getLastSequence() : 0L
-                    ));
-            return roomIds.stream()
-                    .map(id -> seqMap.getOrDefault(id, 0L))
-                    .toList();
-        }
+    public ChatRoom getRoomById(Long roomId) {
+        return chatRoomRepository.findById(roomId)
+                .orElseThrow(() -> new ChatRoomException(ChatRoomErrorCode.CHATROOM_NOT_FOUND));
     }
 
-    @Transactional
-    public void syncSequencesToDb() {
-        Set<String> updatedRoomIds = chatRoomRedisService.getAndClearUpdatedRooms();
-        if (updatedRoomIds.isEmpty()) return;
-
-        List<Long> roomIds = updatedRoomIds.stream().map(Long::valueOf).toList();
-        List<ChatRoom> rooms = chatRoomRepository.findAllById(roomIds);
-        if (rooms.isEmpty()) return;
-
-        List<Long> targetIds = rooms.stream().map(ChatRoom::getId).toList();
-        List<Long> redisSequences = chatRoomRedisService.getSequences(targetIds);
-
-        for (int i = 0; i < rooms.size(); i++) {
-            Long redisSeq = redisSequences.get(i);
-            long currentSeq = rooms.get(i).getLastSequence() != null ? rooms.get(i).getLastSequence() : 0L;
-            if (redisSeq != null && redisSeq > currentSeq) {
-                rooms.get(i).updateLastSequence(redisSeq);
-            }
-        }
-        log.info("last_sequence 동기화 완료 - {}개 채팅방", rooms.size());
-    }
-
-    public Long getLatestSequence(Long roomId) {
-        try {
-            Long redisSeq = chatRoomRedisService.getSequence(roomId);
-            if (redisSeq == -1L) {
-                ChatRoom room = chatRoomRepository.findById(roomId)
-                        .orElseThrow(() -> new ChatRoomException(ChatRoomErrorCode.CHATROOM_NOT_FOUND));
-                long dbSeq = room.getLastSequence();
-                chatRoomRedisService.setSequence(roomId, dbSeq);
-                return dbSeq;
-            }
-            return redisSeq;
-        } catch (Exception e) {
-            log.warn("Redis 장애 - DB 폴백 roomId={}", roomId);
-            return chatRoomRepository.findById(roomId)
-                    .map(r -> r.getLastSequence() != null ? r.getLastSequence() : 0L)
-                    .orElse(0L);
-        }
+    private ChatRoom getByInviteCode(String inviteCode) {
+        return chatRoomRepository.findByInviteCode(inviteCode)
+                .orElseThrow(() -> new ChatRoomException(ChatRoomErrorCode.CHATROOM_NOT_FOUND));
     }
 }

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomService.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomService.java
@@ -86,7 +86,7 @@ public class ChatRoomService {
         chatRoomParticipantService.handleParticipantJoin(room, member);
         chatRoomAlarmService.createAlarm(memberId, room.getId());
 
-        Long seq = chatRoomCacheService.handleMessageDelivery(room.getId());
+        Long seq = chatRoomCacheService.handleMessageDelivery(room.getId(), memberId);
 
         ChatMessage savedMessage = chatMessageService.saveJoinEvent(room, member, seq);
 

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/app/limiter/FallbackLimiter.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/app/limiter/FallbackLimiter.java
@@ -1,0 +1,20 @@
+package project.backend.domain.chat.chatroom.app.limiter;
+
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.Semaphore;
+
+@Component
+public class FallbackLimiter {
+
+    private static final int MAX_CONCURRENT_FALLBACK = 20;
+    private final Semaphore semaphore = new Semaphore(MAX_CONCURRENT_FALLBACK);
+
+    public boolean tryAcquire() {
+        return semaphore.tryAcquire();
+    }
+
+    public void release() {
+        semaphore.release();
+    }
+}

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/app/limiter/UserRateLimiter.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/app/limiter/UserRateLimiter.java
@@ -1,0 +1,43 @@
+package project.backend.domain.chat.chatroom.app.limiter;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import project.backend.domain.chat.chatroom.dao.ChatRoomRedisRepository;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Slf4j
+@Component
+public class UserRateLimiter {
+
+    private final ChatRoomRedisRepository chatRoomRedisRepository;
+
+    private static final int MAX_REQUESTS_PER_SECOND = 5;
+
+    private final ConcurrentHashMap<Long, AtomicInteger> userCounter = new ConcurrentHashMap<>();
+
+    public UserRateLimiter(ChatRoomRedisRepository chatRoomRedisRepository) {
+        this.chatRoomRedisRepository = chatRoomRedisRepository;
+        ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
+        scheduler.scheduleAtFixedRate(userCounter::clear, 1, 1, TimeUnit.SECONDS);
+    }
+
+    public boolean allow(Long userId) {
+        try {
+            Long count = chatRoomRedisRepository.incrementUserRateLimit(userId);
+            return count <= MAX_REQUESTS_PER_SECOND;
+        } catch (Exception e) {
+            log.warn("Redis Rate Limit 실패 - 메모리 기반으로 전환 userId={}", userId);
+            return allowWithMemory(userId);
+        }
+    }
+
+    private boolean allowWithMemory(Long userId) {
+        userCounter.putIfAbsent(userId, new AtomicInteger(0));
+        return userCounter.get(userId).incrementAndGet() <= MAX_REQUESTS_PER_SECOND;
+    }
+}

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/dao/ChatRoomRedisRepository.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/dao/ChatRoomRedisRepository.java
@@ -20,6 +20,7 @@ public class ChatRoomRedisRepository {
     private static final String ROOM_SEQUENCE_KEY = "room:%d:sequence";
     private static final String UPDATED_ROOMS_KEY = "rooms:updated";
     private static final String RANKING_ROOMS_KEY = "rooms:ranking";
+    private static final String USER_RATE_LIMIT_KEY = "rate:user:%d";
 
     private static final int MAX_RANKING_SIZE = 1000;
     private static final long SEQUENCE_TTL_SEC = 60 * 60 * 24 * 3; // 3일
@@ -159,6 +160,18 @@ public class ChatRoomRedisRepository {
             }
         }
         return result;
+    }
+
+    public Long incrementUserRateLimit(Long userId) {
+        String script =
+                "local count = redis.call('INCR', KEYS[1]); " +
+                        "if count == 1 then redis.call('EXPIRE', KEYS[1], 1) end; " +
+                        "return count;";
+
+        return redisTemplate.execute(
+                new DefaultRedisScript<>(script, Long.class),
+                List.of(String.format(USER_RATE_LIMIT_KEY, userId))
+        );
     }
 
     private byte[] toBytes(String key) {

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/dao/ChatRoomRedisRepository.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/dao/ChatRoomRedisRepository.java
@@ -5,7 +5,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import io.micrometer.core.instrument.MeterRegistry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisCallback;
@@ -26,37 +25,27 @@ public class ChatRoomRedisRepository {
     private static final long SEQUENCE_TTL_SEC = 60 * 60 * 24 * 3; // 3일
 
     private final StringRedisTemplate redisTemplate;
-    private final MeterRegistry meterRegistry;
 
     // 방 시퀀스 INCR -> INCR된 키의 ZSET TTL 초기화 (3일) -> 랭킹 상단 등록 -> 랭킹 MAX 사이즈만큼 자르기 -> ROOM SET 추가
     public Long handleMessageDelivery(Long roomId) {
         String script =
-            "local prev = redis.call('GET', KEYS[1]); " +
-                "local seq = redis.call('INCR', KEYS[1]); " +
-                "redis.call('EXPIRE', KEYS[1], ARGV[1]); " +
-                "redis.call('ZADD', KEYS[2], ARGV[2], ARGV[3]); " +
-                "redis.call('ZREMRANGEBYRANK', KEYS[2], 0, ARGV[4]); " +
-                "redis.call('SADD', KEYS[3], ARGV[3]); " +
-                "if prev == false then return -1 end; " +
-                "return seq;";
+                "local prev = redis.call('GET', KEYS[1]); " +
+                        "local seq = redis.call('INCR', KEYS[1]); " +
+                        "redis.call('EXPIRE', KEYS[1], ARGV[1]); " +
+                        "redis.call('ZADD', KEYS[2], ARGV[2], ARGV[3]); " +
+                        "redis.call('ZREMRANGEBYRANK', KEYS[2], 0, ARGV[4]); " +
+                        "redis.call('SADD', KEYS[3], ARGV[3]); " +
+                        "if prev == false then return -1 end; " +
+                        "return seq;";
 
-        String seqKey = String.format(ROOM_SEQUENCE_KEY, roomId);
-        String roomIdStr = String.valueOf(roomId);
-
-        try {
-            return redisTemplate.execute(
+        return redisTemplate.execute(
                 new DefaultRedisScript<>(script, Long.class),
-                List.of(seqKey, RANKING_ROOMS_KEY, UPDATED_ROOMS_KEY),
+                List.of(String.format(ROOM_SEQUENCE_KEY, roomId), RANKING_ROOMS_KEY, UPDATED_ROOMS_KEY),
                 String.valueOf(SEQUENCE_TTL_SEC),
                 String.valueOf(System.currentTimeMillis()),
-                roomIdStr,
+                String.valueOf(roomId),
                 String.valueOf(-MAX_RANKING_SIZE - 1)
-            );
-        } catch (Exception e) {
-            log.error("Lua 스크립트 실행 오류 - roomId: {}", roomId, e);
-            meterRegistry.counter("redis.fallback", "method", "handleMessageDelivery").increment();
-            return null;
-        }
+        );
     }
 
     public Long recoverAndIncr(Long roomId, Long dbSeq) {
@@ -69,24 +58,15 @@ public class ChatRoomRedisRepository {
                         "redis.call('SADD', KEYS[3], ARGV[4]); " +
                         "return seq;";
 
-        String seqKey = String.format(ROOM_SEQUENCE_KEY, roomId);
-        String roomIdStr = String.valueOf(roomId);
-
-        try {
-            return redisTemplate.execute(
-                    new DefaultRedisScript<>(script, Long.class),
-                    List.of(seqKey, RANKING_ROOMS_KEY, UPDATED_ROOMS_KEY),
-                    String.valueOf(dbSeq),
-                    String.valueOf(SEQUENCE_TTL_SEC),
-                    String.valueOf(System.currentTimeMillis()),
-                    roomIdStr,
-                    String.valueOf(-MAX_RANKING_SIZE - 1)
-            );
-        } catch (Exception e) {
-            log.error("recoverAndIncr 오류 - roomId: {}", roomId, e);
-            meterRegistry.counter("redis.fallback", "method", "recoverAndIncr").increment();
-            return null;
-        }
+        return redisTemplate.execute(
+                new DefaultRedisScript<>(script, Long.class),
+                List.of(String.format(ROOM_SEQUENCE_KEY, roomId), RANKING_ROOMS_KEY, UPDATED_ROOMS_KEY),
+                String.valueOf(dbSeq),
+                String.valueOf(SEQUENCE_TTL_SEC),
+                String.valueOf(System.currentTimeMillis()),
+                String.valueOf(roomId),
+                String.valueOf(-MAX_RANKING_SIZE - 1)
+        );
     }
 
     public List<Long> getSortedRoomIds(List<Long> roomIds) {

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/dao/ChatRoomRepository.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/dao/ChatRoomRepository.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import project.backend.domain.chat.chatroom.entity.ChatRoom;
@@ -40,5 +41,12 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
         """)
     List<ChatRoomWithSequenceProjection> findAllRoomsWithSequenceByParticipantId(
         @Param("memberId") Long memberId);
+
+    @Modifying
+    @Query(value = "UPDATE chat_room SET last_sequence = LAST_INSERT_ID(last_sequence + 1) WHERE id = :roomId", nativeQuery = true)
+    void incrementSequence(@Param("roomId") Long roomId);
+
+    @Query(value = "SELECT LAST_INSERT_ID()", nativeQuery = true)
+    Long findLastInsertId();
 }
 

--- a/backend/src/main/java/project/backend/domain/chat/codereview/app/CodeReviewService.java
+++ b/backend/src/main/java/project/backend/domain/chat/codereview/app/CodeReviewService.java
@@ -7,7 +7,7 @@ import org.springframework.transaction.annotation.Transactional;
 import project.backend.domain.chat.chatmessage.dao.ChatMessageRepository;
 import project.backend.domain.chat.chatmessage.entity.ChatMessage;
 import project.backend.domain.chat.chatmessage.entity.MessageType;
-import project.backend.domain.chat.chatroom.app.ChatRoomService;
+import project.backend.domain.chat.chatroom.app.ChatRoomParticipantService;
 import project.backend.domain.chat.codereview.dao.CodeReviewRepository;
 import project.backend.domain.chat.codereview.dto.CodeReviewCreateRequest;
 import project.backend.domain.chat.codereview.dto.CodeReviewEditRequest;
@@ -29,7 +29,7 @@ public class CodeReviewService {
     private final ChatMessageRepository chatMessageRepository;
     private final MemberService memberService;
     private final CodeReviewMapper codeReviewMapper;
-    private final ChatRoomService chatRoomService;
+    private final ChatRoomParticipantService chatRoomParticipantService;
 
     @Transactional
     public CodeReviewResponse createReview(CodeReviewCreateRequest request, Long authorId) {
@@ -42,7 +42,7 @@ public class CodeReviewService {
             throw new CodeReviewException(CodeReviewErrorCode.INVALID_MESSAGE_TYPE);
         }
 
-        chatRoomService.validateParticipant(authorId, message.getChatRoom().getId());
+        chatRoomParticipantService.validateParticipant(authorId, message.getChatRoom().getId());
 
         CodeReview codeReview = codeReviewMapper.toEntity(request, message, author);
 
@@ -56,7 +56,7 @@ public class CodeReviewService {
         ChatMessage message = chatMessageRepository.findById(messageId)
             .orElseThrow(() -> new ChatMessageException(ChatMessageErrorCode.MESSAGE_NOT_FOUND));
 
-        chatRoomService.validateParticipant(memberId, message.getChatRoom().getId());
+        chatRoomParticipantService.validateParticipant(memberId, message.getChatRoom().getId());
 
         List<CodeReview> reviews = codeReviewRepository
             .findByMessageIdOrderByLineNumberAscCreatedAtAsc(messageId);
@@ -70,7 +70,7 @@ public class CodeReviewService {
     public void deleteReview(Long reviewId, Long authorId) {
         CodeReview codeReview = validateReviewOwnership(reviewId, authorId);
 
-        chatRoomService.validateParticipant(authorId,
+        chatRoomParticipantService.validateParticipant(authorId,
             codeReview.getMessage().getChatRoom().getId());
 
         codeReviewRepository.delete(codeReview);
@@ -81,7 +81,7 @@ public class CodeReviewService {
         Long authorId) {
         CodeReview editCodeReview = validateReviewOwnership(reviewId, authorId);
 
-        chatRoomService.validateParticipant(authorId,
+        chatRoomParticipantService.validateParticipant(authorId,
             editCodeReview.getMessage().getChatRoom().getId());
 
         editCodeReview.editReview(request.content());

--- a/backend/src/main/java/project/backend/domain/community/api/PostController.java
+++ b/backend/src/main/java/project/backend/domain/community/api/PostController.java
@@ -6,6 +6,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import project.backend.auth.dto.MemberDetails;
+import project.backend.domain.community.app.ApplicantService;
 import project.backend.domain.community.app.PostService;
 import project.backend.domain.community.dto.ApplicantResponse;
 import project.backend.domain.community.dto.PostCreateRequest;
@@ -20,8 +21,8 @@ import java.util.List;
 public class PostController {
 
     private final PostService postService;
+    private final ApplicantService applicantService;
 
-    // 게시글 목록 조회
     @GetMapping
     public ResponseEntity<?> getPosts(
             @RequestParam(defaultValue = "hot") String sort,
@@ -34,78 +35,71 @@ public class PostController {
         return ResponseEntity.ok(postService.getPosts(sort, activeOnly, myApplied, page, size, memberDetails));
     }
 
-    // 게시글 상세 조회
     @GetMapping("/{postId}")
     public ResponseEntity<PostResponse> getPost(@PathVariable Long postId) {
         return ResponseEntity.ok(postService.getPost(postId));
     }
 
-    // 게시글 작성
     @PostMapping
     public ResponseEntity<PostResponse> createPost(
-        @RequestBody @Valid PostCreateRequest request,
-        @AuthenticationPrincipal MemberDetails memberDetails
+            @RequestBody @Valid PostCreateRequest request,
+            @AuthenticationPrincipal MemberDetails memberDetails
     ) {
         return ResponseEntity.ok(postService.createPost(request, memberDetails));
     }
 
-    // 게시글 수정
     @PostMapping("/{postId}")
     public ResponseEntity<PostResponse> updatePost(
-        @PathVariable Long postId,
-        @RequestBody @Valid PostUpdateRequest request,
-        @AuthenticationPrincipal MemberDetails memberDetails
+            @PathVariable Long postId,
+            @RequestBody @Valid PostUpdateRequest request,
+            @AuthenticationPrincipal MemberDetails memberDetails
     ) {
         return ResponseEntity.ok(postService.updatePost(postId, request, memberDetails));
     }
 
     @DeleteMapping("/{postId}")
     public ResponseEntity<Void> deletePost(
-        @PathVariable Long postId,
-        @AuthenticationPrincipal MemberDetails memberDetails
+            @PathVariable Long postId,
+            @AuthenticationPrincipal MemberDetails memberDetails
     ) {
         postService.deletePost(postId, memberDetails);
         return ResponseEntity.noContent().build();
     }
 
-    // 스터디 신청
     @PostMapping("/{postId}/apply")
     public ResponseEntity<Void> apply(
-        @PathVariable Long postId,
-        @AuthenticationPrincipal MemberDetails memberDetails
+            @PathVariable Long postId,
+            @AuthenticationPrincipal MemberDetails memberDetails
     ) {
-        postService.apply(postId, memberDetails);
+        applicantService.apply(postId, memberDetails);
         return ResponseEntity.ok().build();
     }
 
-    // 신청자 목록 조회 (방장만)
     @GetMapping("/{postId}/applicants")
     public ResponseEntity<List<ApplicantResponse>> getApplicants(
-        @PathVariable Long postId,
-        @AuthenticationPrincipal MemberDetails memberDetails
+            @PathVariable Long postId,
+            @AuthenticationPrincipal MemberDetails memberDetails
     ) {
-        return ResponseEntity.ok(postService.getApplicants(postId, memberDetails));
+        return ResponseEntity.ok(applicantService.getApplicants(postId, memberDetails));
     }
 
-    // 신청 승인
     @PostMapping("/{postId}/applicants/{applicantId}/approve")
     public ResponseEntity<Void> approve(
-        @PathVariable Long postId,
-        @PathVariable Long applicantId,
-        @AuthenticationPrincipal MemberDetails memberDetails
+            @PathVariable Long postId,
+            @PathVariable Long applicantId,
+            @AuthenticationPrincipal MemberDetails memberDetails
     ) {
-        postService.approve(postId, applicantId, memberDetails);
+        applicantService.approve(postId, applicantId, memberDetails);
         return ResponseEntity.ok().build();
     }
 
-    // 신청 거절
     @PostMapping("/{postId}/applicants/{applicantId}/reject")
     public ResponseEntity<Void> reject(
-        @PathVariable Long postId,
-        @PathVariable Long applicantId,
-        @AuthenticationPrincipal MemberDetails memberDetails
+            @PathVariable Long postId,
+            @PathVariable Long applicantId,
+            @AuthenticationPrincipal MemberDetails memberDetails
     ) {
-        postService.reject(postId, applicantId, memberDetails);
+        applicantService.reject(postId, applicantId, memberDetails);
         return ResponseEntity.ok().build();
     }
 }

--- a/backend/src/main/java/project/backend/domain/community/app/ApplicantService.java
+++ b/backend/src/main/java/project/backend/domain/community/app/ApplicantService.java
@@ -104,7 +104,7 @@ public class ApplicantService {
 
         chatRoomAlarmService.createAlarm(applicant.getMember().getId(), post.getChatRoom().getId());
 
-        Long seq = chatRoomCacheService.handleMessageDelivery(post.getChatRoomId());
+        Long seq = chatRoomCacheService.handleMessageDelivery(post.getChatRoomId(), memberDetails.getId());
         ChatMessage savedMessage = chatMessageService.saveJoinEvent(post.getChatRoom(), applicant.getMember(), seq);
 
         eventPublisher.publishEvent(toJoinChatRoomEvent(post, applicant.getMember(), savedMessage));

--- a/backend/src/main/java/project/backend/domain/community/app/ApplicantService.java
+++ b/backend/src/main/java/project/backend/domain/community/app/ApplicantService.java
@@ -1,0 +1,136 @@
+package project.backend.domain.community.app;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import project.backend.auth.dto.MemberDetails;
+import project.backend.domain.chat.chatmessage.app.ChatMessageService;
+import project.backend.domain.chat.chatmessage.entity.ChatMessage;
+import project.backend.domain.chat.chatroom.app.ChatRoomAlarmService;
+import project.backend.domain.chat.chatroom.app.ChatRoomCacheService;
+import project.backend.domain.chat.chatroom.app.ChatRoomSequenceService;
+import project.backend.domain.chat.chatroom.dao.ChatParticipantRepository;
+import project.backend.domain.chat.chatroom.entity.ChatParticipant;
+import project.backend.domain.community.dao.ApplicantRepository;
+import project.backend.domain.community.dao.PostRepository;
+import project.backend.domain.community.dto.ApplicantResponse;
+import project.backend.domain.community.entity.Applicant;
+import project.backend.domain.community.entity.ApplicantStatus;
+import project.backend.domain.community.entity.Post;
+import project.backend.domain.member.entity.Member;
+import project.backend.global.exception.errorcode.ChatRoomErrorCode;
+import project.backend.global.exception.errorcode.PostErrorCode;
+import project.backend.global.exception.ex.ChatRoomException;
+import project.backend.global.exception.ex.PostException;
+
+import java.util.List;
+
+import static project.backend.domain.community.mapper.CommunityMapper.*;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ApplicantService {
+
+    private final PostRepository postRepository;
+    private final ApplicantRepository applicantRepository;
+    private final ChatParticipantRepository chatParticipantRepository;
+    private final ApplicationEventPublisher eventPublisher;
+
+    private final ChatMessageService chatMessageService;
+    private final ChatRoomCacheService chatRoomCacheService;
+    private final ChatRoomAlarmService chatRoomAlarmService;
+    private final ChatRoomSequenceService chatRoomSequenceService;
+
+    public List<ApplicantResponse> getApplicants(Long postId, MemberDetails memberDetails) {
+        Post post = getPostAndValidateOwner(postId, memberDetails);
+
+        return applicantRepository.findByPost_IdAndStatus(postId, ApplicantStatus.PENDING)
+                .stream()
+                .map(ApplicantResponse::from)
+                .toList();
+    }
+
+    @Transactional
+    public void apply(Long postId, MemberDetails memberDetails) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new PostException(PostErrorCode.POST_NOT_FOUND));
+
+        if (post.isClosed()) {
+            throw new PostException(PostErrorCode.POST_ALREADY_CLOSED);
+        }
+        if (post.isFull()) {
+            throw new PostException(PostErrorCode.POST_ALREADY_FULL);
+        }
+
+        Member member = Member.of(memberDetails);
+
+        if (post.getAuthor().getId().equals(member.getId())) {
+            throw new PostException(PostErrorCode.CANNOT_APPLY_OWN_POST);
+        }
+
+        if (chatParticipantRepository.existsByParticipantIdAndChatRoomIdAndIsActiveTrue(
+                member.getId(), post.getChatRoom().getId())) {
+            throw new ChatRoomException(ChatRoomErrorCode.ALREADY_PARTICIPANT);
+        }
+
+        applicantRepository.findByPost_IdAndMember_Id(postId, member.getId())
+                .ifPresent(existing -> {
+                    existing.validateReapply();
+                    applicantRepository.delete(existing);
+                });
+
+        eventPublisher.publishEvent(toApplyEvent(post, member));
+        applicantRepository.save(Applicant.of(post, member));
+    }
+
+    @Transactional
+    public void approve(Long postId, Long applicantId, MemberDetails memberDetails) {
+        Post post = getPostAndValidateOwner(postId, memberDetails);
+        Applicant applicant = getApplicant(applicantId);
+
+        applicant.approve();
+        post.incrementCurrentCount();
+        if (post.isFull()) {
+            post.close();
+        }
+
+        ChatParticipant chatParticipant = ChatParticipant.of(applicant.getMember(), post.getChatRoom());
+        chatParticipantRepository.save(chatParticipant);
+
+        Long currentSequence = chatRoomSequenceService.getLatestSequence(post.getChatRoom().getId());
+        chatParticipant.updateLastReadSequence(currentSequence);
+
+        chatRoomAlarmService.createAlarm(applicant.getMember().getId(), post.getChatRoom().getId());
+
+        Long seq = chatRoomCacheService.handleMessageDelivery(post.getChatRoomId());
+        ChatMessage savedMessage = chatMessageService.saveJoinEvent(post.getChatRoom(), applicant.getMember(), seq);
+
+        eventPublisher.publishEvent(toJoinChatRoomEvent(post, applicant.getMember(), savedMessage));
+        eventPublisher.publishEvent(toApplicantResultEvent(post, applicant, true));
+    }
+
+    @Transactional
+    public void reject(Long postId, Long applicantId, MemberDetails memberDetails) {
+        Post post = getPostAndValidateOwner(postId, memberDetails);
+        Applicant applicant = getApplicant(applicantId);
+        applicant.reject();
+
+        eventPublisher.publishEvent(toApplicantResultEvent(post, applicant, false));
+    }
+
+    private Post getPostAndValidateOwner(Long postId, MemberDetails memberDetails) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new PostException(PostErrorCode.POST_NOT_FOUND));
+        if (!post.getAuthor().getId().equals(memberDetails.getId())) {
+            throw new PostException(PostErrorCode.POST_FORBIDDEN);
+        }
+        return post;
+    }
+
+    private Applicant getApplicant(Long applicantId) {
+        return applicantRepository.findById(applicantId)
+                .orElseThrow(() -> new PostException(PostErrorCode.APPLICANT_NOT_FOUND));
+    }
+}

--- a/backend/src/main/java/project/backend/domain/community/app/PostService.java
+++ b/backend/src/main/java/project/backend/domain/community/app/PostService.java
@@ -1,30 +1,18 @@
 package project.backend.domain.community.app;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import project.backend.auth.dto.MemberDetails;
-import project.backend.domain.chat.chatmessage.dao.ChatMessageRepository;
-import project.backend.domain.chat.chatmessage.entity.ChatMessage;
-import project.backend.domain.chat.chatmessage.mapper.ChatMessageMapper;
-import project.backend.domain.chat.chatroom.app.ChatRoomRedisService;
-import project.backend.domain.chat.chatroom.app.ChatRoomService;
-import project.backend.domain.chat.chatroom.dao.ChatParticipantRepository;
 import project.backend.domain.chat.chatroom.dao.ChatRoomRepository;
-import project.backend.domain.chat.chatroom.entity.ChatParticipant;
 import project.backend.domain.chat.chatroom.entity.ChatRoom;
-import project.backend.domain.community.dao.ApplicantRepository;
 import project.backend.domain.community.dao.PostRepository;
-import project.backend.domain.community.dto.ApplicantResponse;
 import project.backend.domain.community.dto.PostCreateRequest;
 import project.backend.domain.community.dto.PostResponse;
 import project.backend.domain.community.dto.PostUpdateRequest;
-import project.backend.domain.community.entity.ApplicantStatus;
 import project.backend.domain.community.entity.Post;
-import project.backend.domain.community.entity.Applicant;
 import project.backend.domain.community.mapper.CommunityMapper;
 import project.backend.domain.member.entity.Member;
 import project.backend.global.exception.errorcode.ChatRoomErrorCode;
@@ -33,10 +21,6 @@ import project.backend.global.exception.ex.ChatRoomException;
 import project.backend.global.exception.ex.PostException;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.util.List;
-
-import static project.backend.domain.community.mapper.CommunityMapper.*;
 
 @Service
 @RequiredArgsConstructor
@@ -45,18 +29,9 @@ public class PostService {
 
     private final PostRepository postRepository;
     private final ChatRoomRepository chatRoomRepository;
-    private final ChatMessageRepository chatMessageRepository;
-    private final ChatParticipantRepository chatParticipantRepository;
-    private final ApplicantRepository applicantRepository;
-    private final ChatMessageMapper chatMessageMapper;
-    private final ApplicationEventPublisher eventPublisher;
-
-    private final ChatRoomRedisService chatRoomRedisService;
-    private final ChatRoomService chatRoomService;
 
     public Slice<PostResponse> getPosts(String sort, boolean activeOnly, boolean myApplied,
-        int page, int size, MemberDetails memberDetails) {
-
+                                        int page, int size, MemberDetails memberDetails) {
         PageRequest pageable = PageRequest.of(page, size);
 
         if (myApplied) {
@@ -64,20 +39,20 @@ public class PostService {
                 throw new PostException(PostErrorCode.POST_FORBIDDEN);
             }
             return postRepository
-                .findAppliedByMember(memberDetails.getId(), pageable)
-                .map(PostResponse::from);
+                    .findAppliedByMember(memberDetails.getId(), pageable)
+                    .map(PostResponse::from);
         }
 
         Slice<Post> posts;
         if (activeOnly) {
             LocalDate today = LocalDate.now();
             posts = sort.equals("hot")
-                ? postRepository.findActiveByOrderByViewCountDesc(pageable, today)
-                : postRepository.findActiveByOrderByCreatedAtDesc(pageable, today);
+                    ? postRepository.findActiveByOrderByViewCountDesc(pageable, today)
+                    : postRepository.findActiveByOrderByCreatedAtDesc(pageable, today);
         } else {
             posts = sort.equals("hot")
-                ? postRepository.findAllByOrderByViewCountDesc(pageable)
-                : postRepository.findAllByOrderByCreatedAtDesc(pageable);
+                    ? postRepository.findAllByOrderByViewCountDesc(pageable)
+                    : postRepository.findAllByOrderByCreatedAtDesc(pageable);
         }
 
         return posts.map(PostResponse::from);
@@ -86,7 +61,7 @@ public class PostService {
     @Transactional
     public PostResponse getPost(Long postId) {
         Post post = postRepository.findById(postId)
-            .orElseThrow(() -> new PostException(PostErrorCode.POST_NOT_FOUND));
+                .orElseThrow(() -> new PostException(PostErrorCode.POST_NOT_FOUND));
         post.incrementViewCount();
         return PostResponse.from(post);
     }
@@ -100,18 +75,17 @@ public class PostService {
         }
 
         ChatRoom chatRoom = chatRoomRepository.findById(request.getChatRoomId())
-            .orElseThrow(
-                () -> new ChatRoomException(ChatRoomErrorCode.CHATROOM_NOT_FOUND));
+                .orElseThrow(() -> new ChatRoomException(ChatRoomErrorCode.CHATROOM_NOT_FOUND));
 
         return PostResponse.from(
-            postRepository.save(CommunityMapper.toPost(request, author, chatRoom)));
+                postRepository.save(CommunityMapper.toPost(request, author, chatRoom)));
     }
 
     @Transactional
     public PostResponse updatePost(Long postId, PostUpdateRequest request,
-        MemberDetails memberDetails) {
+                                   MemberDetails memberDetails) {
         Post post = postRepository.findById(postId)
-            .orElseThrow(() -> new PostException(PostErrorCode.POST_NOT_FOUND));
+                .orElseThrow(() -> new PostException(PostErrorCode.POST_NOT_FOUND));
 
         if (!post.getAuthor().getId().equals(memberDetails.getId())) {
             throw new PostException(PostErrorCode.POST_FORBIDDEN);
@@ -124,13 +98,13 @@ public class PostService {
         }
 
         post.update(
-            request.getTitle(),
-            request.getContent(),
-            request.getMaxCount(),
-            request.getTag(),
-            request.getMode(),
-            request.getDeadline(),
-            request.getTechStacks() != null ? String.join(",", request.getTechStacks()) : null
+                request.getTitle(),
+                request.getContent(),
+                request.getMaxCount(),
+                request.getTag(),
+                request.getMode(),
+                request.getDeadline(),
+                request.getTechStacks() != null ? String.join(",", request.getTechStacks()) : null
         );
 
         return PostResponse.from(post);
@@ -139,116 +113,12 @@ public class PostService {
     @Transactional
     public void deletePost(Long postId, MemberDetails memberDetails) {
         Post post = postRepository.findById(postId)
-            .orElseThrow(() -> new PostException(PostErrorCode.POST_NOT_FOUND));
+                .orElseThrow(() -> new PostException(PostErrorCode.POST_NOT_FOUND));
 
         if (!post.getAuthor().getId().equals(memberDetails.getId())) {
             throw new PostException(PostErrorCode.POST_FORBIDDEN);
         }
 
         postRepository.delete(post);
-    }
-
-    // 스터디 신청
-    @Transactional
-    public void apply(Long postId, MemberDetails memberDetails) {
-        Post post = postRepository.findById(postId)
-            .orElseThrow(() -> new PostException(PostErrorCode.POST_NOT_FOUND));
-
-        if (post.isClosed()) {
-            throw new PostException(PostErrorCode.POST_ALREADY_CLOSED);
-        }
-        if (post.isFull()) {
-            throw new PostException(PostErrorCode.POST_ALREADY_FULL);
-        }
-
-        Member member = Member.of(memberDetails);
-
-        if (post.getAuthor().getId().equals(member.getId())) {
-            throw new PostException(PostErrorCode.CANNOT_APPLY_OWN_POST);
-        }
-
-        if (chatParticipantRepository.existsByParticipantIdAndChatRoomIdAndIsActiveTrue(
-                member.getId(), post.getChatRoom().getId())) {
-            throw new ChatRoomException(ChatRoomErrorCode.ALREADY_PARTICIPANT);
-        }
-
-        applicantRepository.findByPost_IdAndMember_Id(postId, member.getId())
-            .ifPresent(existing -> {
-                existing.validateReapply();
-                applicantRepository.delete(existing);
-            });
-
-        eventPublisher.publishEvent(CommunityMapper.toApplyEvent(post, member));
-
-        applicantRepository.save(Applicant.of(post, member));
-    }
-
-    // 신청자 목록 조회 (방장만)
-    public List<ApplicantResponse> getApplicants(Long postId, MemberDetails memberDetails) {
-        Post post = postRepository.findById(postId)
-            .orElseThrow(() -> new PostException(PostErrorCode.POST_NOT_FOUND));
-
-        if (!post.getAuthor().getId().equals(memberDetails.getId())) {
-            throw new PostException(PostErrorCode.POST_FORBIDDEN);
-        }
-
-        return applicantRepository.findByPost_IdAndStatus(postId, ApplicantStatus.PENDING)
-            .stream()
-            .map(ApplicantResponse::from)
-            .toList();
-    }
-
-    @Transactional
-    public void approve(Long postId, Long applicantId, MemberDetails memberDetails) {
-        Post post = getPostAndValidateOwner(postId, memberDetails);
-        Applicant applicant = getApplicant(applicantId);
-
-        applicant.approve();
-        post.incrementCurrentCount();
-        if (post.isFull()) {
-            post.close();
-        }
-
-        ChatParticipant chatParticipant = ChatParticipant.of(applicant.getMember(),
-            post.getChatRoom());
-        chatParticipantRepository.save(chatParticipant);
-
-        Long currentSequence = chatRoomService.getLatestSequence(post.getChatRoom().getId());
-        chatParticipant.updateLastReadSequence(currentSequence);
-
-        chatRoomService.createAlarm(applicant.getMember().getId(), post.getChatRoom().getId());
-
-        Long seq = chatRoomRedisService.handleMessageDelivery(post.getChatRoomId());
-
-        ChatMessage message = chatMessageMapper.toEntityWithJoinEvent(
-                post.getChatRoom(), applicant.getMember(), LocalDateTime.now(), seq);
-
-        ChatMessage savedMessage = chatMessageRepository.save(message);
-
-        eventPublisher.publishEvent(toJoinChatRoomEvent(post, applicant.getMember(), savedMessage));
-        eventPublisher.publishEvent(toApplicantResultEvent(post, applicant, true));
-    }
-
-    @Transactional
-    public void reject(Long postId, Long applicantId, MemberDetails memberDetails) {
-        Post post = getPostAndValidateOwner(postId, memberDetails);
-        Applicant applicant = getApplicant(applicantId);
-        applicant.reject();
-
-        eventPublisher.publishEvent(CommunityMapper.toApplicantResultEvent(post, applicant, false));
-    }
-
-    private Post getPostAndValidateOwner(Long postId, MemberDetails memberDetails) {
-        Post post = postRepository.findById(postId)
-            .orElseThrow(() -> new PostException(PostErrorCode.POST_NOT_FOUND));
-        if (!post.getAuthor().getId().equals(memberDetails.getId())) {
-            throw new PostException(PostErrorCode.POST_FORBIDDEN);
-        }
-        return post;
-    }
-
-    private Applicant getApplicant(Long applicantId) {
-        return applicantRepository.findById(applicantId)
-            .orElseThrow(() -> new PostException(PostErrorCode.APPLICANT_NOT_FOUND));
     }
 }

--- a/backend/src/main/java/project/backend/global/exception/errorcode/ChatRoomErrorCode.java
+++ b/backend/src/main/java/project/backend/global/exception/errorcode/ChatRoomErrorCode.java
@@ -17,12 +17,12 @@ public enum ChatRoomErrorCode implements ErrorCode {
     OWNER_CANNOT_LEAVE("CRE-007", "방장은 채팅방에서 나갈 수 없습니다.", HttpStatus.FORBIDDEN),
     OWNER_PERMISSION_REQUIRED("CRE-008", "방장 권한이 필요합니다.", HttpStatus.FORBIDDEN),
     OWNER_NOT_FOUND("CRE-009", "방장을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
-    ASYNC_TASK_REJECTED("CRE-010", "작업량이 많아 요청이 처리되지 않았습니다. 잠시 후 다시 시도해주세요.",
-        HttpStatus.TOO_MANY_REQUESTS),
-	ALARM_NOT_FOUND("CRE-010", "채팅방 알림 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+    ASYNC_TASK_REJECTED("CRE-010", "작업량이 많아 요청이 처리되지 않았습니다. 잠시 후 다시 시도해주세요.", HttpStatus.TOO_MANY_REQUESTS),
+    ALARM_NOT_FOUND("CRE-011", "채팅방 알림 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    TOO_MANY_REQUESTS("CRE-012", "요청이 너무 많습니다. 잠시 후 다시 시도해주세요.", HttpStatus.TOO_MANY_REQUESTS),
+    SERVICE_UNAVAILABLE("CRE-013", "서비스가 일시적으로 불가합니다. 잠시 후 다시 시도해주세요.", HttpStatus.SERVICE_UNAVAILABLE);
 
-
-	private final String code;
+    private final String code;
     private final String message;
     private final HttpStatus status;
 }

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -77,6 +77,12 @@ resilience4j:
           - org.springframework.data.redis.RedisConnectionFailureException
           - io.lettuce.core.RedisException
           - java.util.concurrent.TimeoutException
+  ratelimiter:
+    instances:
+      redis-fallback:
+        limit-for-period: 100        # 최대 인스턴스 수 기준으로 분할 (global limit ≈ 100)
+        limit-refresh-period: 1s
+        timeout-duration: 0s         # 초과 시 즉시 거절
 
 file:
   images:

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -56,6 +56,28 @@ spring:
         show_sql: true
         format_sql: true
 
+resilience4j:
+  circuitbreaker:
+    instances:
+      redis:
+        # CLOSED → OPEN 전환 기준
+        failure-rate-threshold: 50              # 실패율 50% 초과 시 OPEN
+        minimum-number-of-calls: 5              # 최소 5번 호출 후 실패율 계산
+        sliding-window-size: 10                 # 최근 10개 요청 기준
+        sliding-window-type: COUNT_BASED        # 횟수 기반
+        # OPEN → HALF_OPEN 전환 기준
+        wait-duration-in-open-state: 30s        # 30초 후 HALF_OPEN
+        # HALF_OPEN → CLOSED 전환 기준
+        permitted-number-of-calls-in-half-open-state: 3  # 3개 요청 테스트
+        # 느린 호출 기준
+        slow-call-rate-threshold: 80            # 느린 호출 80% 초과 시 OPEN
+        slow-call-duration-threshold: 2s        # 2초 이상이면 느린 호출
+        # 예외 처리
+        record-exceptions:
+          - org.springframework.data.redis.RedisConnectionFailureException
+          - io.lettuce.core.RedisException
+          - java.util.concurrent.TimeoutException
+
 file:
   images:
     profile:

--- a/backend/src/test/java/project/backend/domain/chat/chatmessage/app/ChatMessageServiceTest.java
+++ b/backend/src/test/java/project/backend/domain/chat/chatmessage/app/ChatMessageServiceTest.java
@@ -44,12 +44,13 @@ import project.backend.domain.chat.chatmessage.dto.event.ChatMessageSavedEvent;
 import project.backend.domain.chat.chatmessage.entity.ChatMessage;
 import project.backend.domain.chat.chatmessage.entity.ChatMessageSearch;
 import project.backend.domain.chat.chatmessage.mapper.ChatMessageMapper;
-import project.backend.domain.chat.chatroom.app.ChatRoomRedisService;
-import project.backend.domain.chat.chatroom.app.ChatRoomService;
+import project.backend.domain.chat.chatroom.app.ChatRoomCacheService;
+import project.backend.domain.chat.chatroom.app.ChatRoomParticipantService;
+import project.backend.domain.chat.chatroom.dao.ChatRoomRepository;
 import project.backend.domain.chat.chatroom.entity.ChatRoom;
 import project.backend.domain.imagefile.ImageFile;
 import project.backend.domain.imagefile.ImageFileService;
-import project.backend.domain.member.app.MemberService;
+import project.backend.domain.member.app.MemberRedisService;
 import project.backend.domain.member.entity.Member;
 import project.backend.global.exception.ex.AuthException;
 import project.backend.global.exception.ex.ChatMessageException;
@@ -60,24 +61,16 @@ class ChatMessageServiceTest {
     @InjectMocks
     private ChatMessageService chatMessageService;
 
-    @Mock
-    private ChatMessageRepository chatMessageRepository;
-    @Mock
-    private ChatMessageSearchRepository chatMessageSearchRepository;
-    @Mock
-    private ChatRoomService chatRoomService;
-    @Mock
-    private MemberService memberService;
-    @Mock
-    private ImageFileService imageFileService;
-    @Mock
-    private ApplicationEventPublisher eventPublisher;
-    @Mock
-    private EntityManager entityManager;
-    @Mock
-    private ChatMessageMapper messageMapper;
-    @Mock
-    private ChatRoomRedisService chatRoomRedisService;
+    @Mock private ChatMessageRepository chatMessageRepository;
+    @Mock private ChatMessageSearchRepository chatMessageSearchRepository;
+    @Mock private ChatRoomParticipantService chatRoomParticipantService;
+    @Mock private ChatRoomRepository chatRoomRepository;
+    @Mock private ImageFileService imageFileService;
+    @Mock private ApplicationEventPublisher eventPublisher;
+    @Mock private EntityManager entityManager;
+    @Mock private ChatMessageMapper messageMapper;
+    @Mock private ChatRoomCacheService chatRoomCacheService;
+    @Mock private MemberRedisService memberRedisService;
 
     private Member sender;
     private ChatRoom chatRoom;
@@ -108,14 +101,16 @@ class ChatMessageServiceTest {
             ChatMessageRequest request = mock(ChatMessageRequest.class);
             given(request.getType()).willReturn(TEXT);
 
-            given(chatRoomRedisService.handleMessageDelivery(10L)).willReturn(3L);
+            given(chatRoomCacheService.handleMessageDelivery(10L)).willReturn(3L);
             given(entityManager.getReference(Member.class, 1L)).willReturn(sender);
             given(entityManager.getReference(ChatRoom.class, 10L)).willReturn(chatRoom);
-            given(messageMapper.toEntityWithText(chatRoom, sender, request, 3L)).willReturn(
-                textMessage);
+            given(messageMapper.toEntityWithText(chatRoom, sender, request, 3L)).willReturn(textMessage);
             given(textMessage.getType()).willReturn(TEXT);
-            given(messageMapper.toResponse(textMessage, memberDetails)).willReturn(
-                mock(ChatMessageResponse.class));
+            given(textMessage.getChatRoom()).willReturn(chatRoom);
+            given(chatRoom.getId()).willReturn(10L);
+            given(memberRedisService.getProfileImage(1L)).willReturn("profile.png");
+            given(messageMapper.toResponse(eq(textMessage), eq(memberDetails), anyString()))
+                    .willReturn(mock(ChatMessageResponse.class));
 
             ChatMessageResponse result = chatMessageService.save(10L, request, memberDetails);
 
@@ -133,21 +128,23 @@ class ChatMessageServiceTest {
             given(request.getType()).willReturn(IMAGE);
             given(request.getImageFileId()).willReturn(99L);
 
-            given(chatRoomRedisService.handleMessageDelivery(10L)).willReturn(1L);
+            given(chatRoomCacheService.handleMessageDelivery(10L)).willReturn(1L);
             given(entityManager.getReference(Member.class, 1L)).willReturn(sender);
             given(entityManager.getReference(ChatRoom.class, 10L)).willReturn(chatRoom);
 
             ImageFile imageFile = mock(ImageFile.class);
             given(imageFileService.getImageById(99L)).willReturn(imageFile);
-            given(messageMapper.toEntityWithImage(chatRoom, sender, imageFile, 1L)).willReturn(
-                imageMessage);
+            given(messageMapper.toEntityWithImage(chatRoom, sender, imageFile, 1L)).willReturn(imageMessage);
             given(imageMessage.getType()).willReturn(IMAGE);
-            given(messageMapper.toResponse(imageMessage, memberDetails)).willReturn(
-                mock(ChatMessageResponse.class));
+            given(imageMessage.getChatRoom()).willReturn(chatRoom);
+            given(chatRoom.getId()).willReturn(10L);
+            given(memberRedisService.getProfileImage(1L)).willReturn("profile.png");
+            given(messageMapper.toResponse(eq(imageMessage), eq(memberDetails), anyString()))
+                    .willReturn(mock(ChatMessageResponse.class));
 
             chatMessageService.save(10L, request, memberDetails);
 
-            then(eventPublisher).should(never()).publishEvent(any());
+            then(eventPublisher).should(never()).publishEvent(any(ChatMessageSavedEvent.class));
         }
 
         @Test
@@ -158,14 +155,16 @@ class ChatMessageServiceTest {
             ChatMessageRequest request = mock(ChatMessageRequest.class);
             given(request.getType()).willReturn(CODE);
 
-            given(chatRoomRedisService.handleMessageDelivery(10L)).willReturn(2L);
+            given(chatRoomCacheService.handleMessageDelivery(10L)).willReturn(2L);
             given(entityManager.getReference(Member.class, 1L)).willReturn(sender);
             given(entityManager.getReference(ChatRoom.class, 10L)).willReturn(chatRoom);
-            given(messageMapper.toEntityWithCode(chatRoom, sender, request, 2L)).willReturn(
-                codeMessage);
+            given(messageMapper.toEntityWithCode(chatRoom, sender, request, 2L)).willReturn(codeMessage);
             given(codeMessage.getType()).willReturn(CODE);
-            given(messageMapper.toResponse(codeMessage, memberDetails)).willReturn(
-                mock(ChatMessageResponse.class));
+            given(codeMessage.getChatRoom()).willReturn(chatRoom);
+            given(chatRoom.getId()).willReturn(10L);
+            given(memberRedisService.getProfileImage(1L)).willReturn("profile.png");
+            given(messageMapper.toResponse(eq(codeMessage), eq(memberDetails), anyString()))
+                    .willReturn(mock(ChatMessageResponse.class));
 
             chatMessageService.save(10L, request, memberDetails);
 
@@ -186,8 +185,8 @@ class ChatMessageServiceTest {
             given(request.getPageSize()).willReturn(10);
 
             List<Long> ids = new ArrayList<>(List.of(1L, 2L, 3L));
-            given(chatMessageSearchRepository.searchIdsByKeywordAndRoomIdWithCursor("hello", 10L,
-                null, 11)).willReturn(ids);
+            given(chatMessageSearchRepository.searchIdsByKeywordAndRoomIdWithCursor(
+                    "hello", 10L, null, 11)).willReturn(ids);
             given(chatMessageSearchRepository.countByKeywordAndRoomId("hello", 10L)).willReturn(3L);
 
             ChatMessage msg1 = mock(ChatMessage.class);
@@ -198,48 +197,41 @@ class ChatMessageServiceTest {
             given(msg3.getId()).willReturn(3L);
 
             given(chatMessageRepository.findByIdIn(ids)).willReturn(List.of(msg1, msg2, msg3));
-            given(messageMapper.toSearchResponse(any())).willReturn(
-                mock(ChatMessageSearchResponse.class));
-            willDoNothing().given(chatRoomService).validateParticipant(1L, 10L);
+            given(messageMapper.toSearchResponse(any())).willReturn(mock(ChatMessageSearchResponse.class));
+            willDoNothing().given(chatRoomParticipantService).validateParticipant(1L, 10L);
 
-            Slice<ChatMessageSearchResponse> result = chatMessageService.searchMessages(1L, 10L,
-                request);
+            Slice<ChatMessageSearchResponse> result = chatMessageService.searchMessages(1L, 10L, request);
 
             assertThat(result.getContent()).hasSize(3);
             assertThat(result.hasNext()).isFalse();
         }
 
         @Test
-        @DisplayName("다음 페이지가 있을 때 hasNext=true를 반환하고 totalCount는 조회하지 않는다")
+        @DisplayName("다음 페이지가 있을 때 hasNext=true를 반환한다")
         void searchMessages_hasNextPage_returnsHasNextTrue() {
             ChatMessageSearchRequest request = mock(ChatMessageSearchRequest.class);
             given(request.getKeyword()).willReturn("hello");
             given(request.getLastMessageId()).willReturn(50L);
             given(request.getPageSize()).willReturn(2);
 
-            List<Long> ids = new ArrayList<>(List.of(10L, 20L, 30L)); // pageSize+1 → hasNext
-            given(
-                chatMessageSearchRepository.searchIdsByKeywordAndRoomIdWithCursor("hello", 10L, 50L,
-                    3)).willReturn(ids);
+            List<Long> ids = new ArrayList<>(List.of(10L, 20L, 30L));
+            given(chatMessageSearchRepository.searchIdsByKeywordAndRoomIdWithCursor(
+                    "hello", 10L, 50L, 3)).willReturn(ids);
 
             ChatMessage msg1 = mock(ChatMessage.class);
             given(msg1.getId()).willReturn(10L);
             ChatMessage msg2 = mock(ChatMessage.class);
             given(msg2.getId()).willReturn(20L);
 
-            // remove() 후 ids = [10L, 20L] 이므로 anyList()로 매칭
             given(chatMessageRepository.findByIdIn(anyList())).willReturn(List.of(msg1, msg2));
-            given(messageMapper.toSearchResponse(any())).willReturn(
-                mock(ChatMessageSearchResponse.class));
-            willDoNothing().given(chatRoomService).validateParticipant(1L, 10L);
+            given(messageMapper.toSearchResponse(any())).willReturn(mock(ChatMessageSearchResponse.class));
+            willDoNothing().given(chatRoomParticipantService).validateParticipant(1L, 10L);
 
-            Slice<ChatMessageSearchResponse> result = chatMessageService.searchMessages(1L, 10L,
-                request);
+            Slice<ChatMessageSearchResponse> result = chatMessageService.searchMessages(1L, 10L, request);
 
             assertThat(result.hasNext()).isTrue();
             assertThat(result.getContent()).hasSize(2);
-            then(chatMessageSearchRepository).should(never())
-                .countByKeywordAndRoomId(anyString(), anyLong());
+            then(chatMessageSearchRepository).should(never()).countByKeywordAndRoomId(anyString(), anyLong());
         }
     }
 
@@ -250,25 +242,21 @@ class ChatMessageServiceTest {
         @Test
         @DisplayName("본인 TEXT 메시지를 정상적으로 수정한다")
         void editMessage_textMessage_success() {
-            // PotentialStubbingProblem 수정:
-            //   chatMessageSearchRepository.findById()는 message.getId() 반환값으로 호출됨.
-            //   textMessage.getId()를 명시적으로 stubbing해야 인자가 일치함.
             given(textMessage.getId()).willReturn(100L);
             given(textMessage.getSender()).willReturn(sender);
+            given(textMessage.getChatRoom()).willReturn(chatRoom);
+            given(chatRoom.getId()).willReturn(10L);
             given(textMessage.getType()).willReturn(TEXT);
             given(textMessage.getContent()).willReturn("hello");
-            given(sender.getUsername()).willReturn("testUser");
+            given(sender.getId()).willReturn(1L);
+            given(memberDetails.getId()).willReturn(1L);
 
-            given(memberService.getMemberByUsername("testUser")).willReturn(sender);
             given(chatMessageRepository.findById(100L)).willReturn(Optional.of(textMessage));
-
             ChatMessageSearch searchEntity = mock(ChatMessageSearch.class);
             given(chatMessageSearchRepository.findById(100L)).willReturn(Optional.of(searchEntity));
-            given(messageMapper.toResponse(textMessage)).willReturn(
-                mock(ChatMessageResponse.class));
+            given(memberRedisService.getProfileImage(1L)).willReturn("profile.png");
 
-            chatMessageService.editMessage(10L,
-                new ChatMessageEditRequest(100L, "updated", TEXT, null), "testUser");
+            chatMessageService.editMessage(10L, new ChatMessageEditRequest(100L, "updated", TEXT, null), memberDetails);
 
             then(textMessage).should().updateContent("updated");
             then(searchEntity).should().updateContent("hello");
@@ -277,23 +265,21 @@ class ChatMessageServiceTest {
         @Test
         @DisplayName("CODE 메시지 수정 시 언어도 함께 업데이트한다")
         void editMessage_codeMessage_updatesLanguage() {
-            // codeMessage.getId()를 stubbing해야 findById 인자가 일치함
             given(codeMessage.getId()).willReturn(300L);
             given(codeMessage.getSender()).willReturn(sender);
+            given(codeMessage.getChatRoom()).willReturn(chatRoom);
+            given(chatRoom.getId()).willReturn(10L);
             given(codeMessage.getType()).willReturn(CODE);
             given(codeMessage.getContent()).willReturn("System.out.println();");
-            given(sender.getUsername()).willReturn("testUser");
+            given(sender.getId()).willReturn(1L);
+            given(memberDetails.getId()).willReturn(1L);
 
-            given(memberService.getMemberByUsername("testUser")).willReturn(sender);
             given(chatMessageRepository.findById(300L)).willReturn(Optional.of(codeMessage));
-
             ChatMessageSearch searchEntity = mock(ChatMessageSearch.class);
             given(chatMessageSearchRepository.findById(300L)).willReturn(Optional.of(searchEntity));
-            given(messageMapper.toResponse(codeMessage)).willReturn(
-                mock(ChatMessageResponse.class));
+            given(memberRedisService.getProfileImage(1L)).willReturn("profile.png");
 
-            chatMessageService.editMessage(10L,
-                new ChatMessageEditRequest(300L, "int x=0;", CODE, "JAVA"), "testUser");
+            chatMessageService.editMessage(10L, new ChatMessageEditRequest(300L, "int x=0;", CODE, "JAVA"), memberDetails);
 
             then(codeMessage).should().updateContent("int x=0;");
             then(codeMessage).should().updateLanguage("JAVA");
@@ -302,46 +288,47 @@ class ChatMessageServiceTest {
         @Test
         @DisplayName("존재하지 않는 메시지 수정 시 예외를 던진다")
         void editMessage_notFound_throwsException() {
-            given(memberService.getMemberByUsername("testUser")).willReturn(sender);
             given(chatMessageRepository.findById(999L)).willReturn(Optional.empty());
 
             assertThatThrownBy(() ->
-                chatMessageService.editMessage(10L,
-                    new ChatMessageEditRequest(999L, "x", TEXT, null), "testUser"))
-                .isInstanceOf(ChatMessageException.class);
+                    chatMessageService.editMessage(10L,
+                            new ChatMessageEditRequest(999L, "x", TEXT, null), memberDetails))
+                    .isInstanceOf(ChatMessageException.class);
         }
 
         @Test
         @DisplayName("본인이 아닌 사람이 메시지를 수정하면 FORBIDDEN 예외를 던진다")
         void editMessage_notOwner_throwsAuthException() {
-
             Member otherSender = mock(Member.class);
-            given(otherSender.getUsername()).willReturn("otherUser");
+            given(otherSender.getId()).willReturn(99L);
             given(textMessage.getSender()).willReturn(otherSender);
+            given(textMessage.getChatRoom()).willReturn(chatRoom);
+            given(chatRoom.getId()).willReturn(10L);
+            given(memberDetails.getId()).willReturn(1L);
 
-            given(memberService.getMemberByUsername("testUser")).willReturn(sender);
             given(chatMessageRepository.findById(100L)).willReturn(Optional.of(textMessage));
 
             assertThatThrownBy(() ->
-                chatMessageService.editMessage(10L,
-                    new ChatMessageEditRequest(100L, "hack", TEXT, null), "testUser"))
-                .isInstanceOf(AuthException.class);
+                    chatMessageService.editMessage(10L,
+                            new ChatMessageEditRequest(100L, "hack", TEXT, null), memberDetails))
+                    .isInstanceOf(AuthException.class);
         }
 
         @Test
         @DisplayName("IMAGE 메시지는 검색 엔티티 업데이트를 하지 않는다")
         void editMessage_imageMessage_noSearchUpdate() {
             given(imageMessage.getSender()).willReturn(sender);
+            given(imageMessage.getChatRoom()).willReturn(chatRoom);
+            given(chatRoom.getId()).willReturn(10L);
             given(imageMessage.getType()).willReturn(IMAGE);
-            given(sender.getUsername()).willReturn("testUser");
+            given(sender.getId()).willReturn(1L);
+            given(memberDetails.getId()).willReturn(1L);
 
-            given(memberService.getMemberByUsername("testUser")).willReturn(sender);
             given(chatMessageRepository.findById(200L)).willReturn(Optional.of(imageMessage));
-            given(messageMapper.toResponse(imageMessage)).willReturn(
-                mock(ChatMessageResponse.class));
+            given(memberRedisService.getProfileImage(1L)).willReturn("profile.png");
 
-            chatMessageService.editMessage(10L, new ChatMessageEditRequest(200L, "", IMAGE, null),
-                "testUser");
+            chatMessageService.editMessage(10L,
+                    new ChatMessageEditRequest(200L, "", IMAGE, null), memberDetails);
 
             then(chatMessageSearchRepository).should(never()).findById(anyLong());
         }
@@ -356,18 +343,18 @@ class ChatMessageServiceTest {
         void deleteMessage_textMessage_success() {
             given(textMessage.getId()).willReturn(100L);
             given(textMessage.getSender()).willReturn(sender);
+            given(textMessage.getChatRoom()).willReturn(chatRoom);
+            given(chatRoom.getId()).willReturn(10L);
             given(textMessage.getType()).willReturn(TEXT);
-            given(sender.getUsername()).willReturn("testUser");
+            given(sender.getId()).willReturn(1L);
+            given(memberDetails.getId()).willReturn(1L);
 
-            given(memberService.getMemberByUsername("testUser")).willReturn(sender);
             given(chatMessageRepository.findById(100L)).willReturn(Optional.of(textMessage));
-
             ChatMessageSearch searchEntity = mock(ChatMessageSearch.class);
             given(chatMessageSearchRepository.findById(100L)).willReturn(Optional.of(searchEntity));
-            given(messageMapper.toResponse(textMessage)).willReturn(
-                mock(ChatMessageResponse.class));
+            given(memberRedisService.getProfileImage(1L)).willReturn("profile.png");
 
-            chatMessageService.deleteMessage(10L, 100L, "testUser");
+            chatMessageService.deleteMessage(10L, 100L, memberDetails);
 
             then(textMessage).should().delete();
             then(searchEntity).should().deleteContent();
@@ -376,41 +363,42 @@ class ChatMessageServiceTest {
         @Test
         @DisplayName("존재하지 않는 메시지 삭제 시 예외를 던진다")
         void deleteMessage_notFound_throwsException() {
-            given(memberService.getMemberByUsername("testUser")).willReturn(sender);
             given(chatMessageRepository.findById(999L)).willReturn(Optional.empty());
 
-            assertThatThrownBy(() -> chatMessageService.deleteMessage(10L, 999L, "testUser"))
-                .isInstanceOf(ChatMessageException.class);
+            assertThatThrownBy(() -> chatMessageService.deleteMessage(10L, 999L, memberDetails))
+                    .isInstanceOf(ChatMessageException.class);
         }
 
         @Test
         @DisplayName("본인이 아닌 사람이 메시지를 삭제하면 FORBIDDEN 예외를 던진다")
         void deleteMessage_notOwner_throwsAuthException() {
-
             Member otherSender = mock(Member.class);
-            given(otherSender.getUsername()).willReturn("anotherUser");
+            given(otherSender.getId()).willReturn(99L);
             given(imageMessage.getSender()).willReturn(otherSender);
+            given(imageMessage.getChatRoom()).willReturn(chatRoom);
+            given(chatRoom.getId()).willReturn(10L);
+            given(memberDetails.getId()).willReturn(1L);
 
-            given(memberService.getMemberByUsername("testUser")).willReturn(sender);
             given(chatMessageRepository.findById(200L)).willReturn(Optional.of(imageMessage));
 
-            assertThatThrownBy(() -> chatMessageService.deleteMessage(10L, 200L, "testUser"))
-                .isInstanceOf(AuthException.class);
+            assertThatThrownBy(() -> chatMessageService.deleteMessage(10L, 200L, memberDetails))
+                    .isInstanceOf(AuthException.class);
         }
 
         @Test
         @DisplayName("IMAGE 메시지 삭제 시 검색 엔티티를 건드리지 않는다")
         void deleteMessage_imageMessage_noSearchDelete() {
             given(imageMessage.getSender()).willReturn(sender);
+            given(imageMessage.getChatRoom()).willReturn(chatRoom);
+            given(chatRoom.getId()).willReturn(10L);
             given(imageMessage.getType()).willReturn(IMAGE);
-            given(sender.getUsername()).willReturn("testUser");
+            given(sender.getId()).willReturn(1L);
+            given(memberDetails.getId()).willReturn(1L);
 
-            given(memberService.getMemberByUsername("testUser")).willReturn(sender);
             given(chatMessageRepository.findById(200L)).willReturn(Optional.of(imageMessage));
-            given(messageMapper.toResponse(imageMessage)).willReturn(
-                mock(ChatMessageResponse.class));
+            given(memberRedisService.getProfileImage(1L)).willReturn("profile.png");
 
-            chatMessageService.deleteMessage(10L, 200L, "testUser");
+            chatMessageService.deleteMessage(10L, 200L, memberDetails);
 
             then(imageMessage).should().delete();
             then(chatMessageSearchRepository).should(never()).findById(anyLong());
@@ -424,48 +412,50 @@ class ChatMessageServiceTest {
         @Test
         @DisplayName("cursor가 null이면 최신 메시지부터 조회한다")
         void getMessages_noCursor_fetchFromLatest() {
-            given(chatMessageRepository.findByChatRoom_IdOrderByIdDesc(eq(10L),
-                any(PageRequest.class)))
-                .willReturn(List.of(textMessage));
-            given(messageMapper.toResponse(textMessage)).willReturn(
-                mock(ChatMessageResponse.class));
+            given(chatRoomRepository.findById(10L)).willReturn(Optional.of(chatRoom));
+            willDoNothing().given(chatRoomParticipantService).validateParticipant(1L, 10L);
+            given(chatMessageRepository.findByChatRoom_IdOrderByIdDesc(eq(10L), any(PageRequest.class)))
+                    .willReturn(List.of(textMessage));
+            given(messageMapper.toResponse(textMessage)).willReturn(mock(ChatMessageResponse.class));
 
             ChatScrollResponse result = chatMessageService.getMessagesByRoomId(1L, 10L, null, 10);
 
             assertThat(result.getMessages()).hasSize(1);
             assertThat(result.getNextCursor()).isNull();
             then(chatMessageRepository).should(never())
-                .findByChatRoom_IdAndIdLessThanOrderByIdDesc(anyLong(), anyLong(), any());
+                    .findByChatRoom_IdAndIdLessThanOrderByIdDesc(anyLong(), anyLong(), any());
         }
 
         @Test
         @DisplayName("cursor가 있으면 해당 cursor 이전 메시지를 조회한다")
         void getMessages_withCursor_fetchBeforeCursor() {
+            given(chatRoomRepository.findById(10L)).willReturn(Optional.of(chatRoom));
+            willDoNothing().given(chatRoomParticipantService).validateParticipant(1L, 10L);
             given(chatMessageRepository.findByChatRoom_IdAndIdLessThanOrderByIdDesc(
-                eq(10L), eq(50L), any(PageRequest.class)))
-                .willReturn(List.of(textMessage));
-            given(messageMapper.toResponse(textMessage)).willReturn(
-                mock(ChatMessageResponse.class));
+                    eq(10L), eq(50L), any(PageRequest.class)))
+                    .willReturn(List.of(textMessage));
+            given(messageMapper.toResponse(textMessage)).willReturn(mock(ChatMessageResponse.class));
 
             ChatScrollResponse result = chatMessageService.getMessagesByRoomId(1L, 10L, 50L, 10);
 
             assertThat(result.getMessages()).hasSize(1);
             then(chatMessageRepository).should(never())
-                .findByChatRoom_IdOrderByIdDesc(anyLong(), any());
+                    .findByChatRoom_IdOrderByIdDesc(anyLong(), any());
         }
 
         @Test
         @DisplayName("size+1개가 조회되면 nextCursor를 반환한다")
         void getMessages_hasMore_returnsNextCursor() {
+            given(chatRoomRepository.findById(10L)).willReturn(Optional.of(chatRoom));
+            willDoNothing().given(chatRoomParticipantService).validateParticipant(1L, 10L);
 
             ChatMessage msg1 = mock(ChatMessage.class);
             ChatMessage msg2 = mock(ChatMessage.class);
             ChatMessage msg3 = mock(ChatMessage.class);
             given(msg3.getId()).willReturn(30L);
 
-            given(chatMessageRepository.findByChatRoom_IdOrderByIdDesc(eq(10L),
-                any(PageRequest.class)))
-                .willReturn(List.of(msg1, msg2, msg3));
+            given(chatMessageRepository.findByChatRoom_IdOrderByIdDesc(eq(10L), any(PageRequest.class)))
+                    .willReturn(List.of(msg1, msg2, msg3));
             given(messageMapper.toResponse(any())).willReturn(mock(ChatMessageResponse.class));
 
             ChatScrollResponse result = chatMessageService.getMessagesByRoomId(1L, 10L, null, 2);

--- a/backend/src/test/java/project/backend/domain/chat/chatroom/app/ChatRoomAlarmServiceTest.java
+++ b/backend/src/test/java/project/backend/domain/chat/chatroom/app/ChatRoomAlarmServiceTest.java
@@ -1,0 +1,72 @@
+package project.backend.domain.chat.chatroom.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import project.backend.domain.chat.chatroom.dao.ChatRoomAlarmRepository;
+import project.backend.domain.chat.chatroom.entity.ChatRoomAlarm;
+import project.backend.global.exception.ex.ChatRoomException;
+
+@ExtendWith(MockitoExtension.class)
+class ChatRoomAlarmServiceTest {
+
+    @InjectMocks
+    private ChatRoomAlarmService chatRoomAlarmService;
+
+    @Mock private ChatRoomAlarmRepository chatRoomAlarmRepository;
+
+    @Nested
+    @DisplayName("toggleAlarm() - 알람 토글")
+    class ToggleAlarm {
+
+        @Test
+        @DisplayName("알람이 켜져 있으면 끄고 false를 반환한다")
+        void toggle_enabled_returnsDisabled() {
+            ChatRoomAlarm alarm = mock(ChatRoomAlarm.class);
+            given(alarm.isEnabled()).willReturn(false);
+            given(chatRoomAlarmRepository.findByIdMemberIdAndIdRoomId(1L, 10L))
+                    .willReturn(Optional.of(alarm));
+
+            boolean result = chatRoomAlarmService.toggleAlarm(10L, 1L);
+
+            assertThat(result).isFalse();
+            then(alarm).should().setEnabled(true);
+        }
+
+        @Test
+        @DisplayName("알람이 꺼져 있으면 켜고 true를 반환한다")
+        void toggle_disabled_returnsEnabled() {
+            ChatRoomAlarm alarm = mock(ChatRoomAlarm.class);
+            given(alarm.isEnabled()).willReturn(true);
+            given(chatRoomAlarmRepository.findByIdMemberIdAndIdRoomId(1L, 10L))
+                    .willReturn(Optional.of(alarm));
+
+            boolean result = chatRoomAlarmService.toggleAlarm(10L, 1L);
+
+            assertThat(result).isTrue();
+        }
+
+        @Test
+        @DisplayName("알람 정보가 없으면 예외를 던진다")
+        void toggle_notFound_throwsException() {
+            given(chatRoomAlarmRepository.findByIdMemberIdAndIdRoomId(1L, 10L))
+                    .willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> chatRoomAlarmService.toggleAlarm(10L, 1L))
+                    .isInstanceOf(ChatRoomException.class);
+        }
+    }
+}

--- a/backend/src/test/java/project/backend/domain/chat/chatroom/app/ChatRoomParticipantServiceTest.java
+++ b/backend/src/test/java/project/backend/domain/chat/chatroom/app/ChatRoomParticipantServiceTest.java
@@ -1,0 +1,164 @@
+package project.backend.domain.chat.chatroom.app;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+import project.backend.domain.chat.chatroom.dao.ChatParticipantRepository;
+import project.backend.domain.chat.chatroom.dto.event.LeaveChatRoomEvent;
+import project.backend.domain.chat.chatroom.entity.ChatParticipant;
+import project.backend.domain.chat.chatroom.entity.ChatRoom;
+import project.backend.domain.member.entity.Member;
+import project.backend.global.exception.ex.ChatRoomException;
+
+@ExtendWith(MockitoExtension.class)
+class ChatRoomParticipantServiceTest {
+
+    @InjectMocks
+    private ChatRoomParticipantService chatRoomParticipantService;
+
+    @Mock private ChatParticipantRepository chatParticipantRepository;
+    @Mock private ApplicationEventPublisher eventPublisher;
+
+    private Member owner;
+    private ChatRoom chatRoom;
+    private ChatParticipant ownerParticipant;
+    private ChatParticipant memberParticipant;
+
+    @BeforeEach
+    void setUp() {
+        owner = mock(Member.class);
+        chatRoom = mock(ChatRoom.class);
+        ownerParticipant = mock(ChatParticipant.class);
+        memberParticipant = mock(ChatParticipant.class);
+    }
+
+    @Nested
+    @DisplayName("handleParticipantJoin() - 참가 처리")
+    class HandleParticipantJoin {
+
+        @Test
+        @DisplayName("새 멤버는 채팅방에 추가된다")
+        void join_newMember_addsParticipant() {
+            given(chatRoom.getId()).willReturn(10L);
+            Member newMember = mock(Member.class);
+            given(newMember.getId()).willReturn(2L);
+            given(chatParticipantRepository.findByChatRoomIdAndParticipantId(10L, 2L))
+                    .willReturn(Optional.empty());
+
+            chatRoomParticipantService.handleParticipantJoin(chatRoom, newMember);
+
+            then(chatRoom).should().addParticipant(any(ChatParticipant.class));
+        }
+
+        @Test
+        @DisplayName("이미 활성 참가자가 참가하면 예외를 던진다")
+        void join_alreadyActive_throwsException() {
+            given(chatRoom.getId()).willReturn(10L);
+            given(memberParticipant.isActive()).willReturn(true);
+            Member existingMember = mock(Member.class);
+            given(existingMember.getId()).willReturn(2L);
+            given(chatParticipantRepository.findByChatRoomIdAndParticipantId(10L, 2L))
+                    .willReturn(Optional.of(memberParticipant));
+
+            assertThatThrownBy(() -> chatRoomParticipantService.handleParticipantJoin(chatRoom, existingMember))
+                    .isInstanceOf(ChatRoomException.class);
+        }
+
+        @Test
+        @DisplayName("비활성 참가자가 참가하면 rejoin이 호출된다")
+        void join_inactiveMember_callsRejoin() {
+            given(chatRoom.getId()).willReturn(10L);
+            Member rejoiner = mock(Member.class);
+            given(rejoiner.getId()).willReturn(2L);
+            ChatParticipant inactiveParticipant = mock(ChatParticipant.class);
+            given(inactiveParticipant.isActive()).willReturn(false);
+            given(chatParticipantRepository.findByChatRoomIdAndParticipantId(10L, 2L))
+                    .willReturn(Optional.of(inactiveParticipant));
+
+            chatRoomParticipantService.handleParticipantJoin(chatRoom, rejoiner);
+
+            then(inactiveParticipant).should().rejoin();
+            then(chatRoom).should(never()).addParticipant(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("leaveChatRoom() - 채팅방 나가기")
+    class LeaveChatRoom {
+
+        @Test
+        @DisplayName("일반 참가자는 정상적으로 나간다")
+        void leave_normalMember_success() {
+            given(memberParticipant.isOwner()).willReturn(false);
+            given(chatParticipantRepository.findByChatRoomIdAndParticipantIdAndIsActiveTrue(10L, 2L))
+                    .willReturn(Optional.of(memberParticipant));
+
+            chatRoomParticipantService.leaveChatRoom(10L, 2L, "nick");
+
+            then(memberParticipant).should().leave();
+            then(eventPublisher).should().publishEvent(any(LeaveChatRoomEvent.class));
+        }
+
+        @Test
+        @DisplayName("방장이 나가려 하면 예외를 던진다")
+        void leave_owner_throwsException() {
+            given(ownerParticipant.isOwner()).willReturn(true);
+            given(chatParticipantRepository.findByChatRoomIdAndParticipantIdAndIsActiveTrue(10L, 1L))
+                    .willReturn(Optional.of(ownerParticipant));
+
+            assertThatThrownBy(() -> chatRoomParticipantService.leaveChatRoom(10L, 1L, "nick"))
+                    .isInstanceOf(ChatRoomException.class);
+            then(ownerParticipant).should(never()).leave();
+        }
+
+        @Test
+        @DisplayName("참가자가 아니면 예외를 던진다")
+        void leave_notParticipant_throwsException() {
+            given(chatParticipantRepository.findByChatRoomIdAndParticipantIdAndIsActiveTrue(10L, 99L))
+                    .willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> chatRoomParticipantService.leaveChatRoom(10L, 99L, "nick"))
+                    .isInstanceOf(ChatRoomException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("validateParticipant() - 참가자 검증")
+    class ValidateParticipant {
+
+        @Test
+        @DisplayName("활성 참가자이면 예외 없이 통과한다")
+        void validate_active_noException() {
+            given(chatParticipantRepository.existsByParticipantIdAndChatRoomIdAndIsActiveTrue(1L, 10L))
+                    .willReturn(true);
+
+            chatRoomParticipantService.validateParticipant(1L, 10L);
+        }
+
+        @Test
+        @DisplayName("참가자가 아니면 예외를 던진다")
+        void validate_notMember_throwsException() {
+            given(chatParticipantRepository.existsByParticipantIdAndChatRoomIdAndIsActiveTrue(99L, 10L))
+                    .willReturn(false);
+
+            assertThatThrownBy(() -> chatRoomParticipantService.validateParticipant(99L, 10L))
+                    .isInstanceOf(ChatRoomException.class);
+        }
+    }
+}

--- a/backend/src/test/java/project/backend/domain/chat/chatroom/app/ChatRoomRedisServiceTest.java
+++ b/backend/src/test/java/project/backend/domain/chat/chatroom/app/ChatRoomRedisServiceTest.java
@@ -62,11 +62,11 @@ class ChatRoomRedisServiceTest {
             given(chatRoomRedisRepository.handleMessageDelivery(10L)).willReturn(-1L);
             given(chatRoomRepository.findById(10L)).willReturn(Optional.of(chatRoom));
             given(chatRoom.getLastSequence()).willReturn(3L);
+            given(chatRoomRedisRepository.recoverAndIncr(10L, 3L)).willReturn(4L);
 
             Long result = chatRoomRedisService.handleMessageDelivery(10L);
 
             assertThat(result).isEqualTo(4L);
-            then(chatRoomRedisRepository).should().setSequence(10L, 4L);
         }
 
         @Test
@@ -75,11 +75,11 @@ class ChatRoomRedisServiceTest {
             given(chatRoomRedisRepository.handleMessageDelivery(10L)).willReturn(-1L);
             given(chatRoomRepository.findById(10L)).willReturn(Optional.of(chatRoom));
             given(chatRoom.getLastSequence()).willReturn(null);
+            given(chatRoomRedisRepository.recoverAndIncr(10L, 0L)).willReturn(1L);
 
             Long result = chatRoomRedisService.handleMessageDelivery(10L);
 
             assertThat(result).isEqualTo(1L);
-            then(chatRoomRedisRepository).should().setSequence(10L, 1L);
         }
 
         @Test

--- a/backend/src/test/java/project/backend/domain/chat/chatroom/app/ChatRoomSequenceServiceTest.java
+++ b/backend/src/test/java/project/backend/domain/chat/chatroom/app/ChatRoomSequenceServiceTest.java
@@ -1,0 +1,99 @@
+package project.backend.domain.chat.chatroom.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import project.backend.domain.chat.chatroom.dao.ChatParticipantRepository;
+import project.backend.domain.chat.chatroom.dao.ChatRoomRepository;
+import project.backend.domain.chat.chatroom.entity.ChatRoom;
+
+@ExtendWith(MockitoExtension.class)
+class ChatRoomSequenceServiceTest {
+
+    @InjectMocks
+    private ChatRoomSequenceService chatRoomSequenceService;
+
+    @Mock private ChatRoomRepository chatRoomRepository;
+    @Mock private ChatParticipantRepository chatParticipantRepository;
+    @Mock private ChatRoomCacheService chatRoomCacheService;
+    @Mock private ChatRoomRedisService chatRoomRedisService;
+
+    @Nested
+    @DisplayName("syncSequencesToDb() - Redis → DB 시퀀스 동기화")
+    class SyncSequencesToDb {
+
+        @Test
+        @DisplayName("업데이트된 방이 없으면 조기 반환한다")
+        void sync_empty_earlyReturn() {
+            given(chatRoomRedisService.getAndClearUpdatedRooms()).willReturn(Collections.emptySet());
+
+            chatRoomSequenceService.syncSequencesToDb();
+
+            then(chatRoomRepository).should(never()).findAllById(any());
+        }
+
+        @Test
+        @DisplayName("Redis 시퀀스가 DB보다 크면 DB를 업데이트한다")
+        void sync_redisHigher_updatesDb() {
+            ChatRoom chatRoom = mock(ChatRoom.class);
+            given(chatRoom.getId()).willReturn(10L);
+            given(chatRoom.getLastSequence()).willReturn(3L);
+
+            given(chatRoomRedisService.getAndClearUpdatedRooms()).willReturn(Set.of("10"));
+            given(chatRoomRepository.findAllById(List.of(10L))).willReturn(List.of(chatRoom));
+            given(chatRoomRedisService.getSequences(List.of(10L))).willReturn(List.of(7L));
+
+            chatRoomSequenceService.syncSequencesToDb();
+
+            then(chatRoom).should().updateLastSequence(7L);
+        }
+
+        @Test
+        @DisplayName("Redis 시퀀스가 DB보다 작거나 같으면 업데이트하지 않는다")
+        void sync_redisNotHigher_noUpdate() {
+            ChatRoom chatRoom = mock(ChatRoom.class);
+            given(chatRoom.getId()).willReturn(10L);
+            given(chatRoom.getLastSequence()).willReturn(10L);
+
+            given(chatRoomRedisService.getAndClearUpdatedRooms()).willReturn(Set.of("10"));
+            given(chatRoomRepository.findAllById(List.of(10L))).willReturn(List.of(chatRoom));
+            given(chatRoomRedisService.getSequences(List.of(10L))).willReturn(List.of(5L));
+
+            chatRoomSequenceService.syncSequencesToDb();
+
+            then(chatRoom).should(never()).updateLastSequence(anyLong());
+        }
+    }
+
+    @Nested
+    @DisplayName("getLatestSequence() - 최신 시퀀스 조회")
+    class GetLatestSequence {
+
+        @Test
+        @DisplayName("Redis에 시퀀스가 있으면 Redis 값을 반환한다")
+        void getLatest_fromRedis_returnsRedisValue() {
+            given(chatRoomCacheService.getLatestSequence(10L)).willReturn(5L);
+
+            Long result = chatRoomSequenceService.getLatestSequence(10L);
+
+            assertThat(result).isEqualTo(5L);
+        }
+    }
+}

--- a/backend/src/test/java/project/backend/domain/chat/chatroom/app/ChatRoomServiceTest.java
+++ b/backend/src/test/java/project/backend/domain/chat/chatroom/app/ChatRoomServiceTest.java
@@ -3,23 +3,17 @@ package project.backend.domain.chat.chatroom.app;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
-import static org.mockito.BDDMockito.willThrow;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.*;
 
-import io.micrometer.core.instrument.Counter;
-import io.micrometer.core.instrument.MeterRegistry;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -29,34 +23,25 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.test.util.ReflectionTestUtils;
-import project.backend.domain.chat.chatmessage.dao.ChatMessageRepository;
+
+import project.backend.domain.chat.chatmessage.app.ChatMessageService;
 import project.backend.domain.chat.chatmessage.entity.ChatMessage;
-import project.backend.domain.chat.chatmessage.mapper.ChatMessageMapper;
-import project.backend.domain.chat.chatroom.dao.ChatParticipantRepository;
-import project.backend.domain.chat.chatroom.dao.ChatRoomAlarmRepository;
 import project.backend.domain.chat.chatroom.dao.ChatRoomRepository;
 import project.backend.domain.chat.chatroom.dao.ChatRoomWithSequenceProjection;
+import project.backend.domain.chat.chatroom.dto.AllRoomsResponse;
 import project.backend.domain.chat.chatroom.dto.ChatRoomRequest;
 import project.backend.domain.chat.chatroom.dto.ChatRoomSimpleResponse;
-import project.backend.domain.chat.chatroom.dto.EntryRoomResponse;
 import project.backend.domain.chat.chatroom.dto.InviteJoinResponse;
-import project.backend.domain.chat.chatroom.dto.AllRoomsResponse;
 import project.backend.domain.chat.chatroom.dto.event.DeleteChatRoomEvent;
 import project.backend.domain.chat.chatroom.dto.event.JoinChatRoomEvent;
-import project.backend.domain.chat.chatroom.dto.event.LeaveChatRoomEvent;
 import project.backend.domain.chat.chatroom.entity.ChatParticipant;
 import project.backend.domain.chat.chatroom.entity.ChatRoom;
-import project.backend.domain.chat.chatroom.entity.ChatRoomAlarm;
 import project.backend.domain.chat.chatroom.mapper.ChatRoomMapper;
 import project.backend.domain.chat.github.app.GitMessageService;
 import project.backend.domain.community.dao.PostRepository;
 import project.backend.domain.member.app.MemberService;
 import project.backend.domain.member.entity.Member;
-import project.backend.global.exception.errorcode.ChatRoomErrorCode;
 import project.backend.global.exception.ex.ChatRoomException;
 
 @ExtendWith(MockitoExtension.class)
@@ -65,30 +50,17 @@ class ChatRoomServiceTest {
     @InjectMocks
     private ChatRoomService chatRoomService;
 
-    @Mock
-    private PostRepository postRepository;
-    @Mock
-    private ChatRoomRepository chatRoomRepository;
-    @Mock
-    private ChatMessageRepository chatMessageRepository;
-    @Mock
-    private ChatRoomAlarmRepository chatRoomAlarmRepository;
-    @Mock
-    private ChatParticipantRepository chatParticipantRepository;
-    @Mock
-    private ChatRoomMapper chatRoomMapper;
-    @Mock
-    private ChatMessageMapper chatMessageMapper;
-    @Mock
-    private MemberService memberService;
-    @Mock
-    private GitMessageService gitMessageService;
-    @Mock
-    private ChatRoomRedisService chatRoomRedisService;
-    @Mock
-    private ApplicationEventPublisher eventPublisher;
-    @Mock
-    private MeterRegistry meterRegistry;
+    @Mock private PostRepository postRepository;
+    @Mock private ChatRoomRepository chatRoomRepository;
+    @Mock private ChatRoomMapper chatRoomMapper;
+    @Mock private MemberService memberService;
+    @Mock private ChatMessageService chatMessageService;
+    @Mock private GitMessageService gitMessageService;
+    @Mock private ChatRoomCacheService chatRoomCacheService;
+    @Mock private ChatRoomAlarmService chatRoomAlarmService;
+    @Mock private ChatRoomSequenceService chatRoomSequenceService;
+    @Mock private ChatRoomParticipantService chatRoomParticipantService;
+    @Mock private ApplicationEventPublisher eventPublisher;
 
     private Member owner;
     private ChatRoom chatRoom;
@@ -98,24 +70,10 @@ class ChatRoomServiceTest {
     @BeforeEach
     void setUp() {
         ReflectionTestUtils.setField(chatRoomService, "githubUsername", "github-bot");
-
         owner = mock(Member.class);
-        given(owner.getId()).willReturn(1L);
-        given(owner.getNickname()).willReturn("ownerNick");
-
         chatRoom = mock(ChatRoom.class);
-        given(chatRoom.getId()).willReturn(10L);
-        given(chatRoom.getName()).willReturn("테스트 방");
-        given(chatRoom.getInviteCode()).willReturn("INVITE-CODE");
-
         ownerParticipant = mock(ChatParticipant.class);
-        given(ownerParticipant.isOwner()).willReturn(true);
-        given(ownerParticipant.isActive()).willReturn(true);
-        given(ownerParticipant.getParticipant()).willReturn(owner);
-
         memberParticipant = mock(ChatParticipant.class);
-        given(memberParticipant.isOwner()).willReturn(false);
-        given(memberParticipant.isActive()).willReturn(true);
     }
 
     @Nested
@@ -125,52 +83,39 @@ class ChatRoomServiceTest {
         @Test
         @DisplayName("레포지토리 URL 없이 채팅방을 생성하면 웹훅 등록 없이 방이 생성된다")
         void createChatRoom_noRepository_success() {
-            // given
             ChatRoomRequest request = mock(ChatRoomRequest.class);
             given(request.getRepositoryUrl()).willReturn("");
-
             given(memberService.getMemberById(1L)).willReturn(owner);
             given(chatRoomMapper.toEntity(request)).willReturn(chatRoom);
             given(chatRoomRepository.save(chatRoom)).willReturn(chatRoom);
-
             ChatRoomSimpleResponse expected = mock(ChatRoomSimpleResponse.class);
             given(chatRoomMapper.toSimpleResponse(chatRoom, owner)).willReturn(expected);
 
-            ChatRoomAlarm alarm = mock(ChatRoomAlarm.class);
-            given(chatRoomAlarmRepository.save(any())).willReturn(alarm);
-
-            // when
             ChatRoomSimpleResponse result = chatRoomService.createChatRoom(request, 1L);
 
-            // then
             assertThat(result).isEqualTo(expected);
-            then(gitMessageService).should(never())
-                .registerWebhook(anyString(), anyLong(), anyLong());
+            then(gitMessageService).should(never()).registerWebhook(anyString(), anyLong(), anyLong());
         }
 
         @Test
         @DisplayName("레포지토리 URL이 있으면 웹훅 등록과 깃허브봇 참가가 실행된다")
         void createChatRoom_withRepository_registersWebhookAndBot() {
-            // given
+            given(chatRoom.getId()).willReturn(10L);
+            given(owner.getId()).willReturn(1L);
+
             ChatRoomRequest request = mock(ChatRoomRequest.class);
             given(request.getRepositoryUrl()).willReturn("https://github.com/test/repo");
-
             Member githubBot = mock(Member.class);
             given(memberService.getMemberById(1L)).willReturn(owner);
             given(memberService.getMemberByUsername("github-bot")).willReturn(githubBot);
             given(chatRoomMapper.toEntity(request)).willReturn(chatRoom);
             given(chatRoomRepository.save(chatRoom)).willReturn(chatRoom);
-            given(chatRoomMapper.toSimpleResponse(chatRoom, owner)).willReturn(
-                mock(ChatRoomSimpleResponse.class));
-            given(chatRoomAlarmRepository.save(any())).willReturn(mock(ChatRoomAlarm.class));
+            given(chatRoomMapper.toSimpleResponse(chatRoom, owner)).willReturn(mock(ChatRoomSimpleResponse.class));
 
-            // when
             chatRoomService.createChatRoom(request, 1L);
 
-            // then
-            then(gitMessageService).should()
-                .registerWebhook("https://github.com/test/repo", 10L, 1L);
-            then(chatRoom).should().addParticipant(any(ChatParticipant.class));
+            then(gitMessageService).should().registerWebhook("https://github.com/test/repo", 10L, 1L);
+            then(chatRoom).should(times(2)).addParticipant(any(ChatParticipant.class));
         }
     }
 
@@ -181,100 +126,36 @@ class ChatRoomServiceTest {
         @Test
         @DisplayName("새 멤버가 정상적으로 채팅방에 참가한다")
         void joinChatRoom_newMember_success() {
-            // given
+            given(chatRoom.getId()).willReturn(10L);
+            given(chatRoom.getInviteCode()).willReturn("INVITE-CODE");
+            given(chatRoom.getName()).willReturn("테스트 방");
+
             Member joiner = mock(Member.class);
-            given(joiner.getId()).willReturn(2L);
             given(joiner.getNickname()).willReturn("joinerNick");
 
-            given(chatRoomRepository.findByInviteCode("INVITE-CODE")).willReturn(
-                Optional.of(chatRoom));
+            given(chatRoomRepository.findByInviteCode("INVITE-CODE")).willReturn(Optional.of(chatRoom));
             given(memberService.getMemberById(2L)).willReturn(joiner);
-            given(chatParticipantRepository.findByChatRoomIdAndParticipantId(10L, 2L))
-                .willReturn(Optional.empty());
-            given(chatRoomRedisService.handleMessageDelivery(10L)).willReturn(1L);
-            given(chatRoomAlarmRepository.save(any())).willReturn(mock(ChatRoomAlarm.class));
+            given(chatRoomCacheService.handleMessageDelivery(10L)).willReturn(1L);
 
             ChatMessage joinMessage = mock(ChatMessage.class);
             given(joinMessage.getId()).willReturn(500L);
             given(joinMessage.getSendAt()).willReturn(java.time.LocalDateTime.now());
-            given(chatMessageMapper.toEntityWithJoinEvent(eq(chatRoom), eq(joiner), any(), eq(1L)))
-                .willReturn(joinMessage);
-            given(chatMessageRepository.save(joinMessage)).willReturn(joinMessage);
+            given(chatMessageService.saveJoinEvent(chatRoom, joiner, 1L)).willReturn(joinMessage);
 
-            // when
             InviteJoinResponse result = chatRoomService.joinChatRoom("INVITE-CODE", 2L);
 
-            // then
             assertThat(result.getId()).isEqualTo(10L);
             assertThat(result.getInviteCode()).isEqualTo("INVITE-CODE");
             then(eventPublisher).should().publishEvent(any(JoinChatRoomEvent.class));
         }
 
         @Test
-        @DisplayName("이미 활성 참가자가 다시 참가하면 ALREADY_PARTICIPANT 예외를 던진다")
-        void joinChatRoom_alreadyActive_throwsException() {
-            // given
-            Member joiner = mock(Member.class);
-            given(joiner.getId()).willReturn(2L);
-
-            given(chatRoomRepository.findByInviteCode("INVITE-CODE")).willReturn(
-                Optional.of(chatRoom));
-            given(memberService.getMemberById(2L)).willReturn(joiner);
-
-            ChatParticipant activeParticipant = mock(ChatParticipant.class);
-            given(activeParticipant.isActive()).willReturn(true);
-            given(chatParticipantRepository.findByChatRoomIdAndParticipantId(10L, 2L))
-                .willReturn(Optional.of(activeParticipant));
-
-            // when & then
-            assertThatThrownBy(() -> chatRoomService.joinChatRoom("INVITE-CODE", 2L))
-                .isInstanceOf(ChatRoomException.class);
-        }
-
-        @Test
-        @DisplayName("비활성 참가자가 재참가하면 rejoin()이 호출된다")
-        void joinChatRoom_inactiveMember_callsRejoin() {
-            // given
-            Member rejoiner = mock(Member.class);
-            given(rejoiner.getId()).willReturn(2L);
-            given(rejoiner.getNickname()).willReturn("rejoinerNick");
-
-            ChatParticipant inactiveParticipant = mock(ChatParticipant.class);
-            given(inactiveParticipant.isActive()).willReturn(false);
-
-            given(chatRoomRepository.findByInviteCode("INVITE-CODE")).willReturn(
-                Optional.of(chatRoom));
-            given(memberService.getMemberById(2L)).willReturn(rejoiner);
-            given(chatParticipantRepository.findByChatRoomIdAndParticipantId(10L, 2L))
-                .willReturn(Optional.of(inactiveParticipant));
-            given(chatRoomRedisService.handleMessageDelivery(10L)).willReturn(2L);
-            given(chatRoomAlarmRepository.save(any())).willReturn(mock(ChatRoomAlarm.class));
-
-            ChatMessage joinMessage = mock(ChatMessage.class);
-            given(joinMessage.getId()).willReturn(501L);
-            given(joinMessage.getSendAt()).willReturn(java.time.LocalDateTime.now());
-            given(
-                chatMessageMapper.toEntityWithJoinEvent(eq(chatRoom), eq(rejoiner), any(), eq(2L)))
-                .willReturn(joinMessage);
-            given(chatMessageRepository.save(joinMessage)).willReturn(joinMessage);
-
-            // when
-            chatRoomService.joinChatRoom("INVITE-CODE", 2L);
-
-            // then
-            then(inactiveParticipant).should().rejoin();
-            then(chatRoom).should(never()).addParticipant(any());
-        }
-
-        @Test
         @DisplayName("존재하지 않는 초대 코드로 참가하면 예외를 던진다")
         void joinChatRoom_invalidCode_throwsException() {
-            // given
             given(chatRoomRepository.findByInviteCode("WRONG-CODE")).willReturn(Optional.empty());
 
-            // when & then
             assertThatThrownBy(() -> chatRoomService.joinChatRoom("WRONG-CODE", 2L))
-                .isInstanceOf(ChatRoomException.class);
+                    .isInstanceOf(ChatRoomException.class);
         }
     }
 
@@ -285,81 +166,34 @@ class ChatRoomServiceTest {
         @Test
         @DisplayName("일반 참가자는 채팅방을 정상적으로 나간다")
         void leaveChatRoom_normalMember_success() {
-            // given
             Member leavingMember = mock(Member.class);
             given(leavingMember.getNickname()).willReturn("leaverNick");
-
-            given(
-                chatParticipantRepository.findByChatRoomIdAndParticipantIdAndIsActiveTrue(10L, 2L))
-                .willReturn(Optional.of(memberParticipant));
             given(memberService.getMemberById(2L)).willReturn(leavingMember);
+            given(chatRoomParticipantService.findTopRecentActiveRoom(2L)).willReturn(Optional.empty());
 
-            // findTopByParticipantId... → 가장 최근 활성 방 없음
-            given(chatParticipantRepository.findTopByParticipantIdAndIsActiveTrueOrderByJoinAtDesc(
-                2L))
-                .willReturn(Optional.empty());
-
-            // when
             chatRoomService.leaveChatRoom(10L, 2L);
 
-            // then
-            then(memberParticipant).should().leave();
-            then(eventPublisher).should().publishEvent(any(LeaveChatRoomEvent.class));
+            then(chatRoomParticipantService).should().leaveChatRoom(10L, 2L, "leaverNick");
             then(leavingMember).should().setRecentRoomId(null);
         }
 
         @Test
-        @DisplayName("방 나가기 후 남은 활성 방이 있으면 recentRoomId를 그 방으로 업데이트한다")
+        @DisplayName("방 나가기 후 남은 활성 방이 있으면 recentRoomId를 업데이트한다")
         void leaveChatRoom_hasOtherRoom_updatesRecentRoom() {
-            // given
             Member leavingMember = mock(Member.class);
             given(leavingMember.getNickname()).willReturn("leaverNick");
+            given(memberService.getMemberById(2L)).willReturn(leavingMember);
 
             ChatParticipant otherRoomParticipant = mock(ChatParticipant.class);
             ChatRoom otherRoom = mock(ChatRoom.class);
             given(otherRoom.getId()).willReturn(20L);
             given(otherRoomParticipant.getChatRoom()).willReturn(otherRoom);
+            given(chatRoomParticipantService.findTopRecentActiveRoom(2L))
+                    .willReturn(Optional.of(otherRoomParticipant));
 
-            given(
-                chatParticipantRepository.findByChatRoomIdAndParticipantIdAndIsActiveTrue(10L, 2L))
-                .willReturn(Optional.of(memberParticipant));
-            given(memberService.getMemberById(2L)).willReturn(leavingMember);
-            given(chatParticipantRepository.findTopByParticipantIdAndIsActiveTrueOrderByJoinAtDesc(
-                2L))
-                .willReturn(Optional.of(otherRoomParticipant));
-
-            // when
             chatRoomService.leaveChatRoom(10L, 2L);
 
-            // then
             then(leavingMember).should().setRecentRoomId(20L);
-        }
-
-        @Test
-        @DisplayName("방장이 채팅방을 나가려 하면 OWNER_CANNOT_LEAVE 예외를 던진다")
-        void leaveChatRoom_owner_throwsException() {
-            // given
-            given(
-                chatParticipantRepository.findByChatRoomIdAndParticipantIdAndIsActiveTrue(10L, 1L))
-                .willReturn(Optional.of(ownerParticipant));
-
-            // when & then
-            assertThatThrownBy(() -> chatRoomService.leaveChatRoom(10L, 1L))
-                .isInstanceOf(ChatRoomException.class);
-            then(memberParticipant).should(never()).leave();
-        }
-
-        @Test
-        @DisplayName("참가하지 않은 멤버가 나가기를 시도하면 예외를 던진다")
-        void leaveChatRoom_notParticipant_throwsException() {
-            // given
-            given(
-                chatParticipantRepository.findByChatRoomIdAndParticipantIdAndIsActiveTrue(10L, 99L))
-                .willReturn(Optional.empty());
-
-            // when & then
-            assertThatThrownBy(() -> chatRoomService.leaveChatRoom(10L, 99L))
-                .isInstanceOf(ChatRoomException.class);
         }
     }
 
@@ -370,179 +204,43 @@ class ChatRoomServiceTest {
         @Test
         @DisplayName("방장이 채팅방을 삭제하면 관련 데이터가 모두 삭제된다")
         void deleteChatRoom_owner_success() {
-            // given
-            given(chatRoomRepository.findById(10L)).willReturn(Optional.of(chatRoom));
-            given(
-                chatParticipantRepository.findByChatRoomIdAndParticipantIdAndIsActiveTrue(10L, 1L))
-                .willReturn(Optional.of(ownerParticipant));
+            given(ownerParticipant.isOwner()).willReturn(true);
 
-            // when
+            given(chatRoomRepository.findById(10L)).willReturn(Optional.of(chatRoom));
+            given(chatRoomParticipantService.findActiveParticipant(10L, 1L))
+                    .willReturn(Optional.of(ownerParticipant));
+
             chatRoomService.deleteChatRoom(10L, 1L);
 
-            // then
             then(gitMessageService).should().deleteWebhook(chatRoom, 1L);
             then(eventPublisher).should().publishEvent(any(DeleteChatRoomEvent.class));
-            then(chatParticipantRepository).should().deleteByChatRoom_Id(10L);
-            then(chatMessageRepository).should().deleteByChatRoom_Id(10L);
+            then(chatRoomParticipantService).should().deleteAllByRoomId(10L);
+            then(chatMessageService).should().deleteByRoomId(10L);
             then(postRepository).should().deleteByChatRoom_Id(10L);
             then(chatRoomRepository).should().delete(chatRoom);
         }
 
         @Test
-        @DisplayName("일반 멤버가 삭제를 시도하면 OWNER_PERMISSION_REQUIRED 예외를 던진다")
+        @DisplayName("일반 멤버가 삭제를 시도하면 예외를 던진다")
         void deleteChatRoom_notOwner_throwsException() {
-            // given
-            given(chatRoomRepository.findById(10L)).willReturn(Optional.of(chatRoom));
-            given(
-                chatParticipantRepository.findByChatRoomIdAndParticipantIdAndIsActiveTrue(10L, 2L))
-                .willReturn(Optional.of(memberParticipant));
+            given(memberParticipant.isOwner()).willReturn(false);
 
-            // when & then
+            given(chatRoomRepository.findById(10L)).willReturn(Optional.of(chatRoom));
+            given(chatRoomParticipantService.findActiveParticipant(10L, 2L))
+                    .willReturn(Optional.of(memberParticipant));
+
             assertThatThrownBy(() -> chatRoomService.deleteChatRoom(10L, 2L))
-                .isInstanceOf(ChatRoomException.class);
+                    .isInstanceOf(ChatRoomException.class);
             then(chatRoomRepository).should(never()).delete(any());
         }
 
         @Test
         @DisplayName("존재하지 않는 채팅방을 삭제하면 예외를 던진다")
         void deleteChatRoom_roomNotFound_throwsException() {
-            // given
             given(chatRoomRepository.findById(999L)).willReturn(Optional.empty());
 
-            // when & then
             assertThatThrownBy(() -> chatRoomService.deleteChatRoom(999L, 1L))
-                .isInstanceOf(ChatRoomException.class);
-        }
-    }
-
-    @Nested
-    @DisplayName("toggleAlarm() - 알람 토글")
-    class ToggleAlarm {
-
-        @Test
-        @DisplayName("알람이 켜져 있으면 끄고 false를 반환한다")
-        void toggleAlarm_enabled_returnsDisabled() {
-            // given
-            ChatRoomAlarm alarm = mock(ChatRoomAlarm.class);
-            given(alarm.isEnabled()).willReturn(false); // toggle 후 반환값
-            given(chatRoomAlarmRepository.findByIdMemberIdAndIdRoomId(1L, 10L))
-                .willReturn(Optional.of(alarm));
-
-            // when
-            boolean result = chatRoomService.toggleAlarm(10L, 1L);
-
-            // then
-            assertThat(result).isFalse();
-            then(alarm).should().setEnabled(true); // !false = true → setEnabled(true)
-        }
-
-        @Test
-        @DisplayName("알람이 꺼져 있으면 켜고 true를 반환한다")
-        void toggleAlarm_disabled_returnsEnabled() {
-            // given
-            ChatRoomAlarm alarm = mock(ChatRoomAlarm.class);
-            given(alarm.isEnabled()).willReturn(true);
-            given(chatRoomAlarmRepository.findByIdMemberIdAndIdRoomId(1L, 10L))
-                .willReturn(Optional.of(alarm));
-
-            // when
-            boolean result = chatRoomService.toggleAlarm(10L, 1L);
-
-            // then
-            assertThat(result).isTrue();
-        }
-
-        @Test
-        @DisplayName("알람 정보가 없으면 ALARM_NOT_FOUND 예외를 던진다")
-        void toggleAlarm_notFound_throwsException() {
-            // given
-            given(chatRoomAlarmRepository.findByIdMemberIdAndIdRoomId(1L, 10L))
-                .willReturn(Optional.empty());
-
-            // when & then
-            assertThatThrownBy(() -> chatRoomService.toggleAlarm(10L, 1L))
-                .isInstanceOf(ChatRoomException.class);
-        }
-    }
-
-    @Nested
-    @DisplayName("validateParticipant() - 참가자 검증")
-    class ValidateParticipant {
-
-        @Test
-        @DisplayName("활성 참가자이면 예외 없이 통과한다")
-        void validateParticipant_active_noException() {
-            // given
-            given(chatParticipantRepository.existsByParticipantIdAndChatRoomIdAndIsActiveTrue(1L,
-                10L))
-                .willReturn(true);
-
-            // when & then (no exception)
-            chatRoomService.validateParticipant(1L, 10L);
-        }
-
-        @Test
-        @DisplayName("참가자가 아니면 NOT_PARTICIPANT 예외를 던진다")
-        void validateParticipant_notMember_throwsException() {
-            // given
-            given(chatParticipantRepository.existsByParticipantIdAndChatRoomIdAndIsActiveTrue(99L,
-                10L))
-                .willReturn(false);
-
-            // when & then
-            assertThatThrownBy(() -> chatRoomService.validateParticipant(99L, 10L))
-                .isInstanceOf(ChatRoomException.class);
-        }
-    }
-
-    @Nested
-    @DisplayName("getLatestSequence() - 최신 시퀀스 조회")
-    class GetLatestSequence {
-
-        @Test
-        @DisplayName("Redis에 시퀀스가 있으면 Redis 값을 반환한다")
-        void getLatestSequence_fromRedis_returnsRedisValue() {
-            // given
-            given(chatRoomRedisService.getSequence(10L)).willReturn(5L);
-
-            // when
-            Long result = chatRoomService.getLatestSequence(10L);
-
-            // then
-            assertThat(result).isEqualTo(5L);
-            then(chatRoomRepository).should(never()).findById(anyLong());
-        }
-
-        @Test
-        @DisplayName("Redis 시퀀스가 0이면 DB에서 조회 후 Redis에 세팅하고 반환한다")
-        void getLatestSequence_redisZero_fallbackToDb() {
-            // given
-            given(chatRoomRedisService.getSequence(10L)).willReturn(0L);
-            given(chatRoom.getLastSequence()).willReturn(3L);
-            given(chatRoomRepository.findById(10L)).willReturn(Optional.of(chatRoom));
-
-            // when
-            Long result = chatRoomService.getLatestSequence(10L);
-
-            // then
-            assertThat(result).isEqualTo(3L);
-            then(chatRoomRedisService).should().setSequence(10L, 3L);
-        }
-
-        @Test
-        @DisplayName("Redis 장애 시 DB에서 시퀀스를 폴백으로 반환한다")
-        void getLatestSequence_redisDown_fallbackToDb() {
-            // given
-            given(chatRoomRedisService.getSequence(10L)).willThrow(
-                new RuntimeException("Redis down"));
-            given(chatRoom.getLastSequence()).willReturn(7L);
-            given(chatRoomRepository.findById(10L)).willReturn(Optional.of(chatRoom));
-
-            // when
-            Long result = chatRoomService.getLatestSequence(10L);
-
-            // then
-            assertThat(result).isEqualTo(7L);
+                    .isInstanceOf(ChatRoomException.class);
         }
     }
 
@@ -551,169 +249,39 @@ class ChatRoomServiceTest {
     class FindAllRoomsByMemberId {
 
         @Test
-        @DisplayName("정상적으로 채팅방 목록과 읽지 않은 메시지 수를 계산해 반환한다")
-        void findAllRooms_success_returnsWithUnreadCount() {
-            // given
+        @DisplayName("정상적으로 채팅방 목록과 안읽음 수를 반환한다")
+        void findAllRooms_success() {
             ChatRoomWithSequenceProjection projection = mock(ChatRoomWithSequenceProjection.class);
             given(projection.getChatRoomId()).willReturn(10L);
-            given(projection.getInviteCode()).willReturn("INVITE-CODE");
-            given(projection.getName()).willReturn("테스트 방");
-            given(projection.getLastReadSequence()).willReturn(3L);
-
             given(chatRoomRepository.findAllRoomsWithSequenceByParticipantId(1L))
-                .willReturn(List.of(projection));
-            given(chatRoomRedisService.getSortedRoomIds(List.of(10L))).willReturn(List.of(10L));
-            given(chatRoomAlarmRepository.findEnabledMap(1L, List.of(10L)))
-                .willReturn(Map.of(10L, true));
-            given(chatRoomRedisService.getSequences(List.of(10L))).willReturn(List.of(5L));
+                    .willReturn(List.of(projection));
+            given(chatRoomAlarmService.findAlarmEnabledMap(1L, List.of(10L)))
+                    .willReturn(Map.of(10L, true));
 
-            // when
+            AllRoomsResponse expected = mock(AllRoomsResponse.class);
+            given(chatRoomSequenceService.findAllRoomsWithUnread(any(), any(), any()))
+                    .willReturn(List.of(expected));
+
             List<AllRoomsResponse> result = chatRoomService.findAllRoomsByMemberId(1L);
 
-            // then
             assertThat(result).hasSize(1);
-            AllRoomsResponse response = result.get(0);
-            assertThat(response.getRoomId()).isEqualTo(10L);
-            assertThat(response.getUnreadCount()).isEqualTo(2L); // 5 - 3 = 2
-            assertThat(response.isAlarmEnabled()).isTrue();
-        }
-
-        @Test
-        @DisplayName("Redis 정렬 장애 시 원래 순서대로 반환한다")
-        void findAllRooms_redisSortFail_usesOriginalOrder() {
-            // given
-            ChatRoomWithSequenceProjection p1 = mock(ChatRoomWithSequenceProjection.class);
-            given(p1.getChatRoomId()).willReturn(10L);
-            given(p1.getInviteCode()).willReturn("A");
-            given(p1.getName()).willReturn("방A");
-            given(p1.getLastReadSequence()).willReturn(0L);
-
-            ChatRoomWithSequenceProjection p2 = mock(ChatRoomWithSequenceProjection.class);
-            given(p2.getChatRoomId()).willReturn(20L);
-            given(p2.getInviteCode()).willReturn("B");
-            given(p2.getName()).willReturn("방B");
-            given(p2.getLastReadSequence()).willReturn(0L);
-
-            given(chatRoomRepository.findAllRoomsWithSequenceByParticipantId(1L))
-                .willReturn(List.of(p1, p2));
-            given(chatRoomRedisService.getSortedRoomIds(any()))
-                .willThrow(new RuntimeException("Redis down"));
-            given(chatRoomAlarmRepository.findEnabledMap(eq(1L), anyList()))
-                .willReturn(Map.of(10L, true, 20L, false));
-            given(chatRoomRedisService.getSequences(anyList())).willReturn(List.of(0L, 0L));
-
-            // when
-            List<AllRoomsResponse> result = chatRoomService.findAllRoomsByMemberId(1L);
-
-            // then
-            assertThat(result).hasSize(2);
-            assertThat(result.get(0).getRoomId()).isEqualTo(10L);
-            assertThat(result.get(1).getRoomId()).isEqualTo(20L);
-        }
-
-        @Test
-        @DisplayName("Redis sequence 장애 시 DB fallback으로 시퀀스를 가져온다")
-        void findAllRooms_redisSequenceFail_fallbackToDb() {
-            // given
-            ChatRoomWithSequenceProjection projection = mock(ChatRoomWithSequenceProjection.class);
-            given(projection.getChatRoomId()).willReturn(10L);
-            given(projection.getInviteCode()).willReturn("INVITE-CODE");
-            given(projection.getName()).willReturn("테스트 방");
-            given(projection.getLastReadSequence()).willReturn(1L);
-
-            given(chatRoomRepository.findAllRoomsWithSequenceByParticipantId(1L))
-                .willReturn(List.of(projection));
-            given(chatRoomRedisService.getSortedRoomIds(List.of(10L))).willReturn(List.of(10L));
-            given(chatRoomAlarmRepository.findEnabledMap(1L, List.of(10L)))
-                .willReturn(Map.of(10L, true));
-
-            // Redis 장애
-            given(chatRoomRedisService.getSequences(anyList()))
-                .willThrow(new RuntimeException("Redis down"));
-
-            // DB 폴백
-            given(chatRoom.getLastSequence()).willReturn(4L);
-            given(chatRoomRepository.findAllById(List.of(10L))).willReturn(List.of(chatRoom));
-
-            Counter counter = mock(Counter.class);
-            given(meterRegistry.counter("redis.fallback", "reason", "sequence")).willReturn(
-                counter);
-
-            // when
-            List<AllRoomsResponse> result = chatRoomService.findAllRoomsByMemberId(1L);
-
-            // then
-            assertThat(result).hasSize(1);
-            assertThat(result.get(0).getUnreadCount()).isEqualTo(3L); // 4 - 1 = 3
-            then(counter).should().increment();
+            assertThat(result.get(0)).isEqualTo(expected);
         }
 
         @Test
         @DisplayName("참가한 채팅방이 없으면 빈 리스트를 반환한다")
         void findAllRooms_empty_returnsEmptyList() {
-            // given
             given(chatRoomRepository.findAllRoomsWithSequenceByParticipantId(1L))
-                .willReturn(Collections.emptyList());
+                    .willReturn(Collections.emptyList());
+            given(chatRoomSequenceService.findAllRoomsWithUnread(any(), any(), any()))
+                    .willReturn(Collections.emptyList());
 
-            // when
             List<AllRoomsResponse> result = chatRoomService.findAllRoomsByMemberId(1L);
 
-            // then
             assertThat(result).isEmpty();
         }
     }
 
-    @Nested
-    @DisplayName("syncSequencesToDb() - Redis → DB 시퀀스 동기화")
-    class SyncSequencesToDb {
-
-        @Test
-        @DisplayName("업데이트된 방이 없으면 조기 반환한다")
-        void syncSequencesToDb_empty_earlyReturn() {
-            // given
-            given(chatRoomRedisService.getAndClearUpdatedRooms()).willReturn(
-                Collections.emptySet());
-
-            // when
-            chatRoomService.syncSequencesToDb();
-
-            // then
-            then(chatRoomRepository).should(never()).findAllById(any());
-        }
-
-        @Test
-        @DisplayName("Redis 시퀀스가 DB보다 크면 DB를 업데이트한다")
-        void syncSequencesToDb_redisHigherThanDb_updatesDb() {
-            // given
-            given(chatRoomRedisService.getAndClearUpdatedRooms()).willReturn(Set.of("10"));
-            given(chatRoom.getLastSequence()).willReturn(3L);
-            given(chatRoomRepository.findAllById(List.of(10L))).willReturn(List.of(chatRoom));
-            given(chatRoomRedisService.getSequences(List.of(10L))).willReturn(List.of(7L));
-
-            // when
-            chatRoomService.syncSequencesToDb();
-
-            // then
-            then(chatRoom).should().updateLastSequence(7L);
-        }
-
-        @Test
-        @DisplayName("Redis 시퀀스가 DB보다 작거나 같으면 업데이트하지 않는다")
-        void syncSequencesToDb_redisNotHigher_noUpdate() {
-            // given
-            given(chatRoomRedisService.getAndClearUpdatedRooms()).willReturn(Set.of("10"));
-            given(chatRoom.getLastSequence()).willReturn(10L);
-            given(chatRoomRepository.findAllById(List.of(10L))).willReturn(List.of(chatRoom));
-            given(chatRoomRedisService.getSequences(List.of(10L))).willReturn(List.of(5L));
-
-            // when
-            chatRoomService.syncSequencesToDb();
-
-            // then
-            then(chatRoom).should(never()).updateLastSequence(anyLong());
-        }
-    }
-    
     @Nested
     @DisplayName("getRecentRoomInviteCode() - 최근 채팅방 초대 코드 조회")
     class GetRecentRoomInviteCode {
@@ -721,28 +289,24 @@ class ChatRoomServiceTest {
         @Test
         @DisplayName("최근 방이 있으면 초대 코드를 반환한다")
         void getRecentRoomInviteCode_exists_returnsCode() {
-            // given
+            given(chatRoom.getInviteCode()).willReturn("INVITE-CODE");
             given(owner.getRecentRoomId()).willReturn(10L);
             given(memberService.getMemberById(1L)).willReturn(owner);
             given(chatRoomRepository.findById(10L)).willReturn(Optional.of(chatRoom));
 
-            // when
             String result = chatRoomService.getRecentRoomInviteCode(1L);
 
-            // then
             assertThat(result).isEqualTo("INVITE-CODE");
         }
 
         @Test
-        @DisplayName("최근 방이 null이면 CHATROOM_NOT_EXIST 예외를 던진다")
+        @DisplayName("최근 방이 null이면 예외를 던진다")
         void getRecentRoomInviteCode_null_throwsException() {
-            // given
             given(owner.getRecentRoomId()).willReturn(null);
             given(memberService.getMemberById(1L)).willReturn(owner);
 
-            // when & then
             assertThatThrownBy(() -> chatRoomService.getRecentRoomInviteCode(1L))
-                .isInstanceOf(ChatRoomException.class);
+                    .isInstanceOf(ChatRoomException.class);
         }
     }
 }

--- a/backend/src/test/java/project/backend/domain/community/app/ApplicantServiceTest.java
+++ b/backend/src/test/java/project/backend/domain/community/app/ApplicantServiceTest.java
@@ -1,0 +1,325 @@
+package project.backend.domain.community.app;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import project.backend.auth.dto.MemberDetails;
+import project.backend.domain.chat.chatmessage.app.ChatMessageService;
+import project.backend.domain.chat.chatmessage.entity.ChatMessage;
+import project.backend.domain.chat.chatroom.app.ChatRoomAlarmService;
+import project.backend.domain.chat.chatroom.app.ChatRoomCacheService;
+import project.backend.domain.chat.chatroom.app.ChatRoomSequenceService;
+import project.backend.domain.chat.chatroom.dao.ChatParticipantRepository;
+import project.backend.domain.chat.chatroom.entity.ChatParticipant;
+import project.backend.domain.chat.chatroom.entity.ChatRoom;
+import project.backend.domain.community.dao.ApplicantRepository;
+import project.backend.domain.community.dao.PostRepository;
+import project.backend.domain.community.dto.ApplicantResponse;
+import project.backend.domain.community.entity.Applicant;
+import project.backend.domain.community.entity.ApplicantStatus;
+import project.backend.domain.community.entity.Post;
+import project.backend.domain.member.entity.Member;
+import project.backend.global.exception.ex.ChatRoomException;
+import project.backend.global.exception.ex.PostException;
+
+@ExtendWith(MockitoExtension.class)
+class ApplicantServiceTest {
+
+    @InjectMocks
+    private ApplicantService applicantService;
+
+    @Mock private PostRepository postRepository;
+    @Mock private ApplicantRepository applicantRepository;
+    @Mock private ChatParticipantRepository chatParticipantRepository;
+    @Mock private ApplicationEventPublisher eventPublisher;
+    @Mock private ChatMessageService chatMessageService;
+    @Mock private ChatRoomCacheService chatRoomCacheService;
+    @Mock private ChatRoomSequenceService chatRoomSequenceService;
+    @Mock private ChatRoomAlarmService chatRoomAlarmService;
+
+    private Post post;
+    private Member author;
+    private Member applicantMember;
+    private ChatRoom chatRoom;
+    private MemberDetails ownerDetails;
+    private MemberDetails otherDetails;
+
+    @BeforeEach
+    void setUp() {
+        author = mock(Member.class);
+        applicantMember = mock(Member.class);
+        chatRoom = mock(ChatRoom.class);
+        post = mock(Post.class);
+        ownerDetails = mock(MemberDetails.class);
+        otherDetails = mock(MemberDetails.class);
+    }
+
+    @Nested
+    @DisplayName("getApplicants() - 신청자 목록 조회")
+    class GetApplicants {
+
+        @Test
+        @DisplayName("방장이 신청자 목록을 정상 조회한다")
+        void getApplicants_owner_success() {
+            given(ownerDetails.getId()).willReturn(1L);
+            given(author.getId()).willReturn(1L);
+            given(post.getAuthor()).willReturn(author);
+            given(postRepository.findById(1L)).willReturn(Optional.of(post));
+            given(applicantRepository.findByPost_IdAndStatus(1L, ApplicantStatus.PENDING))
+                    .willReturn(List.of());
+
+            List<ApplicantResponse> result = applicantService.getApplicants(1L, ownerDetails);
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("방장이 아니면 예외를 던진다")
+        void getApplicants_notOwner_throwsException() {
+            given(ownerDetails.getId()).willReturn(99L);
+            given(author.getId()).willReturn(1L);
+            given(post.getAuthor()).willReturn(author);
+            given(postRepository.findById(1L)).willReturn(Optional.of(post));
+
+            assertThatThrownBy(() -> applicantService.getApplicants(1L, ownerDetails))
+                    .isInstanceOf(PostException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("apply() - 스터디 신청")
+    class Apply {
+
+        @Test
+        @DisplayName("정상적으로 스터디를 신청한다")
+        void apply_success() {
+            given(otherDetails.getId()).willReturn(2L);
+            given(author.getId()).willReturn(1L);
+            given(post.isClosed()).willReturn(false);
+            given(post.isFull()).willReturn(false);
+            given(post.getAuthor()).willReturn(author);
+            given(post.getChatRoom()).willReturn(chatRoom);
+            given(chatRoom.getId()).willReturn(10L);
+            given(postRepository.findById(1L)).willReturn(Optional.of(post));
+            given(chatParticipantRepository.existsByParticipantIdAndChatRoomIdAndIsActiveTrue(2L, 10L))
+                    .willReturn(false);
+            given(applicantRepository.findByPost_IdAndMember_Id(1L, 2L)).willReturn(Optional.empty());
+
+            applicantService.apply(1L, otherDetails);
+
+            then(applicantRepository).should().save(any(Applicant.class));
+            then(eventPublisher).should().publishEvent(any(Object.class));
+        }
+
+        @Test
+        @DisplayName("마감된 게시글에 신청하면 예외를 던진다")
+        void apply_closed_throwsException() {
+            given(post.isClosed()).willReturn(true);
+            given(postRepository.findById(1L)).willReturn(Optional.of(post));
+
+            assertThatThrownBy(() -> applicantService.apply(1L, otherDetails))
+                    .isInstanceOf(PostException.class);
+        }
+
+        @Test
+        @DisplayName("인원이 꽉 찬 게시글에 신청하면 예외를 던진다")
+        void apply_full_throwsException() {
+            given(post.isClosed()).willReturn(false);
+            given(post.isFull()).willReturn(true);
+            given(postRepository.findById(1L)).willReturn(Optional.of(post));
+
+            assertThatThrownBy(() -> applicantService.apply(1L, otherDetails))
+                    .isInstanceOf(PostException.class);
+        }
+
+        @Test
+        @DisplayName("본인 게시글에 신청하면 예외를 던진다")
+        void apply_ownPost_throwsException() {
+            given(ownerDetails.getId()).willReturn(1L);
+            given(author.getId()).willReturn(1L);
+            given(post.isClosed()).willReturn(false);
+            given(post.isFull()).willReturn(false);
+            given(post.getAuthor()).willReturn(author);
+            given(postRepository.findById(1L)).willReturn(Optional.of(post));
+
+            assertThatThrownBy(() -> applicantService.apply(1L, ownerDetails))
+                    .isInstanceOf(PostException.class);
+        }
+
+        @Test
+        @DisplayName("이미 채팅방에 참가 중이면 예외를 던진다")
+        void apply_alreadyParticipant_throwsException() {
+            given(otherDetails.getId()).willReturn(2L);
+            given(author.getId()).willReturn(1L);
+            given(post.isClosed()).willReturn(false);
+            given(post.isFull()).willReturn(false);
+            given(post.getAuthor()).willReturn(author);
+            given(post.getChatRoom()).willReturn(chatRoom);
+            given(chatRoom.getId()).willReturn(10L);
+            given(postRepository.findById(1L)).willReturn(Optional.of(post));
+            given(chatParticipantRepository.existsByParticipantIdAndChatRoomIdAndIsActiveTrue(2L, 10L))
+                    .willReturn(true);
+
+            assertThatThrownBy(() -> applicantService.apply(1L, otherDetails))
+                    .isInstanceOf(ChatRoomException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("approve() - 신청 승인")
+    class Approve {
+
+        @Test
+        @DisplayName("신청을 승인하면 참가자가 추가되고 이벤트가 2회 발행된다")
+        void approve_success() {
+            given(ownerDetails.getId()).willReturn(1L);
+            given(author.getId()).willReturn(1L);
+            given(applicantMember.getId()).willReturn(2L);
+            given(applicantMember.getUsername()).willReturn("applicantUser");
+            given(applicantMember.getNickname()).willReturn("applicantNick");
+
+            Applicant applicant = mock(Applicant.class);
+            given(applicant.getMember()).willReturn(applicantMember);
+            given(post.getAuthor()).willReturn(author);
+            given(post.getId()).willReturn(1L);
+            given(post.getTitle()).willReturn("테스트 게시글");
+            given(post.isFull()).willReturn(false);
+            given(post.getChatRoom()).willReturn(chatRoom);
+            given(post.getChatRoomId()).willReturn(10L);
+            given(chatRoom.getId()).willReturn(10L);
+
+            given(postRepository.findById(1L)).willReturn(Optional.of(post));
+            given(applicantRepository.findById(10L)).willReturn(Optional.of(applicant));
+
+            ChatParticipant chatParticipant = mock(ChatParticipant.class);
+            given(chatParticipantRepository.save(any(ChatParticipant.class))).willReturn(chatParticipant);
+            given(chatRoomSequenceService.getLatestSequence(10L)).willReturn(5L);
+            given(chatRoomCacheService.handleMessageDelivery(10L)).willReturn(6L);
+
+            ChatMessage joinMessage = mock(ChatMessage.class);
+            given(joinMessage.getId()).willReturn(100L);
+            given(joinMessage.getSendAt()).willReturn(java.time.LocalDateTime.now());
+            given(chatMessageService.saveJoinEvent(chatRoom, applicantMember, 6L)).willReturn(joinMessage);
+
+            applicantService.approve(1L, 10L, ownerDetails);
+
+            then(applicant).should().approve();
+            then(post).should().incrementCurrentCount();
+            then(chatParticipantRepository).should().save(any(ChatParticipant.class));
+            then(eventPublisher).should(times(2)).publishEvent(any(Object.class));
+        }
+
+        @Test
+        @DisplayName("승인으로 인원이 꽉 차면 게시글이 마감된다")
+        void approve_becomeFull_closesPost() {
+            given(ownerDetails.getId()).willReturn(1L);
+            given(author.getId()).willReturn(1L);
+            given(applicantMember.getId()).willReturn(2L);
+            given(applicantMember.getUsername()).willReturn("applicantUser");
+            given(applicantMember.getNickname()).willReturn("applicantNick");
+
+            Applicant applicant = mock(Applicant.class);
+            given(applicant.getMember()).willReturn(applicantMember);
+            given(post.getAuthor()).willReturn(author);
+            given(post.getId()).willReturn(1L);
+            given(post.getTitle()).willReturn("테스트 게시글");
+            given(post.getChatRoom()).willReturn(chatRoom);
+            given(post.getChatRoomId()).willReturn(10L);
+            given(chatRoom.getId()).willReturn(10L);
+            given(post.isFull()).willReturn(true);
+
+            given(postRepository.findById(1L)).willReturn(Optional.of(post));
+            given(applicantRepository.findById(10L)).willReturn(Optional.of(applicant));
+
+            ChatParticipant chatParticipant = mock(ChatParticipant.class);
+            given(chatParticipantRepository.save(any())).willReturn(chatParticipant);
+            given(chatRoomSequenceService.getLatestSequence(10L)).willReturn(3L);
+            given(chatRoomCacheService.handleMessageDelivery(10L)).willReturn(4L);
+
+            ChatMessage joinMessage = mock(ChatMessage.class);
+            given(joinMessage.getId()).willReturn(200L);
+            given(joinMessage.getSendAt()).willReturn(java.time.LocalDateTime.now());
+            given(chatMessageService.saveJoinEvent(chatRoom, applicantMember, 4L)).willReturn(joinMessage);
+
+            applicantService.approve(1L, 10L, ownerDetails);
+
+            then(post).should().close();
+        }
+
+        @Test
+        @DisplayName("방장이 아니면 예외를 던진다")
+        void approve_notOwner_throwsException() {
+            given(ownerDetails.getId()).willReturn(99L);
+            given(author.getId()).willReturn(1L);
+            given(post.getAuthor()).willReturn(author);
+            given(postRepository.findById(1L)).willReturn(Optional.of(post));
+
+            assertThatThrownBy(() -> applicantService.approve(1L, 10L, ownerDetails))
+                    .isInstanceOf(PostException.class);
+        }
+
+        @Test
+        @DisplayName("신청자가 존재하지 않으면 예외를 던진다")
+        void approve_applicantNotFound_throwsException() {
+            given(ownerDetails.getId()).willReturn(1L);
+            given(author.getId()).willReturn(1L);
+            given(post.getAuthor()).willReturn(author);
+            given(postRepository.findById(1L)).willReturn(Optional.of(post));
+            given(applicantRepository.findById(999L)).willReturn(Optional.empty());
+
+            assertThatThrownBy(() -> applicantService.approve(1L, 999L, ownerDetails))
+                    .isInstanceOf(PostException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("reject() - 신청 거절")
+    class Reject {
+
+        @Test
+        @DisplayName("신청을 거절하면 reject()가 호출되고 이벤트가 1회 발행된다")
+        void reject_success() {
+            given(ownerDetails.getId()).willReturn(1L);
+            given(author.getId()).willReturn(1L);
+            given(post.getAuthor()).willReturn(author);
+
+            Applicant applicant = mock(Applicant.class);
+            given(applicant.getMember()).willReturn(applicantMember);
+            given(postRepository.findById(1L)).willReturn(Optional.of(post));
+            given(applicantRepository.findById(10L)).willReturn(Optional.of(applicant));
+
+            applicantService.reject(1L, 10L, ownerDetails);
+
+            then(applicant).should().reject();
+            then(eventPublisher).should(times(1)).publishEvent(any(Object.class));
+        }
+
+        @Test
+        @DisplayName("방장이 아니면 예외를 던진다")
+        void reject_notOwner_throwsException() {
+            given(ownerDetails.getId()).willReturn(99L);
+            given(author.getId()).willReturn(1L);
+            given(post.getAuthor()).willReturn(author);
+            given(postRepository.findById(1L)).willReturn(Optional.of(post));
+
+            assertThatThrownBy(() -> applicantService.reject(1L, 10L, ownerDetails))
+                    .isInstanceOf(PostException.class);
+        }
+    }
+}

--- a/backend/src/test/java/project/backend/domain/community/app/PostServiceTest.java
+++ b/backend/src/test/java/project/backend/domain/community/app/PostServiceTest.java
@@ -3,16 +3,12 @@ package project.backend.domain.community.app;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 
-import java.time.LocalDateTime;
-import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -22,32 +18,22 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 import project.backend.auth.dto.MemberDetails;
-import project.backend.domain.chat.chatmessage.dao.ChatMessageRepository;
-import project.backend.domain.chat.chatmessage.entity.ChatMessage;
-import project.backend.domain.chat.chatmessage.mapper.ChatMessageMapper;
-import project.backend.domain.chat.chatroom.app.ChatRoomRedisService;
-import project.backend.domain.chat.chatroom.app.ChatRoomService;
-import project.backend.domain.chat.chatroom.dao.ChatParticipantRepository;
 import project.backend.domain.chat.chatroom.dao.ChatRoomRepository;
-import project.backend.domain.chat.chatroom.entity.ChatParticipant;
 import project.backend.domain.chat.chatroom.entity.ChatRoom;
-import project.backend.domain.community.dao.ApplicantRepository;
 import project.backend.domain.community.dao.PostRepository;
-import project.backend.domain.community.dto.ApplicantResponse;
 import project.backend.domain.community.dto.PostCreateRequest;
 import project.backend.domain.community.dto.PostResponse;
 import project.backend.domain.community.dto.PostUpdateRequest;
-import project.backend.domain.community.entity.Applicant;
-import project.backend.domain.community.entity.ApplicantStatus;
 import project.backend.domain.community.entity.Post;
 import project.backend.domain.member.entity.Member;
 import project.backend.global.exception.ex.ChatRoomException;
 import project.backend.global.exception.ex.PostException;
+
+import java.util.List;
 
 @ExtendWith(MockitoExtension.class)
 class PostServiceTest {
@@ -55,40 +41,20 @@ class PostServiceTest {
     @InjectMocks
     private PostService postService;
 
-    @Mock
-    private PostRepository postRepository;
-    @Mock
-    private ChatRoomRepository chatRoomRepository;
-    @Mock
-    private ChatMessageRepository chatMessageRepository;
-    @Mock
-    private ChatParticipantRepository chatParticipantRepository;
-    @Mock
-    private ApplicantRepository applicantRepository;
-    @Mock
-    private ChatMessageMapper chatMessageMapper;
-    @Mock
-    private ApplicationEventPublisher eventPublisher;
-    @Mock
-    private ChatRoomRedisService chatRoomRedisService;
-    @Mock
-    private ChatRoomService chatRoomService;
-    
+    @Mock private PostRepository postRepository;
+    @Mock private ChatRoomRepository chatRoomRepository;
+
     private Post post;
     private Member author;
-    private Member applicantMember;
     private ChatRoom chatRoom;
     private MemberDetails ownerDetails;
-    private MemberDetails otherDetails;
 
     @BeforeEach
     void setUp() {
         author = mock(Member.class);
-        applicantMember = mock(Member.class);
         chatRoom = mock(ChatRoom.class);
         post = mock(Post.class);
         ownerDetails = mock(MemberDetails.class);
-        otherDetails = mock(MemberDetails.class);
     }
 
     @Nested
@@ -99,8 +65,8 @@ class PostServiceTest {
         @DisplayName("myApplied=true인데 비로그인이면 예외를 던진다")
         void getPosts_myApplied_notLoggedIn_throwsException() {
             assertThatThrownBy(() ->
-                postService.getPosts("recent", false, true, 0, 10, null))
-                .isInstanceOf(PostException.class);
+                    postService.getPosts("recent", false, true, 0, 10, null))
+                    .isInstanceOf(PostException.class);
         }
 
         @Test
@@ -108,11 +74,9 @@ class PostServiceTest {
         void getPosts_myApplied_loggedIn_returnsAppliedPosts() {
             given(ownerDetails.getId()).willReturn(1L);
             Slice<Post> slice = new SliceImpl<>(List.of());
-            given(postRepository.findAppliedByMember(eq(1L), any(PageRequest.class))).willReturn(
-                slice);
+            given(postRepository.findAppliedByMember(eq(1L), any(PageRequest.class))).willReturn(slice);
 
-            Slice<PostResponse> result = postService.getPosts("recent", false, true, 0, 10,
-                ownerDetails);
+            Slice<PostResponse> result = postService.getPosts("recent", false, true, 0, 10, ownerDetails);
 
             assertThat(result).isNotNull();
             then(postRepository).should().findAppliedByMember(eq(1L), any());
@@ -170,7 +134,6 @@ class PostServiceTest {
         @Test
         @DisplayName("존재하는 게시글 조회 시 조회수가 증가한다")
         void getPost_exists_incrementsViewCount() {
-            // NullPointer 수정: PostResponse.from()이 post.getAuthor()를 실제 호출하므로 stubbing 필요
             given(post.getAuthor()).willReturn(author);
             given(postRepository.findById(1L)).willReturn(Optional.of(post));
 
@@ -185,7 +148,7 @@ class PostServiceTest {
             given(postRepository.findById(999L)).willReturn(Optional.empty());
 
             assertThatThrownBy(() -> postService.getPost(999L))
-                .isInstanceOf(PostException.class);
+                    .isInstanceOf(PostException.class);
         }
     }
 
@@ -199,7 +162,6 @@ class PostServiceTest {
             PostCreateRequest request = mock(PostCreateRequest.class);
             given(request.getChatRoomId()).willReturn(10L);
             given(ownerDetails.getId()).willReturn(1L);
-
             given(postRepository.existsByChatRoom_Id(10L)).willReturn(false);
             given(chatRoomRepository.findById(10L)).willReturn(Optional.of(chatRoom));
 
@@ -221,7 +183,7 @@ class PostServiceTest {
             given(postRepository.existsByChatRoom_Id(10L)).willReturn(true);
 
             assertThatThrownBy(() -> postService.createPost(request, ownerDetails))
-                .isInstanceOf(PostException.class);
+                    .isInstanceOf(PostException.class);
             then(postRepository).should(never()).save(any());
         }
 
@@ -235,7 +197,7 @@ class PostServiceTest {
             given(chatRoomRepository.findById(10L)).willReturn(Optional.empty());
 
             assertThatThrownBy(() -> postService.createPost(request, ownerDetails))
-                .isInstanceOf(ChatRoomException.class);
+                    .isInstanceOf(ChatRoomException.class);
         }
     }
 
@@ -270,8 +232,8 @@ class PostServiceTest {
             given(postRepository.findById(1L)).willReturn(Optional.of(post));
 
             assertThatThrownBy(() ->
-                postService.updatePost(1L, mock(PostUpdateRequest.class), ownerDetails))
-                .isInstanceOf(PostException.class);
+                    postService.updatePost(1L, mock(PostUpdateRequest.class), ownerDetails))
+                    .isInstanceOf(PostException.class);
         }
 
         @Test
@@ -284,8 +246,8 @@ class PostServiceTest {
             given(postRepository.findById(1L)).willReturn(Optional.of(post));
 
             assertThatThrownBy(() ->
-                postService.updatePost(1L, mock(PostUpdateRequest.class), ownerDetails))
-                .isInstanceOf(PostException.class);
+                    postService.updatePost(1L, mock(PostUpdateRequest.class), ownerDetails))
+                    .isInstanceOf(PostException.class);
         }
 
         @Test
@@ -302,7 +264,7 @@ class PostServiceTest {
             given(request.getMaxCount()).willReturn(3);
 
             assertThatThrownBy(() -> postService.updatePost(1L, request, ownerDetails))
-                .isInstanceOf(PostException.class);
+                    .isInstanceOf(PostException.class);
         }
     }
 
@@ -332,7 +294,7 @@ class PostServiceTest {
             given(postRepository.findById(1L)).willReturn(Optional.of(post));
 
             assertThatThrownBy(() -> postService.deletePost(1L, ownerDetails))
-                .isInstanceOf(PostException.class);
+                    .isInstanceOf(PostException.class);
             then(postRepository).should(never()).delete(any());
         }
 
@@ -342,269 +304,7 @@ class PostServiceTest {
             given(postRepository.findById(999L)).willReturn(Optional.empty());
 
             assertThatThrownBy(() -> postService.deletePost(999L, ownerDetails))
-                .isInstanceOf(PostException.class);
-        }
-    }
-
-    @Nested
-    @DisplayName("apply() - 스터디 신청")
-    class Apply {
-
-        @Test
-        @DisplayName("정상적으로 스터디를 신청한다")
-        void apply_success() {
-            given(otherDetails.getId()).willReturn(2L);
-            given(author.getId()).willReturn(1L);
-
-            given(post.isClosed()).willReturn(false);
-            given(post.isFull()).willReturn(false);
-            given(post.getAuthor()).willReturn(author);
-            given(post.getChatRoom()).willReturn(chatRoom);
-            given(chatRoom.getId()).willReturn(10L);
-            given(postRepository.findById(1L)).willReturn(Optional.of(post));
-            given(chatParticipantRepository.existsByParticipantIdAndChatRoomIdAndIsActiveTrue(2L,
-                10L))
-                .willReturn(false);
-            given(applicantRepository.findByPost_IdAndMember_Id(1L, 2L)).willReturn(
-                Optional.empty());
-
-            postService.apply(1L, otherDetails);
-
-            then(applicantRepository).should().save(any(Applicant.class));
-
-            then(eventPublisher).should().publishEvent(any(Object.class));
-        }
-
-        @Test
-        @DisplayName("마감된 게시글에 신청하면 예외를 던진다")
-        void apply_closed_throwsException() {
-            given(post.isClosed()).willReturn(true);
-            given(postRepository.findById(1L)).willReturn(Optional.of(post));
-
-            assertThatThrownBy(() -> postService.apply(1L, otherDetails))
-                .isInstanceOf(PostException.class);
-        }
-
-        @Test
-        @DisplayName("인원이 꽉 찬 게시글에 신청하면 예외를 던진다")
-        void apply_full_throwsException() {
-            given(post.isClosed()).willReturn(false);
-            given(post.isFull()).willReturn(true);
-            given(postRepository.findById(1L)).willReturn(Optional.of(post));
-
-            assertThatThrownBy(() -> postService.apply(1L, otherDetails))
-                .isInstanceOf(PostException.class);
-        }
-
-        @Test
-        @DisplayName("본인 게시글에 신청하면 예외를 던진다")
-        void apply_ownPost_throwsException() {
-            given(ownerDetails.getId()).willReturn(1L);
-            given(author.getId()).willReturn(1L);
-            given(post.isClosed()).willReturn(false);
-            given(post.isFull()).willReturn(false);
-            given(post.getAuthor()).willReturn(author);
-            given(postRepository.findById(1L)).willReturn(Optional.of(post));
-
-            assertThatThrownBy(() -> postService.apply(1L, ownerDetails))
-                .isInstanceOf(PostException.class);
-        }
-
-        @Test
-        @DisplayName("이미 채팅방에 참가 중이면 예외를 던진다")
-        void apply_alreadyParticipant_throwsException() {
-            given(otherDetails.getId()).willReturn(2L);
-            given(author.getId()).willReturn(1L);
-            given(post.isClosed()).willReturn(false);
-            given(post.isFull()).willReturn(false);
-            given(post.getAuthor()).willReturn(author);
-            given(post.getChatRoom()).willReturn(chatRoom);
-            given(chatRoom.getId()).willReturn(10L);
-            given(postRepository.findById(1L)).willReturn(Optional.of(post));
-            given(chatParticipantRepository.existsByParticipantIdAndChatRoomIdAndIsActiveTrue(2L,
-                10L))
-                .willReturn(true);
-
-            assertThatThrownBy(() -> postService.apply(1L, otherDetails))
-                .isInstanceOf(ChatRoomException.class);
-        }
-    }
-
-    @Nested
-    @DisplayName("getApplicants() - 신청자 목록 조회")
-    class GetApplicants {
-
-        @Test
-        @DisplayName("방장이 신청자 목록을 정상 조회한다")
-        void getApplicants_owner_success() {
-            given(ownerDetails.getId()).willReturn(1L);
-            given(author.getId()).willReturn(1L);
-            given(post.getAuthor()).willReturn(author);
-            given(postRepository.findById(1L)).willReturn(Optional.of(post));
-            given(applicantRepository.findByPost_IdAndStatus(1L, ApplicantStatus.PENDING))
-                .willReturn(List.of());
-
-            List<ApplicantResponse> result = postService.getApplicants(1L, ownerDetails);
-
-            assertThat(result).isEmpty();
-        }
-
-        @Test
-        @DisplayName("방장이 아니면 예외를 던진다")
-        void getApplicants_notOwner_throwsException() {
-            given(ownerDetails.getId()).willReturn(99L);
-            given(author.getId()).willReturn(1L);
-            given(post.getAuthor()).willReturn(author);
-            given(postRepository.findById(1L)).willReturn(Optional.of(post));
-
-            assertThatThrownBy(() -> postService.getApplicants(1L, ownerDetails))
-                .isInstanceOf(PostException.class);
-        }
-    }
-
-    @Nested
-    @DisplayName("approve() - 신청 승인")
-    class Approve {
-
-        @Test
-        @DisplayName("신청을 승인하면 참가자가 추가되고 이벤트가 2회 발행된다")
-        void approve_success() {
-            given(ownerDetails.getId()).willReturn(1L);
-            given(author.getId()).willReturn(1L);
-            given(applicantMember.getId()).willReturn(2L);
-
-            Applicant applicant = mock(Applicant.class);
-            given(applicant.getMember()).willReturn(applicantMember);
-
-            given(post.getAuthor()).willReturn(author);
-            given(post.isFull()).willReturn(false);
-            given(post.getChatRoom()).willReturn(chatRoom);
-            given(post.getChatRoomId()).willReturn(10L);
-            given(chatRoom.getId()).willReturn(10L);
-
-            given(postRepository.findById(1L)).willReturn(Optional.of(post));
-            given(applicantRepository.findById(10L)).willReturn(Optional.of(applicant));
-
-            ChatParticipant chatParticipant = mock(ChatParticipant.class);
-            given(chatParticipantRepository.save(any(ChatParticipant.class))).willReturn(
-                chatParticipant);
-            given(chatRoomService.getLatestSequence(10L)).willReturn(5L);
-            given(chatRoomRedisService.handleMessageDelivery(10L)).willReturn(6L);
-
-            ChatMessage joinMessage = mock(ChatMessage.class);
-            given(joinMessage.getId()).willReturn(100L);
-            given(joinMessage.getSendAt()).willReturn(LocalDateTime.now());
-            given(chatMessageMapper.toEntityWithJoinEvent(eq(chatRoom), eq(applicantMember), any(),
-                eq(6L)))
-                .willReturn(joinMessage);
-            given(chatMessageRepository.save(joinMessage)).willReturn(joinMessage);
-
-            postService.approve(1L, 10L, ownerDetails);
-
-            then(applicant).should().approve();
-            then(post).should().incrementCurrentCount();
-            then(chatParticipantRepository).should().save(any(ChatParticipant.class));
-
-            then(eventPublisher).should(times(2)).publishEvent(any(Object.class));
-        }
-
-        @Test
-        @DisplayName("승인으로 인원이 꽉 차면 게시글이 마감된다")
-        void approve_becomeFull_closesPost() {
-            given(ownerDetails.getId()).willReturn(1L);
-            given(author.getId()).willReturn(1L);
-            given(applicantMember.getId()).willReturn(2L);
-
-            Applicant applicant = mock(Applicant.class);
-            given(applicant.getMember()).willReturn(applicantMember);
-
-            given(post.getAuthor()).willReturn(author);
-            given(post.getChatRoom()).willReturn(chatRoom);
-            given(post.getChatRoomId()).willReturn(10L);
-            given(chatRoom.getId()).willReturn(10L);
-            given(post.isFull()).willReturn(true);
-
-            given(postRepository.findById(1L)).willReturn(Optional.of(post));
-            given(applicantRepository.findById(10L)).willReturn(Optional.of(applicant));
-
-            ChatParticipant chatParticipant = mock(ChatParticipant.class);
-            given(chatParticipantRepository.save(any())).willReturn(chatParticipant);
-            given(chatRoomService.getLatestSequence(10L)).willReturn(3L);
-            given(chatRoomRedisService.handleMessageDelivery(10L)).willReturn(4L);
-
-            ChatMessage joinMessage = mock(ChatMessage.class);
-            given(joinMessage.getId()).willReturn(200L);
-            given(joinMessage.getSendAt()).willReturn(LocalDateTime.now());
-            given(chatMessageMapper.toEntityWithJoinEvent(any(), any(), any(), anyLong()))
-                .willReturn(joinMessage);
-            given(chatMessageRepository.save(joinMessage)).willReturn(joinMessage);
-
-            postService.approve(1L, 10L, ownerDetails);
-
-            then(post).should().close();
-        }
-
-        @Test
-        @DisplayName("방장이 아니면 예외를 던진다")
-        void approve_notOwner_throwsException() {
-            given(ownerDetails.getId()).willReturn(99L);
-            given(author.getId()).willReturn(1L);
-            given(post.getAuthor()).willReturn(author);
-            given(postRepository.findById(1L)).willReturn(Optional.of(post));
-
-            assertThatThrownBy(() -> postService.approve(1L, 10L, ownerDetails))
-                .isInstanceOf(PostException.class);
-        }
-
-        @Test
-        @DisplayName("신청자가 존재하지 않으면 예외를 던진다")
-        void approve_applicantNotFound_throwsException() {
-            given(ownerDetails.getId()).willReturn(1L);
-            given(author.getId()).willReturn(1L);
-            given(post.getAuthor()).willReturn(author);
-            given(postRepository.findById(1L)).willReturn(Optional.of(post));
-            given(applicantRepository.findById(999L)).willReturn(Optional.empty());
-
-            assertThatThrownBy(() -> postService.approve(1L, 999L, ownerDetails))
-                .isInstanceOf(PostException.class);
-        }
-    }
-
-    @Nested
-    @DisplayName("reject() - 신청 거절")
-    class Reject {
-
-        @Test
-        @DisplayName("신청을 거절하면 reject()가 호출되고 이벤트가 1회 발행된다")
-        void reject_success() {
-            given(ownerDetails.getId()).willReturn(1L);
-            given(author.getId()).willReturn(1L);
-            given(post.getAuthor()).willReturn(author);
-            // post.getChatRoom(), applicant.getMember() — reject() 서비스 코드에서 호출하지 않으므로 제거
-
-            Applicant applicant = mock(Applicant.class);
-            // CommunityMapper.toApplicantResultEvent()가 applicant.getMember().getId() 호출
-            given(applicant.getMember()).willReturn(applicantMember);
-
-            given(postRepository.findById(1L)).willReturn(Optional.of(post));
-            given(applicantRepository.findById(10L)).willReturn(Optional.of(applicant));
-
-            postService.reject(1L, 10L, ownerDetails);
-
-            then(applicant).should().reject();
-            then(eventPublisher).should(times(1)).publishEvent(any(Object.class));
-        }
-
-        @Test
-        @DisplayName("방장이 아니면 예외를 던진다")
-        void reject_notOwner_throwsException() {
-            given(ownerDetails.getId()).willReturn(99L);
-            given(author.getId()).willReturn(1L);
-            given(post.getAuthor()).willReturn(author);
-            given(postRepository.findById(1L)).willReturn(Optional.of(post));
-
-            assertThatThrownBy(() -> postService.reject(1L, 10L, ownerDetails))
-                .isInstanceOf(PostException.class);
+                    .isInstanceOf(PostException.class);
         }
     }
 }


### PR DESCRIPTION
## 🛰️ Issue Number
close #230 

## 🪐 작업 내용

## 개요
Redis 장애 시 안정적인 서비스 운영을 위한 Circuit Breaker를 도입하고, 비대해진 `ChatRoomService`의 책임을 분리했습니다.
또한 Redis 장애 시 DB로 쏠리는 트래픽을 제한하기 위해 Rate Limiting 및 Semaphore를 적용했습니다.

## 변경 사항

### Circuit Breaker 도입
- Resilience4j Circuit Breaker 적용으로 Redis 장애 시 자동 폴백 처리
- OPEN 상태에서 Redis 시도 없이 즉시 DB 폴백으로 응답 지연 제거
- 메시지 전송 폴백: DB `lastSequence` 직접 증가로 시퀀스 유실 방지
- 목록 조회 폴백: DB `lastSequence` 단순 조회로 집계 쿼리 없이 처리

### Circuit Breaker 상태 전환 기준
| 상태 | 조건 |
|------|------|
| CLOSED → OPEN | 최근 10번 요청 중 실패율 50% 초과 |
| OPEN → HALF_OPEN | 30초 경과 |
| HALF_OPEN → CLOSED | 3개 테스트 요청 성공 |

### DB 보호를 위한 Rate Limiting 적용
| 컴포넌트 | 방식 | 목적 |
|----------|------|------|
| `UserRateLimiter` | Redis 기반 → 장애 시 메모리 기반 자동 전환 | 사용자별 초당 5건 제한 |
| `RateLimiter` | Resilience4j 기반 | 폴백 초당 100건 제한으로 지속적 과부하 방지 |
| `FallbackLimiter` | Semaphore 기반 | 동시 처리 20건 제한으로 순간 트래픽 폭발 방지 |

### 서비스 책임 분리
| 클래스 | 책임 |
|--------|------|
| `ChatRoomService` | 채팅방 생성/삭제/조회/참여 orchestration |
| `ChatRoomCacheService` | Circuit Breaker + 폴백 로직 |
| `ChatRoomRedisService` | 순수 Redis 연산 |
| `ChatRoomSequenceService` | 시퀀스/안읽음 카운트/DB 동기화 |
| `ChatRoomParticipantService` | 참여자 관리/입퇴장/검증 |
| `ChatRoomAlarmService` | 알람 생성/토글/조회 |

## 테스트
분리된 서비스별 단위 테스트 추가

## 📚 Reference

## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?