### PR TITLE
fix: Spring Cloud BOM 버전 문제 해결

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -61,7 +61,7 @@ dependencies {
 }
 dependencyManagement {
     imports {
-        mavenBom 'org.springframework.cloud:spring-cloud-dependencies:2023.0.3'
+        mavenBom 'org.springframework.cloud:spring-cloud-dependencies:2024.0.1'
     }
 }
 


### PR DESCRIPTION
## 🛰️ Issue Number


## 🪐 작업 내용
Spring Cloud BOM의 버전을 24.01로 업데이트 했습니다.

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?