### PR TITLE
fix: 닉네임 변경 시 JWT 불일치 및 관련 리팩토링

### DIFF
--- a/backend/src/main/java/project/backend/auth/app/AuthTokenService.java
+++ b/backend/src/main/java/project/backend/auth/app/AuthTokenService.java
@@ -12,13 +12,14 @@ import project.backend.auth.dao.AuthTokenRepository;
 import project.backend.auth.dto.MemberDetails;
 import project.backend.auth.entity.AuthToken;
 import project.backend.auth.jwt.JwtProvider;
+import project.backend.auth.jwt.Token;
+import project.backend.domain.member.entity.Member;
 import project.backend.global.exception.errorcode.TokenErrorCode;
 import project.backend.global.exception.ex.CustomJwtException;
 import project.backend.global.util.CookieUtils;
 import project.backend.global.util.CryptUtils;
 
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 
 @Slf4j
 @Service
@@ -29,8 +30,6 @@ public class AuthTokenService {
     private final JwtProvider jwtProvider;
     private final CryptUtils cryptUtils;
     private final TokenRefreshCachePort tokenRefreshCachePort;
-
-    private static final long GRACE_PERIOD_SECONDS = 30;
 
     @Transactional
     public void saveToken(Long memberId, String refreshToken, String githubAccessToken) {
@@ -52,51 +51,89 @@ public class AuthTokenService {
 
     @Transactional
     public void refresh(String refreshToken, HttpServletResponse response) {
+        if (handleGracePeriod(refreshToken, response)) return;
 
+        DecodedJWT decoded = verifyAndValidateRefreshToken(refreshToken);
+        Long memberId = Long.valueOf(decoded.getClaim("id").asString());
+
+        AuthToken authToken = getAuthToken(memberId);
+        validateStoredRefreshToken(authToken, refreshToken);
+
+        MemberDetails memberDetails = extractMemberDetails(memberId, decoded);
+        String newAccessToken = jwtProvider.regenerateAccessToken(refreshToken);
+        String newRefreshToken = jwtProvider.generateTokenPair(memberDetails).refreshToken();
+
+        authToken.updateRefreshToken(cryptUtils.encrypt(newRefreshToken));
+        tokenRefreshCachePort.saveWithGracePeriod(refreshToken, newAccessToken);
+        CookieUtils.saveAccessTokenCookie(response, newAccessToken);
+        CookieUtils.saveRefreshTokenCookie(response, newRefreshToken);
+
+        log.info("Access Token 재발급 성공 - memberId: {}", memberId);
+    }
+
+    private boolean handleGracePeriod(String refreshToken, HttpServletResponse response) {
         Optional<String> cached = tokenRefreshCachePort.getNewTokenIfInGracePeriod(refreshToken);
         if (cached.isPresent()) {
             log.info("Grace Period 내 재발급 요청 - 캐시된 토큰 반환");
             CookieUtils.saveAccessTokenCookie(response, cached.get());
-            return;
+            return true;
         }
+        return false;
+    }
 
-        DecodedJWT decoded;
+    private DecodedJWT verifyAndValidateRefreshToken(String refreshToken) {
         try {
-            decoded = jwtProvider.verifyRefreshToken(refreshToken);
+            return jwtProvider.verifyRefreshToken(refreshToken);
         } catch (TokenExpiredException e) {
             throw new CustomJwtException(TokenErrorCode.EXPIRED_TOKEN);
         } catch (Exception e) {
             log.error("서명 검증 실패: {}", e.getMessage());
             throw new CustomJwtException(TokenErrorCode.INVALID_TOKEN);
         }
+    }
 
-        Long memberId = Long.valueOf(decoded.getClaim("id").asString());
-
-        AuthToken authToken = authTokenRepository.findById(memberId)
+    private AuthToken getAuthToken(Long memberId) {
+        return authTokenRepository.findById(memberId)
                 .orElseThrow(() -> new CustomJwtException(TokenErrorCode.NOT_FOUND_TOKEN));
+    }
 
-        String decryptedRefreshToken = cryptUtils.decrypt(authToken.getRefreshToken());
-        if (!decryptedRefreshToken.equals(refreshToken)) {
+    private void validateStoredRefreshToken(AuthToken authToken, String refreshToken) {
+        String decrypted = cryptUtils.decrypt(authToken.getRefreshToken());
+        if (!decrypted.equals(refreshToken)) {
             throw new CustomJwtException(TokenErrorCode.INVALID_TOKEN);
         }
+    }
 
-        String newAccessToken = jwtProvider.regenerateAccessToken(refreshToken);
+    private MemberDetails extractMemberDetails(Long memberId, DecodedJWT decoded) {
+        return new MemberDetails(
+                memberId,
+                decoded.getClaim("username").asString(),
+                decoded.getClaim("nickname").asString(),
+                null
+        );
+    }
 
-        String newRefreshToken = jwtProvider.generateTokenPair(
-                new MemberDetails(memberId,
-                        decoded.getClaim("username").asString(),
-                        decoded.getClaim("nickname").asString(),
-                        null)
-        ).refreshToken();
+    @Transactional
+    public void reissueTokensForNicknameChange(Member member, HttpServletResponse response) {
+        MemberDetails memberDetails = new MemberDetails(
+                member.getId(),
+                member.getUsername(),
+                member.getNickname(),
+                null
+        );
 
-        authToken.updateRefreshToken(cryptUtils.encrypt(newRefreshToken));
+        AuthToken authToken = authTokenRepository.findById(member.getId())
+                .orElseThrow(() -> new CustomJwtException(TokenErrorCode.NOT_FOUND_TOKEN));
 
-        tokenRefreshCachePort.saveWithGracePeriod(refreshToken, newAccessToken);
+        issueAndSaveTokens(memberDetails, authToken, response);
+    }
 
-        CookieUtils.saveAccessTokenCookie(response, newAccessToken);
-        CookieUtils.saveRefreshTokenCookie(response, newRefreshToken);
-
-        log.info("Access Token 재발급 성공 - memberId: {}", memberId);
+    private void issueAndSaveTokens(MemberDetails memberDetails, AuthToken authToken,
+                                    HttpServletResponse response) {
+        Token newToken = jwtProvider.generateTokenPair(memberDetails);
+        authToken.updateRefreshToken(cryptUtils.encrypt(newToken.refreshToken()));
+        CookieUtils.saveAccessTokenCookie(response, newToken.accessToken());
+        CookieUtils.saveRefreshTokenCookie(response, newToken.refreshToken());
     }
 
     @Transactional

--- a/backend/src/main/java/project/backend/auth/jwt/JwtProvider.java
+++ b/backend/src/main/java/project/backend/auth/jwt/JwtProvider.java
@@ -52,11 +52,10 @@ public class JwtProvider {
 
     public String regenerateAccessToken(String refreshToken) {
         DecodedJWT decodedJWT = verifyRefreshToken(refreshToken);
-
-        Map<String, String> payload = Map.of(
-                "username", decodedJWT.getClaim("username").asString(),
-                "id", decodedJWT.getClaim("id").asString(),
-                "nickname", decodedJWT.getClaim("nickname").asString()
+        Map<String, String> payload = buildPayload(
+                decodedJWT.getClaim("username").asString(),
+                decodedJWT.getClaim("id").asString(),
+                decodedJWT.getClaim("nickname").asString()
         );
         return generateAccessToken(payload);
     }
@@ -119,5 +118,9 @@ public class JwtProvider {
                 .withExpiresAt(new Date(now + expiration * 1000))
                 .withPayload(payload)
                 .sign(getSignatureAlgorithm());
+    }
+
+    private Map<String, String> buildPayload(String username, String id, String nickname) {
+        return Map.of("username", username, "id", id, "nickname", nickname);
     }
 }

--- a/backend/src/main/java/project/backend/domain/chat/chatmessage/dao/ChatMessageIndexStatusRepository.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatmessage/dao/ChatMessageIndexStatusRepository.java
@@ -1,6 +1,9 @@
 package project.backend.domain.chat.chatmessage.dao;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import project.backend.domain.chat.chatmessage.entity.ChatMessageIndexStatus;
 
 import java.util.List;
@@ -8,5 +11,9 @@ import java.util.List;
 public interface ChatMessageIndexStatusRepository extends JpaRepository<ChatMessageIndexStatus, Long> {
 
     List<ChatMessageIndexStatus> findTop100ByOrderByMessageIdAsc();
+
+    @Modifying
+    @Query("DELETE FROM ChatMessageIndexStatus c WHERE c.messageId IN :ids")
+    void deleteAllByMessageIdIn(@Param("ids") List<Long> ids);
 
 }

--- a/backend/src/main/java/project/backend/domain/chat/chatsearch/app/ChatMessageSearchScheduler.java
+++ b/backend/src/main/java/project/backend/domain/chat/chatsearch/app/ChatMessageSearchScheduler.java
@@ -44,7 +44,7 @@ public class ChatMessageSearchScheduler {
 
         try {
             bulkRepository.bulkInsertIgnore(searchList);
-            indexStatusRepository.deleteAll(targets);
+            indexStatusRepository.deleteAllByMessageIdIn(messageIds);
             log.info("[검색색인] 배치 처리 완료: {}건", searchList.size());
         } catch (Exception e) {
             meterRegistry.counter("chat.search.index.fail").increment();

--- a/backend/src/main/java/project/backend/domain/member/api/MemberController.java
+++ b/backend/src/main/java/project/backend/domain/member/api/MemberController.java
@@ -2,6 +2,7 @@ package project.backend.domain.member.api;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -11,10 +12,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import project.backend.domain.member.app.MemberService;
-import project.backend.domain.member.dto.MemberResponse;
-import project.backend.domain.member.dto.MemberInfoUpdateRequest;
-import project.backend.domain.member.dto.MemberSearchResponse;
-import project.backend.domain.member.dto.PasswordChangeRequest;
+import project.backend.domain.member.dto.*;
 
 @Tag(name = "Member", description = "회원 관리 API")
 @Slf4j
@@ -36,9 +34,10 @@ public class MemberController {
     public MemberResponse updateMemberInfo(
         Authentication authentication,
         @RequestPart("request") @Valid MemberInfoUpdateRequest request,
-        @RequestPart(value = "profileImage", required = false) MultipartFile profileImg
-    ) {
-        return memberService.updateMemberInfo(authentication, request, profileImg);
+        @RequestPart(value = "profileImage", required = false) MultipartFile profileImg,
+        HttpServletResponse response
+        ) {
+        return memberService.updateMemberInfo(authentication, request, profileImg, response);
     }
 
     @Operation(summary = "비밀번호 변경 (Form 회원가입의 경우)")

--- a/backend/src/main/java/project/backend/domain/member/app/MemberService.java
+++ b/backend/src/main/java/project/backend/domain/member/app/MemberService.java
@@ -1,5 +1,6 @@
 package project.backend.domain.member.app;
 
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -12,15 +13,12 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+import project.backend.auth.app.AuthTokenService;
 import project.backend.domain.imagefile.ImageFileService;
 import project.backend.domain.member.dao.MemberRepository;
-import project.backend.domain.member.dto.MemberSearchResponse;
-import project.backend.domain.member.dto.PasswordChangeRequest;
+import project.backend.domain.member.dto.*;
 import project.backend.domain.member.dto.event.ProfileUpdateEvent;
 import project.backend.auth.dto.MemberDetails;
-import project.backend.domain.member.dto.MemberResponse;
-import project.backend.domain.member.dto.MemberInfoUpdateRequest;
-import project.backend.domain.member.dto.SignUpRequest;
 import project.backend.domain.member.entity.Member;
 import project.backend.domain.member.entity.ProviderType;
 import project.backend.domain.member.mapper.MemberMapper;
@@ -37,6 +35,7 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
     private final ImageFileService imageFileService;
+    private final AuthTokenService authTokenService;
     private final PasswordEncoder passwordEncoder;
     private final ApplicationEventPublisher eventPublisher;
     private final ProfileImageCache profileImageCache;
@@ -62,14 +61,17 @@ public class MemberService {
         return MemberMapper.toResponse(newMember);
     }
 
-    public MemberResponse updateMemberInfo(Authentication auth, MemberInfoUpdateRequest request,
-        MultipartFile file) {
+    public MemberResponse updateMemberInfo(Authentication auth,
+                                           MemberInfoUpdateRequest request, MultipartFile file, HttpServletResponse response) {
         MemberDetails memberDetails = checkAuthentication(auth);
         Member targetMember = getMemberById(memberDetails.getId());
 
         doUpdateMemberInfo(targetMember, request, file);
-
         eventPublisher.publishEvent(ProfileUpdateEvent.of(targetMember));
+
+        if (request.getNickname() != null) {
+            authTokenService.reissueTokensForNicknameChange(targetMember, response);
+        }
 
         return MemberMapper.toResponse(targetMember);
     }

--- a/frontend/src/components/common/WebSocketContext.js
+++ b/frontend/src/components/common/WebSocketContext.js
@@ -1,4 +1,4 @@
-import { createContext, useContext, useEffect, useRef, useState } from "react"
+import { createContext, useContext, useEffect, useRef, useState, useCallback } from "react"
 import { Client } from "@stomp/stompjs"
 import { safeRefreshToken } from "../api/refreshManager"
 
@@ -8,7 +8,7 @@ export const WebSocketProvider = ({ children }) => {
   const stompClientRef = useRef(null)
   const [connected, setConnected] = useState(false)
 
-  useEffect(() => {
+  const createClient = useCallback(() => {
     const client = new Client({
       webSocketFactory: () => new WebSocket(process.env.REACT_APP_WEB_SOCKET_URL),
       heartbeatIncoming: 15000,
@@ -39,7 +39,11 @@ export const WebSocketProvider = ({ children }) => {
         console.error("💥 STOMP error:", frame.headers["message"])
       },
     })
+    return client
+  }, [])
 
+  useEffect(() => {
+    const client = createClient()
     client.activate()
     stompClientRef.current = client
     window.__stompClient = client
@@ -48,10 +52,20 @@ export const WebSocketProvider = ({ children }) => {
       setConnected(false)
       if (client.active) client.deactivate()
     }
-  }, [])
+  }, [createClient])
+
+  const reconnect = useCallback(async () => {
+    const old = stompClientRef.current
+    if (old?.active) await old.deactivate()
+
+    const client = createClient()
+    client.activate()
+    stompClientRef.current = client
+    window.__stompClient = client
+  }, [createClient])
 
   return (
-    <WebSocketContext.Provider value={{ stompClientRef, connected }}>
+    <WebSocketContext.Provider value={{ stompClientRef, connected, reconnect }}>
       {children}
     </WebSocketContext.Provider>
   )

--- a/frontend/src/pages/editprofile.jsx
+++ b/frontend/src/pages/editprofile.jsx
@@ -6,9 +6,11 @@ import { User, Shield, Edit2 } from "lucide-react";
 import PasswordChangeModal from "../components/modals/PasswordChangeModal";
 import axiosInstance from "../components/api/axiosInstance";
 import styles from "../edit-profile-page.module.css";
+import { useWebSocketContext } from "../components/common/WebSocketContext";
 
 export default function EditProfilePage() {
   const navigate = useNavigate();
+  const { reconnect } = useWebSocketContext();
   const [userDetails, setUserDetails] = useState(null);
   const [nickname, setNickname] = useState("");
   const [email, setEmail] = useState("");
@@ -56,12 +58,7 @@ export default function EditProfilePage() {
     formData.append(
       "request",
       new Blob(
-        [
-          JSON.stringify({
-            nickname: nickname,
-            email: email,
-          }),
-        ],
+        [JSON.stringify({ nickname: nickname, email: email })],
         { type: "application/json" }
       )
     );
@@ -70,8 +67,14 @@ export default function EditProfilePage() {
     }
 
     try {
+      const nicknameChanged = nickname !== userDetails.nickname;
       await axiosInstance.put("/user/info", formData);
       alert("프로필이 성공적으로 수정되었습니다!");
+
+      if (nicknameChanged) {
+        await reconnect();
+      }
+
       const response = await axiosInstance.get("/user/details");
       setUserDetails(response.data);
       setNickname(response.data.nickname);
@@ -99,21 +102,15 @@ export default function EditProfilePage() {
 
   return (
     <div className={styles.appContainer}>
-      {/* Main Content */}
-
       <div className={styles.mainContent}>
-        {/* Profile Content */}
         <main className={styles.profileMain}>
           <div className={styles.profileContainer}>
             <h1 className={styles.pageTitle}>Profile Setting</h1>
 
-            {/* Tabs */}
             <div className={styles.tabs}>
               <div className={styles.tabsList}>
                 <button
-                  className={`${styles.tabTrigger} ${
-                    activeTab === "personal" ? styles.tabActive : ""
-                  }`}
+                  className={`${styles.tabTrigger} ${activeTab === "personal" ? styles.tabActive : ""}`}
                   onClick={() => setActiveTab("personal")}
                 >
                   <User className={styles.tabIcon} />
@@ -121,9 +118,7 @@ export default function EditProfilePage() {
                 </button>
                 {userDetails.provider === "LOCAL" && (
                   <button
-                    className={`${styles.tabTrigger} ${
-                      activeTab === "security" ? styles.tabActive : ""
-                    }`}
+                    className={`${styles.tabTrigger} ${activeTab === "security" ? styles.tabActive : ""}`}
                     onClick={() => setActiveTab("security")}
                   >
                     <Shield className={styles.tabIcon} />
@@ -132,24 +127,16 @@ export default function EditProfilePage() {
                 )}
               </div>
 
-              {/* Personal Info Tab */}
               {activeTab === "personal" && (
                 <div className={styles.tabContent}>
                   <div className={styles.profileCard}>
-                    {/* Profile Avatar Section */}
                     <div className={styles.avatarSection}>
                       <div className={styles.avatarContainer}>
                         <img
-                          src={
-                            selectedImage ||
-                            `${process.env.REACT_APP_PROFILE_IMAGE_URL}/${userDetails.profileImg}`
-                          }
+                          src={selectedImage || `${process.env.REACT_APP_PROFILE_IMAGE_URL}/${userDetails.profileImg}`}
                           alt="Profile"
                           className={styles.avatarImage}
-                          onError={(e) => {
-                            e.currentTarget.src =
-                              "/images/not-found-profile.png";
-                          }}
+                          onError={(e) => { e.currentTarget.src = "/images/not-found-profile.png" }}
                         />
                         <div className={styles.editIcon}>
                           <Edit2 size={20} style={{ pointerEvents: "none" }} />
@@ -163,7 +150,6 @@ export default function EditProfilePage() {
                       </div>
                     </div>
 
-                    {/* Nickname Field */}
                     <div className={styles.formSection}>
                       <div className={styles.formGroup}>
                         <label className={styles.label}>Nickname</label>
@@ -176,8 +162,8 @@ export default function EditProfilePage() {
                             setNickname(value);
                             setIsModified(
                               value !== userDetails.nickname ||
-                                email !== userDetails.email ||
-                                imageFile !== null
+                              email !== userDetails.email ||
+                              imageFile !== null
                             );
                           }}
                           className={styles.input}
@@ -196,8 +182,8 @@ export default function EditProfilePage() {
                             setEmail(value);
                             setIsModified(
                               nickname !== userDetails.nickname ||
-                                value !== userDetails.email ||
-                                imageFile !== null
+                              value !== userDetails.email ||
+                              imageFile !== null
                             );
                           }}
                           className={styles.input}
@@ -206,7 +192,6 @@ export default function EditProfilePage() {
                       </div>
                     </div>
 
-                    {/* Save Button */}
                     <div className={styles.buttonSection}>
                       <button
                         className={styles.saveButton}
@@ -220,21 +205,15 @@ export default function EditProfilePage() {
                 </div>
               )}
 
-              {/* Security Tab */}
               {activeTab === "security" && (
                 <div className={styles.tabContent}>
                   <div className={styles.profileCard}>
                     <div className={styles.securitySection}>
-                      <h2 className={styles.securityTitle}>
-                        Password Settings
-                      </h2>
-
+                      <h2 className={styles.securityTitle}>Password Settings</h2>
                       <div className={styles.securityContent}>
                         <p className={styles.securityDescription}>
-                          Change your password to keep your account secure. We
-                          recommend using a strong, unique password.
+                          Change your password to keep your account secure. We recommend using a strong, unique password.
                         </p>
-
                         <button
                           onClick={() => setIsPasswordModalOpen(true)}
                           className={styles.changePasswordButton}
@@ -244,12 +223,9 @@ export default function EditProfilePage() {
                       </div>
 
                       <div className={styles.sessionsSection}>
-                        <h3 className={styles.sessionsTitle}>
-                          Two-Step Authentication
-                        </h3>
+                        <h3 className={styles.sessionsTitle}>Two-Step Authentication</h3>
                         <p className={styles.sessionsDescription}>
-                          Add an extra layer of security to your account by
-                          enabling two-step authentication.
+                          Add an extra layer of security to your account by enabling two-step authentication.
                         </p>
                         <button
                           onClick={() => alert("개발 예정입니다.")}
@@ -262,9 +238,7 @@ export default function EditProfilePage() {
                       <div className={styles.sessionsSection}>
                         <h3 className={styles.sessionsTitle}>Login Sessions</h3>
                         <p className={styles.sessionsDescription}>
-                          You're currently logged in on this device. You can
-                          review your active sessions and log out from other
-                          devices.
+                          You're currently logged in on this device. You can review your active sessions and log out from other devices.
                         </p>
                         <button
                           onClick={() => alert("개발 예정입니다.")}


### PR DESCRIPTION
## 🛰️ Issue Number
merge to dev

## 🪐 작업 내용
## 개요
닉네임 변경 후 재로그인 없이 채팅 메시지를 전송하면 변경 전 닉네임으로 브로드캐스트되는 버그를 수정

## 원인
채팅 메시지 브로드캐스트 시 닉네임을 JWT에서 파싱한 MemberDetails에서 가져오는데, 닉네임 변경 시 JWT를 재발급하지 않아 기존 토큰에 변경 전 닉네임이 그대로 남아있는 문제

## 변경 사항

### fix
- 닉네임 변경 시 accessToken, refreshToken 재발급 및 쿠키 갱신
- 웹소켓 재연결로 새 닉네임 Principal 적용

### refactor
- AuthTokenService refresh 메서드 단계별 분리
- issueAndSaveTokens 공통 메서드 추출
- JwtProvider buildPayload 공통 메서드 추출

### chore
- AuthTokenService dead code 제거 (GRACE_PERIOD_SECONDS)

### perf
- ChatMessageIndexStatus 배치 삭제 쿼리 최적화 (건별 DELETE → IN절)

## 파일 내역
- `JwtProvider.java` - buildPayload 추출
- `AuthTokenService.java` - reissueTokensForNicknameChange 추가, refresh 메서드 분리, dead code 제거
- `MemberService.java` - updateMemberInfo 수정
- `MemberController.java` - HttpServletResponse 추가
- `WebSocketContext.jsx` - reconnect 함수 추가
- `EditProfilePage.jsx` - 닉네임 변경 시 reconnect 호출
- `ChatMessageIndexStatusRepository.java` - deleteAllByMessageIdIn 추가
- `ChatMessageSearchScheduler.java` - deleteAllByMessageIdIn 적용

## 📚 Reference


## ✅ Check List
- [x] 코드가 정상적으로 컴파일되나요?
- [x] 테스트 코드를 통과했나요?
- [x] merge할 브랜치의 위치를 확인했나요?
- [x] Label을 지정했나요?