### PR TITLE
Fix: 순환 참조 문제 해결

### DIFF
--- a/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomCacheService.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomCacheService.java
@@ -23,7 +23,7 @@ import java.util.stream.Collectors;
 public class ChatRoomCacheService {
 
     private final ChatRoomRedisService chatRoomRedisService;
-    private final ChatRoomService chatRoomService;
+    private final ChatRoomSequenceWriter chatRoomSequenceWriter;
     private final ChatRoomRepository chatRoomRepository;
     private final MeterRegistry meterRegistry;
     private final UserRateLimiter userRateLimiter;
@@ -117,7 +117,7 @@ public class ChatRoomCacheService {
         }
 
         try {
-            return chatRoomService.incrementSequenceFromDb(roomId);
+            return chatRoomSequenceWriter.incrementSequenceFromDb(roomId);
         } finally {
             fallbackLimiter.release();
         }

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomSequenceWriter.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomSequenceWriter.java
@@ -1,0 +1,19 @@
+package project.backend.domain.chat.chatroom.app;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import project.backend.domain.chat.chatroom.dao.ChatRoomRepository;
+
+@Component
+@RequiredArgsConstructor
+public class ChatRoomSequenceWriter {
+
+    private final ChatRoomRepository chatRoomRepository;
+
+    @Transactional
+    public Long incrementSequenceFromDb(Long roomId) {
+        chatRoomRepository.incrementSequence(roomId);
+        return chatRoomRepository.findLastInsertId();
+    }
+}

--- a/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomService.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/app/ChatRoomService.java
@@ -213,10 +213,4 @@ public class ChatRoomService {
         return chatRoomRepository.findByInviteCode(inviteCode)
                 .orElseThrow(() -> new ChatRoomException(ChatRoomErrorCode.CHATROOM_NOT_FOUND));
     }
-
-    @Transactional
-    public Long incrementSequenceFromDb(Long roomId) {
-        chatRoomRepository.incrementSequence(roomId);
-        return chatRoomRepository.findLastInsertId();
-    }
 }


### PR DESCRIPTION
## 🛰️ Issue Number


## 🪐 작업 내용
ChatRoomService의 incrementSequenceFromDb() 메서드를 ChatRoomSequenceWriter로 분리하여 ChatRoomCacheService가 ChatRoomService 대신 ChatRoomSequenceWriter를 직접 주입받도록 변경
- 트랜잭션 유지를 위해 @Transactional은 ChatRoomSequenceWriter에 적용
- ChatRoomService에서 incrementSequenceFromDb() 제거

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?