### PR TITLE
feat: 서버 재시작 시 Redis seq 복구를 위한 ApplicationReadyEvent 리스너 추가

### DIFF
--- a/backend/src/main/java/project/backend/domain/chat/chatroom/listener/RedisRecoveryEventListener.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatroom/listener/RedisRecoveryEventListener.java
@@ -5,6 +5,8 @@ import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 import project.backend.domain.chat.chatroom.app.ChatRoomSyncService;
 
@@ -26,5 +28,10 @@ public class RedisRecoveryEventListener {
                         chatRoomSyncService.recoverSequences();
                     }
                 });
+    }
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void onApplicationReady() {
+        chatRoomSyncService.recoverSequences();
     }
 }


### PR DESCRIPTION
## 🛰️ Issue Number
merge to dev

## 🪐 작업 내용
- ApplicationReadyEvent를 수신하는 이벤트 리스너 추가
- Spring 서버 재시작시 레디스의 값을 최신 상태로 유지합니다.

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?