### PR TITLE
fix: WebSocket 구독 전역 관리 및 Redis 장애 시 폴백 안정화

### DIFF
--- a/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomCacheService.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomCacheService.java
@@ -1,8 +1,6 @@
 package project.backend.domain.chat.chatroom.app;
 
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
-import io.github.resilience4j.ratelimiter.RequestNotPermitted;
-import io.github.resilience4j.ratelimiter.annotation.RateLimiter;
 import io.micrometer.core.instrument.MeterRegistry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -30,6 +28,8 @@ public class ChatRoomCacheService {
     private final UserRateLimiter userRateLimiter;
     private final FallbackLimiter fallbackLimiter;
 
+    // ===== 메시지 전송 시퀀스 =====
+
     @CircuitBreaker(name = "redis", fallbackMethod = "handleMessageDeliveryFallback")
     public Long handleMessageDelivery(Long roomId, Long userId) {
         if (!userRateLimiter.allow(userId)) {
@@ -38,8 +38,7 @@ public class ChatRoomCacheService {
         return chatRoomRedisService.handleMessageDelivery(roomId);
     }
 
-    @RateLimiter(name = "redis-fallback", fallbackMethod = "handleMessageDeliveryRateLimitFallback")
-    public Long handleMessageDeliveryFallback(Long roomId, Long userId, Exception e) {
+    public Long handleMessageDeliveryFallback(Long roomId, Long userId, Throwable e) {
         log.warn("Circuit OPEN - handleMessageDelivery 폴백 roomId={}", roomId);
         meterRegistry.counter("redis.fallback", "method", "handleMessageDelivery").increment();
 
@@ -67,29 +66,7 @@ public class ChatRoomCacheService {
         return chatRoomRepository.findLastInsertId();
     }
 
-    public Long handleMessageDeliveryRateLimitFallback(Long roomId, Long userId, RequestNotPermitted e) {
-        log.warn("Fallback RateLimit 초과 - DB 보호 roomId={}", roomId);
-        meterRegistry.counter("redis.fallback.rejected").increment();
-        throw new ChatRoomException(ChatRoomErrorCode.SERVICE_UNAVAILABLE);
-    }
-
-    @CircuitBreaker(name = "redis", fallbackMethod = "getSequencesFallback")
-    public List<Long> getSequences(List<Long> roomIds) {
-        return chatRoomRedisService.getSequences(roomIds);
-    }
-
-    public List<Long> getSequencesFallback(List<Long> roomIds, Exception e) {
-        log.warn("Circuit OPEN - getSequences 폴백");
-        meterRegistry.counter("redis.fallback", "reason", "sequence").increment();
-        Map<Long, Long> seqMap = chatRoomRepository.findAllById(roomIds).stream()
-                .collect(Collectors.toMap(
-                        ChatRoom::getId,
-                        ChatRoom::getLastSequence
-                ));
-        return roomIds.stream()
-                .map(id -> seqMap.getOrDefault(id, 0L))
-                .toList();
-    }
+    // ===== 시퀀스 조회 =====
 
     @CircuitBreaker(name = "redis", fallbackMethod = "getLatestSequenceFallback")
     public Long getLatestSequence(Long roomId) {
@@ -104,7 +81,7 @@ public class ChatRoomCacheService {
         return redisSeq;
     }
 
-    public Long getLatestSequenceFallback(Long roomId, Exception e) {
+    public Long getLatestSequenceFallback(Long roomId, Throwable e) {
         log.warn("Circuit OPEN - getLatestSequence 폴백 roomId={}", roomId);
         meterRegistry.counter("redis.fallback", "reason", "latestSequence").increment();
         return chatRoomRepository.findById(roomId)
@@ -112,12 +89,32 @@ public class ChatRoomCacheService {
                 .orElse(0L);
     }
 
+    @CircuitBreaker(name = "redis", fallbackMethod = "getSequencesFallback")
+    public List<Long> getSequences(List<Long> roomIds) {
+        return chatRoomRedisService.getSequences(roomIds);
+    }
+
+    public List<Long> getSequencesFallback(List<Long> roomIds, Throwable e) {
+        log.warn("Circuit OPEN - getSequences 폴백");
+        meterRegistry.counter("redis.fallback", "reason", "sequence").increment();
+        Map<Long, Long> seqMap = chatRoomRepository.findAllById(roomIds).stream()
+                .collect(Collectors.toMap(
+                        ChatRoom::getId,
+                        ChatRoom::getLastSequence
+                ));
+        return roomIds.stream()
+                .map(id -> seqMap.getOrDefault(id, 0L))
+                .toList();
+    }
+
+    // ===== 채팅방 정렬 =====
+
     @CircuitBreaker(name = "redis", fallbackMethod = "getSortedRoomIdsFallback")
     public List<Long> getSortedRoomIds(List<Long> roomIds) {
         return chatRoomRedisService.getSortedRoomIds(roomIds);
     }
 
-    public List<Long> getSortedRoomIdsFallback(List<Long> roomIds, Exception e) {
+    public List<Long> getSortedRoomIdsFallback(List<Long> roomIds, Throwable e) {
         log.warn("Circuit OPEN - getSortedRoomIds 폴백");
         return roomIds;
     }

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/dao/ChatRoomRepository.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/dao/ChatRoomRepository.java
@@ -43,7 +43,7 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
         @Param("memberId") Long memberId);
 
     @Modifying
-    @Query(value = "UPDATE chat_room SET last_sequence = LAST_INSERT_ID(last_sequence + 1) WHERE id = :roomId", nativeQuery = true)
+    @Query(value = "UPDATE chat_room SET last_sequence = LAST_INSERT_ID(last_sequence + 1) WHERE room_id = :roomId", nativeQuery = true)
     void incrementSequence(@Param("roomId") Long roomId);
 
     @Query(value = "SELECT LAST_INSERT_ID()", nativeQuery = true)

--- a/backend/src/main/java/project/backend/domain/member/app/MemberRedisService.java
+++ b/backend/src/main/java/project/backend/domain/member/app/MemberRedisService.java
@@ -1,11 +1,13 @@
 package project.backend.domain.member.app;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
 import java.util.concurrent.TimeUnit;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class MemberRedisService {
@@ -21,7 +23,12 @@ public class MemberRedisService {
     }
 
     public String getProfileImage(Long memberId) {
-        String key = String.format(MEMBER_PROFILE_KEY, memberId);
-        return redisTemplate.opsForValue().get(key);
+        try {
+            String key = String.format(MEMBER_PROFILE_KEY, memberId);
+            return redisTemplate.opsForValue().get(key);
+        } catch (Exception e) {
+            log.warn("Redis 장애 - 프로필 이미지 조회 실패 memberId={}", memberId);
+            return null;
+        }
     }
 }

--- a/frontend/src/components/FriendsSidebar.jsx
+++ b/frontend/src/components/FriendsSidebar.jsx
@@ -65,12 +65,9 @@ const FriendsSidebar = ({ onStartChat }) => {
   }, [])
 
   useWebSocketNotifications({
-    username: currentUser?.username,
     onNotificationReceived: handleFriendNotification,
-    // other props...
   })
 
-  // Listen for new DM notifications from the header to apply visual effects.
   useEffect(() => {
     const handleNewDmForSidebar = (event) => {
       const { senderUsername } = event.detail

--- a/frontend/src/components/common/WebSocketContext.js
+++ b/frontend/src/components/common/WebSocketContext.js
@@ -1,29 +1,20 @@
 import { createContext, useContext, useEffect, useRef, useState } from "react"
 import { Client } from "@stomp/stompjs"
 import { useNavigate } from "react-router-dom"
-import { safeRefreshToken } from "../api/refreshManager"
 
 const WebSocketContext = createContext(null)
 
 export const WebSocketProvider = ({ children }) => {
   const stompClientRef = useRef(null)
-  const subscriptionsRef = useRef([])
   const retryCountRef = useRef(0)
   const [connected, setConnected] = useState(false)
   const navigate = useNavigate()
 
   useEffect(() => {
     const client = new Client({
-      webSocketFactory: async () => {
-        try {
-          await safeRefreshToken()
-          return new WebSocket(process.env.REACT_APP_WEB_SOCKET_URL)
-        } catch (err) {
-          console.error("❌ 토큰 갱신 실패 → 로그인 이동")
-          navigate("/login")
-          client.configure({ reconnectDelay: 0 }) // 재연결 중단
-          throw err
-        }
+      webSocketFactory: () => {
+        console.log("🔌 webSocketFactory 호출")
+        return new WebSocket(process.env.REACT_APP_WEB_SOCKET_URL)
       },
       heartbeatIncoming: 15000,
       heartbeatOutgoing: 10000,
@@ -37,75 +28,32 @@ export const WebSocketProvider = ({ children }) => {
         console.log("✅ Connected")
         retryCountRef.current = 0
         setConnected(true)
-
-        // 기존 구독 정리 후 재구독
-        subscriptionsRef.current.forEach((sub) => {
-          sub.subscription?.unsubscribe()
-        })
-        subscriptionsRef.current = subscriptionsRef.current.map(({ destination, callback }) => {
-          const newSub = client.subscribe(destination, callback)
-          return { destination, callback, subscription: newSub }
-        })
       },
-      onWebSocketClose: () => {
-        console.warn("🛑 WebSocket 끊김")
+      onWebSocketClose: (event) => {
+        console.warn("🛑 WebSocket 끊김", "code:", event.code, "reason:", event.reason, "wasClean:", event.wasClean)
         setConnected(false)
+      },
+      onDisconnect: () => {
+        console.warn("🛑 STOMP Disconnect")
       },
       onStompError: (frame) => {
         console.error("💥 STOMP error:", frame.headers["message"])
       },
     })
 
+    console.log("🚀 client.activate() 호출")
     client.activate()
     stompClientRef.current = client
 
     return () => {
+      console.log("🧹 cleanup - deactivate")
       setConnected(false)
       if (client.active) client.deactivate()
     }
-  }, [navigate])
-
-  const subscribe = (destination, callback) => {
-    const client = stompClientRef.current
-
-    const exists = subscriptionsRef.current.find(
-      (sub) => sub.destination === destination
-    )
-    if (!exists) {
-      subscriptionsRef.current.push({ destination, callback, subscription: null })
-    }
-
-    if (client && client.connected) {
-      const subscription = client.subscribe(destination, callback)
-      const target = subscriptionsRef.current.find(
-        (sub) => sub.destination === destination
-      )
-      if (target) target.subscription = subscription
-      return subscription
-    }
-  }
-
-  const unsubscribe = (destination) => {
-    const target = subscriptionsRef.current.find(
-      (sub) => sub.destination === destination
-    )
-    if (target) {
-      target.subscription?.unsubscribe()
-    }
-    subscriptionsRef.current = subscriptionsRef.current.filter(
-      (sub) => sub.destination !== destination
-    )
-  }
+  }, [])
 
   return (
-    <WebSocketContext.Provider
-      value={{
-        stompClientRef,
-        connected,
-        subscribe,
-        unsubscribe,
-      }}
-    >
+    <WebSocketContext.Provider value={{ stompClientRef, connected }}>
       {children}
     </WebSocketContext.Provider>
   )

--- a/frontend/src/components/common/useWebSocket.jsx
+++ b/frontend/src/components/common/useWebSocket.jsx
@@ -1,5 +1,3 @@
-"use client"
-
 import { useEffect, useRef } from "react"
 import { useWebSocketContext } from "./WebSocketContext"
 
@@ -18,7 +16,6 @@ const useWebSocket = ({
 }) => {
   const { stompClientRef, connected } = useWebSocketContext()
 
-  // 모든 콜백을 ref로 관리 → 구독 재등록 없이 항상 최신 함수 호출
   const onMessageReceivedRef = useRef(onMessageReceived)
   const onNotificationReceivedRef = useRef(onNotificationReceived)
   const onProfileUpdateRef = useRef(onProfileUpdate)
@@ -35,56 +32,40 @@ const useWebSocket = ({
   useEffect(() => { onDmMessageReceivedRef.current = onDmMessageReceived }, [onDmMessageReceived])
   useEffect(() => { currentRoomIdRef.current = currentRoomId }, [currentRoomId])
 
-  const subscriptionRef = useRef(null)
-  const notificationSubscriptionRef = useRef(null)
-  const profileSubscriptionRef = useRef(null)
-  const deleteSubscriptionRef = useRef(null)
-  const sidebarSubscriptionsRef = useRef(new Map())
-
-  // 채팅방 + 프로필 + 방 삭제 + 알림 구독
-  // 콜백은 ref로 관리하므로 의존성에서 제외 → roomId, connected 바뀔 때만 재구독
+  // 채팅방 메시지 + 방 삭제 구독
   useEffect(() => {
     const client = stompClientRef.current
-    if (!client?.connected) return
+    if (!connected || !client?.connected || !roomId) return
 
-    if (roomId) {
-      subscriptionRef.current?.unsubscribe()
-      subscriptionRef.current = client.subscribe(`/topic/chat/${roomId}`, (message) => {
-        try {
-          const received = JSON.parse(message.body)
-          received.sendAt = received.sendAt || new Date().toISOString()
-          onMessageReceivedRef.current?.(received)
-        } catch (e) {
-          console.error("📛 Failed to parse chat message", e)
-        }
-      })
+    const subs = []
 
-      deleteSubscriptionRef.current?.unsubscribe()
-      deleteSubscriptionRef.current = client.subscribe(`/topic/chat/${roomId}/deleted`, (message) => {
-        try {
-          onRoomDeletedRef.current?.(JSON.parse(message.body))
-        } catch (e) {
-          console.error("📛 Failed to parse delete message", e)
-        }
-      })
-    }
+    subs.push(client.subscribe(`/topic/chat/${roomId}`, (message) => {
+      try {
+        const received = JSON.parse(message.body)
+        received.sendAt = received.sendAt || new Date().toISOString()
+        onMessageReceivedRef.current?.(received)
+      } catch (e) {
+        console.error("📛 Failed to parse chat message", e)
+      }
+    }))
 
-    if (username) {
-      notificationSubscriptionRef.current?.unsubscribe()
-      notificationSubscriptionRef.current = client.subscribe(`/topic/notifications/${username}`, (message) => {
-        try {
-          const notification = JSON.parse(message.body)
-          notification.timestamp = new Date().toISOString()
-          notification.id = `${Date.now()}-${Math.random()}`
-          onNotificationReceivedRef.current?.(notification)
-        } catch (e) {
-          console.error("📛 Failed to parse notification message", e)
-        }
-      })
-    }
+    subs.push(client.subscribe(`/topic/chat/${roomId}/deleted`, (message) => {
+      try {
+        onRoomDeletedRef.current?.(JSON.parse(message.body))
+      } catch (e) {
+        console.error("📛 Failed to parse delete message", e)
+      }
+    }))
 
-    profileSubscriptionRef.current?.unsubscribe()
-    profileSubscriptionRef.current = client.subscribe("/topic/profile-update", (message) => {
+    return () => subs.forEach((sub) => sub.unsubscribe())
+  }, [connected, roomId])
+
+  // 프로필 업데이트 구독 - onProfileUpdate가 있을 때만
+  useEffect(() => {
+    const client = stompClientRef.current
+    if (!connected || !client?.connected || !onProfileUpdate) return
+
+    const sub = client.subscribe("/topic/profile-update", (message) => {
       try {
         onProfileUpdateRef.current?.(JSON.parse(message.body))
       } catch (e) {
@@ -92,25 +73,34 @@ const useWebSocket = ({
       }
     })
 
-    return () => {
-      subscriptionRef.current?.unsubscribe()
-      subscriptionRef.current = null
-      deleteSubscriptionRef.current?.unsubscribe()
-      deleteSubscriptionRef.current = null
-      notificationSubscriptionRef.current?.unsubscribe()
-      notificationSubscriptionRef.current = null
-      profileSubscriptionRef.current?.unsubscribe()
-      profileSubscriptionRef.current = null
-    }
-  }, [connected, roomId, username])
+    return () => sub.unsubscribe()
+  }, [connected, onProfileUpdate])
 
-  // 사이드바 구독 (현재 방 제외)
+  // 알림 구독 - username이 있을 때만
   useEffect(() => {
     const client = stompClientRef.current
-    if (!client?.connected || !chatRooms.length) return
+    if (!connected || !client?.connected || !username) return
 
-    sidebarSubscriptionsRef.current.forEach((sub) => sub.unsubscribe())
-    sidebarSubscriptionsRef.current.clear()
+    const sub = client.subscribe(`/topic/notifications/${username}`, (message) => {
+      try {
+        const notification = JSON.parse(message.body)
+        notification.timestamp = new Date().toISOString()
+        notification.id = `${Date.now()}-${Math.random()}`
+        onNotificationReceivedRef.current?.(notification)
+      } catch (e) {
+        console.error("📛 Failed to parse notification message", e)
+      }
+    })
+
+    return () => sub.unsubscribe()
+  }, [connected, username])
+
+  // 사이드바 구독
+  useEffect(() => {
+    const client = stompClientRef.current
+    if (!connected || !client?.connected || !chatRooms.length) return
+
+    const subs = []
 
     chatRooms.forEach((room) => {
       const roomUniqueId = room.uniqueId
@@ -128,21 +118,18 @@ const useWebSocket = ({
         }
       })
 
-      sidebarSubscriptionsRef.current.set(roomUniqueId, sub)
+      subs.push(sub)
     })
 
-    return () => {
-      sidebarSubscriptionsRef.current.forEach((sub) => sub.unsubscribe())
-      sidebarSubscriptionsRef.current.clear()
-    }
+    return () => subs.forEach((sub) => sub.unsubscribe())
   }, [connected, chatRooms, currentRoomId])
 
   // DM 구독
   useEffect(() => {
     const client = stompClientRef.current
-    if (!client?.connected || !dmRoomId) return
+    if (!connected || !client?.connected || !dmRoomId) return
 
-    const subscription = client.subscribe(`/topic/dm/${dmRoomId}`, (message) => {
+    const sub = client.subscribe(`/topic/dm/${dmRoomId}`, (message) => {
       try {
         onDmMessageReceivedRef.current?.(JSON.parse(message.body))
       } catch (e) {
@@ -150,7 +137,7 @@ const useWebSocket = ({
       }
     })
 
-    return () => subscription.unsubscribe()
+    return () => sub.unsubscribe()
   }, [connected, dmRoomId])
 
   return { stompClientRef, connected }


### PR DESCRIPTION
## 🛰️ Issue Number


## 🪐 작업 내용
- WebSocketContext에서 safeRefreshToken 제거로 Redis 장애 시 WebSocket 끊김 방지
- useEffect 의존성에서 navigate 제거로 불필요한 재연결 방지
- MemberRedisService.getProfileImage() try-catch 추가로 Redis 장애 시 앱 중단 방지
- ChatRoomCacheService 폴백 메서드 파라미터 Throwable로 통일
- @RateLimiter 중첩 제거 후 폴백 메서드 내에서 직접 처리
- incrementSequence 쿼리 컬럼명 id → room_id 수정

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?